### PR TITLE
test(server): mock errors for memory db

### DIFF
--- a/server/internal/infrastructure/memory/project_test.go
+++ b/server/internal/infrastructure/memory/project_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -23,6 +24,7 @@ func TestProjectRepo_CountByWorkspace(t *testing.T) {
 		filter  *repo.WorkspaceFilter
 		want    int
 		wantErr error
+		mockErr bool
 	}{
 		{
 			name:    "0 count in empty db",
@@ -90,6 +92,11 @@ func TestProjectRepo_CountByWorkspace(t *testing.T) {
 			want:    0,
 			wantErr: nil,
 		},
+		{
+			name:    "must mock error",
+			wantErr: errors.New("test"),
+			mockErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -98,6 +105,9 @@ func TestProjectRepo_CountByWorkspace(t *testing.T) {
 			t.Parallel()
 
 			r := NewProject()
+			if tc.mockErr {
+				SetProjectError(r, tc.wantErr)
+			}
 			ctx := context.Background()
 			for _, p := range tc.seeds {
 				err := r.Save(ctx, p.Clone())
@@ -131,6 +141,7 @@ func TestProjectRepo_Filtered(t *testing.T) {
 		seeds   project.List
 		arg     repo.WorkspaceFilter
 		wantErr error
+		mockErr bool
 	}{
 		{
 			name: "no r/w workspaces operation denied",
@@ -156,6 +167,11 @@ func TestProjectRepo_Filtered(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		{
+			name:    "must mock error",
+			wantErr: errors.New("test"),
+			mockErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -164,6 +180,9 @@ func TestProjectRepo_Filtered(t *testing.T) {
 			t.Parallel()
 
 			r := NewProject().Filtered(tc.arg)
+			if tc.mockErr {
+				SetProjectError(r, tc.wantErr)
+			}
 			defer MockProjectNow(r, mocknow)()
 			ctx := context.Background()
 			for _, p := range tc.seeds {
@@ -186,6 +205,7 @@ func TestProjectRepo_FindByID(t *testing.T) {
 		filter  *repo.WorkspaceFilter
 		want    *project.Project
 		wantErr error
+		mockErr bool
 	}{
 		{
 			name:    "Not found in empty db",
@@ -251,6 +271,11 @@ func TestProjectRepo_FindByID(t *testing.T) {
 			want:    p1,
 			wantErr: nil,
 		},
+		{
+			name:    "must mock error",
+			wantErr: errors.New("test"),
+			mockErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -259,6 +284,9 @@ func TestProjectRepo_FindByID(t *testing.T) {
 			t.Parallel()
 
 			r := NewProject()
+			if tc.mockErr {
+				SetProjectError(r, tc.wantErr)
+			}
 			defer MockProjectNow(r, mocknow)()
 			ctx := context.Background()
 			for _, p := range tc.seeds {
@@ -295,6 +323,7 @@ func TestProjectRepo_FindByIDs(t *testing.T) {
 		filter  *repo.WorkspaceFilter
 		want    project.List
 		wantErr error
+		mockErr bool
 	}{
 		{
 			name:    "0 count in empty db",
@@ -375,6 +404,11 @@ func TestProjectRepo_FindByIDs(t *testing.T) {
 			want:    project.List{p1, p2},
 			wantErr: nil,
 		},
+		{
+			name:    "must mock error",
+			wantErr: errors.New("test"),
+			mockErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -383,6 +417,9 @@ func TestProjectRepo_FindByIDs(t *testing.T) {
 			t.Parallel()
 
 			r := NewProject()
+			if tc.mockErr {
+				SetProjectError(r, tc.wantErr)
+			}
 			defer MockProjectNow(r, mocknow)()
 			ctx := context.Background()
 			for _, p := range tc.seeds {
@@ -431,6 +468,7 @@ func TestProjectRepo_FindByPublicName(t *testing.T) {
 		filter  *repo.WorkspaceFilter
 		want    *project.Project
 		wantErr error
+		mockErr bool
 	}{
 		{
 			name:    "Not found in empty db",
@@ -506,6 +544,11 @@ func TestProjectRepo_FindByPublicName(t *testing.T) {
 			want:    p1,
 			wantErr: nil,
 		},
+		{
+			name:    "must mock error",
+			wantErr: errors.New("test"),
+			mockErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -514,6 +557,9 @@ func TestProjectRepo_FindByPublicName(t *testing.T) {
 			t.Parallel()
 
 			r := NewProject()
+			if tc.mockErr {
+				SetProjectError(r, tc.wantErr)
+			}
 			defer MockProjectNow(r, mocknow)()
 			ctx := context.Background()
 			for _, p := range tc.seeds {
@@ -553,6 +599,7 @@ func TestProjectRepo_FindByWorkspace(t *testing.T) {
 		filter  *repo.WorkspaceFilter
 		want    project.List
 		wantErr error
+		mockErr bool
 	}{
 		{
 			name:    "0 count in empty db",
@@ -645,6 +692,11 @@ func TestProjectRepo_FindByWorkspace(t *testing.T) {
 			want:    nil,
 			wantErr: nil,
 		},
+		{
+			name:    "must mock error",
+			wantErr: errors.New("test"),
+			mockErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -653,6 +705,9 @@ func TestProjectRepo_FindByWorkspace(t *testing.T) {
 			t.Parallel()
 
 			r := NewProject()
+			if tc.mockErr {
+				SetProjectError(r, tc.wantErr)
+			}
 			defer MockProjectNow(r, mocknow)()
 			ctx := context.Background()
 			for _, p := range tc.seeds {
@@ -685,6 +740,7 @@ func TestProjectRepo_Remove(t *testing.T) {
 		arg     id.ProjectID
 		filter  *repo.WorkspaceFilter
 		wantErr error
+		mockErr bool
 	}{
 		{
 			name:    "Not found in empty db",
@@ -744,6 +800,11 @@ func TestProjectRepo_Remove(t *testing.T) {
 			filter:  &repo.WorkspaceFilter{Readable: []id.WorkspaceID{}, Writable: []id.WorkspaceID{tid1}},
 			wantErr: nil,
 		},
+		{
+			name:    "must mock error",
+			wantErr: errors.New("test"),
+			mockErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -752,6 +813,9 @@ func TestProjectRepo_Remove(t *testing.T) {
 			t.Parallel()
 
 			r := NewProject()
+			if tc.mockErr {
+				SetProjectError(r, tc.wantErr)
+			}
 			ctx := context.Background()
 			for _, p := range tc.seeds {
 				err := r.Save(ctx, p.Clone())
@@ -778,6 +842,7 @@ func TestProjectRepo_Save(t *testing.T) {
 	tid1 := id.NewWorkspaceID()
 	id1 := id.NewProjectID()
 	p1 := project.New().ID(id1).Workspace(tid1).UpdatedAt(time.Now().Truncate(time.Millisecond).UTC()).MustBuild()
+
 	tests := []struct {
 		name    string
 		seeds   project.List
@@ -785,6 +850,7 @@ func TestProjectRepo_Save(t *testing.T) {
 		filter  *repo.WorkspaceFilter
 		want    *project.Project
 		wantErr error
+		mockErr bool
 	}{
 		{
 			name: "Saved",
@@ -826,6 +892,11 @@ func TestProjectRepo_Save(t *testing.T) {
 			want:    p1,
 			wantErr: nil,
 		},
+		{
+			name:    "must mock error",
+			wantErr: errors.New("test"),
+			mockErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -836,6 +907,9 @@ func TestProjectRepo_Save(t *testing.T) {
 			r := NewProject()
 			if tc.filter != nil {
 				r = r.Filtered(*tc.filter)
+			}
+			if tc.mockErr {
+				SetProjectError(r, tc.wantErr)
 			}
 			ctx := context.Background()
 			for _, p := range tc.seeds {

--- a/server/internal/infrastructure/memory/user.go
+++ b/server/internal/infrastructure/memory/user.go
@@ -12,6 +12,7 @@ import (
 
 type User struct {
 	data *util.SyncMap[id.UserID, *user.User]
+	err  error
 }
 
 func NewUser() repo.User {
@@ -21,6 +22,10 @@ func NewUser() repo.User {
 }
 
 func (r *User) FindByIDs(ctx context.Context, ids id.UserIDList) ([]*user.User, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
 	res := r.data.FindAll(func(key id.UserID, value *user.User) bool {
 		return ids.Has(key)
 	})
@@ -29,18 +34,20 @@ func (r *User) FindByIDs(ctx context.Context, ids id.UserIDList) ([]*user.User, 
 }
 
 func (r *User) FindByID(ctx context.Context, v id.UserID) (*user.User, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
 	return rerror.ErrIfNil(r.data.Find(func(key id.UserID, value *user.User) bool {
 		return key == v
 	}), rerror.ErrNotFound)
-
-}
-
-func (r *User) Save(ctx context.Context, u *user.User) error {
-	r.data.Store(u.ID(), u)
-	return nil
 }
 
 func (r *User) FindBySub(ctx context.Context, auth0sub string) (*user.User, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
 	if auth0sub == "" {
 		return nil, rerror.ErrInvalidParams
 	}
@@ -51,6 +58,10 @@ func (r *User) FindBySub(ctx context.Context, auth0sub string) (*user.User, erro
 }
 
 func (r *User) FindByPasswordResetRequest(ctx context.Context, token string) (*user.User, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
 	if token == "" {
 		return nil, rerror.ErrInvalidParams
 	}
@@ -61,6 +72,10 @@ func (r *User) FindByPasswordResetRequest(ctx context.Context, token string) (*u
 }
 
 func (r *User) FindByEmail(ctx context.Context, email string) (*user.User, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
 	if email == "" {
 		return nil, rerror.ErrInvalidParams
 	}
@@ -71,6 +86,10 @@ func (r *User) FindByEmail(ctx context.Context, email string) (*user.User, error
 }
 
 func (r *User) FindByName(ctx context.Context, name string) (*user.User, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
 	if name == "" {
 		return nil, rerror.ErrInvalidParams
 	}
@@ -81,6 +100,10 @@ func (r *User) FindByName(ctx context.Context, name string) (*user.User, error) 
 }
 
 func (r *User) FindByNameOrEmail(ctx context.Context, nameOrEmail string) (*user.User, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
 	if nameOrEmail == "" {
 		return nil, rerror.ErrInvalidParams
 	}
@@ -90,12 +113,11 @@ func (r *User) FindByNameOrEmail(ctx context.Context, nameOrEmail string) (*user
 	}), rerror.ErrNotFound)
 }
 
-func (r *User) Remove(ctx context.Context, user id.UserID) error {
-	r.data.Delete(user)
-	return nil
-}
-
 func (r *User) FindByVerification(ctx context.Context, code string) (*user.User, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
 	if code == "" {
 		return nil, rerror.ErrInvalidParams
 	}
@@ -104,4 +126,26 @@ func (r *User) FindByVerification(ctx context.Context, code string) (*user.User,
 		return value.Verification() != nil && value.Verification().Code() == code
 
 	}), rerror.ErrNotFound)
+}
+
+func (r *User) Save(ctx context.Context, u *user.User) error {
+	if r.err != nil {
+		return r.err
+	}
+
+	r.data.Store(u.ID(), u)
+	return nil
+}
+
+func (r *User) Remove(ctx context.Context, user id.UserID) error {
+	if r.err != nil {
+		return r.err
+	}
+
+	r.data.Delete(user)
+	return nil
+}
+
+func SetUserError(r repo.User, err error) {
+	r.(*User).err = err
 }

--- a/server/internal/infrastructure/memory/workspace.go
+++ b/server/internal/infrastructure/memory/workspace.go
@@ -13,6 +13,7 @@ import (
 
 type Workspace struct {
 	data *util.SyncMap[id.WorkspaceID, *user.Workspace]
+	err  error
 }
 
 func NewWorkspace() repo.Workspace {
@@ -22,12 +23,20 @@ func NewWorkspace() repo.Workspace {
 }
 
 func (r *Workspace) FindByUser(ctx context.Context, i id.UserID) (user.WorkspaceList, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
 	return rerror.ErrIfNil(r.data.FindAll(func(key id.WorkspaceID, value *user.Workspace) bool {
 		return value.Members().ContainsUser(i)
 	}), rerror.ErrNotFound)
 }
 
 func (r *Workspace) FindByIDs(ctx context.Context, ids id.WorkspaceIDList) (user.WorkspaceList, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
 	res := r.data.FindAll(func(key id.WorkspaceID, value *user.Workspace) bool {
 		return ids.Has(key)
 	})
@@ -36,17 +45,29 @@ func (r *Workspace) FindByIDs(ctx context.Context, ids id.WorkspaceIDList) (user
 }
 
 func (r *Workspace) FindByID(ctx context.Context, v id.WorkspaceID) (*user.Workspace, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
 	return rerror.ErrIfNil(r.data.Find(func(key id.WorkspaceID, value *user.Workspace) bool {
 		return key == v
 	}), rerror.ErrNotFound)
 }
 
 func (r *Workspace) Save(ctx context.Context, t *user.Workspace) error {
+	if r.err != nil {
+		return r.err
+	}
+
 	r.data.Store(t.ID(), t)
 	return nil
 }
 
 func (r *Workspace) SaveAll(ctx context.Context, workspaces []*user.Workspace) error {
+	if r.err != nil {
+		return r.err
+	}
+
 	for _, t := range workspaces {
 		r.data.Store(t.ID(), t)
 	}
@@ -54,13 +75,25 @@ func (r *Workspace) SaveAll(ctx context.Context, workspaces []*user.Workspace) e
 }
 
 func (r *Workspace) Remove(ctx context.Context, wid id.WorkspaceID) error {
+	if r.err != nil {
+		return r.err
+	}
+
 	r.data.Delete(wid)
 	return nil
 }
 
 func (r *Workspace) RemoveAll(ctx context.Context, ids id.WorkspaceIDList) error {
+	if r.err != nil {
+		return r.err
+	}
+
 	for _, wid := range ids {
 		r.data.Delete(wid)
 	}
 	return nil
+}
+
+func SetWorkspaceError(r repo.Workspace, err error) {
+	r.(*Workspace).err = err
 }

--- a/server/internal/infrastructure/memory/workspace_test.go
+++ b/server/internal/infrastructure/memory/workspace_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/reearth/reearth-cms/server/pkg/util"
@@ -34,6 +35,10 @@ func TestWorkspace_FindByID(t *testing.T) {
 	out2, err := r.FindByID(ctx, id.WorkspaceID{})
 	assert.Nil(t, out2)
 	assert.Same(t, rerror.ErrNotFound, err)
+
+	wantErr := errors.New("test")
+	SetWorkspaceError(r, wantErr)
+	assert.Same(t, wantErr, r.Save(ctx, ws))
 }
 
 func TestWorkspace_FindByIDs(t *testing.T) {
@@ -51,6 +56,10 @@ func TestWorkspace_FindByIDs(t *testing.T) {
 	out, err := r.FindByIDs(ctx, ids)
 	assert.NoError(t, err)
 	assert.Equal(t, wsl, out)
+
+	wantErr := errors.New("test")
+	SetWorkspaceError(r, wantErr)
+	assert.Same(t, wantErr, r.Save(ctx, ws))
 }
 
 func TestWorkspace_FindByUser(t *testing.T) {
@@ -70,6 +79,40 @@ func TestWorkspace_FindByUser(t *testing.T) {
 	assert.Same(t, rerror.ErrNotFound, err)
 	assert.Nil(t, out2)
 
+	wantErr := errors.New("test")
+	SetWorkspaceError(r, wantErr)
+	assert.Same(t, wantErr, r.Save(ctx, ws))
+}
+
+func TestWorkspace_Save(t *testing.T) {
+	ctx := context.Background()
+	ws := user.NewWorkspace().NewID().Name("hoge").MustBuild()
+
+	r := &Workspace{
+		data: &util.SyncMap[id.WorkspaceID, *user.Workspace]{},
+	}
+	_ = r.Save(ctx, ws)
+	assert.Equal(t, 1, r.data.Len())
+
+	wantErr := errors.New("test")
+	SetWorkspaceError(r, wantErr)
+	assert.Same(t, wantErr, r.Save(ctx, ws))
+}
+
+func TestWorkspace_SaveAll(t *testing.T) {
+	ctx := context.Background()
+	ws1 := user.NewWorkspace().NewID().Name("hoge").MustBuild()
+	ws2 := user.NewWorkspace().NewID().Name("foo").MustBuild()
+
+	r := &Workspace{
+		data: &util.SyncMap[id.WorkspaceID, *user.Workspace]{},
+	}
+	_ = r.SaveAll(ctx, []*user.Workspace{ws1, ws2})
+	assert.Equal(t, 2, r.data.Len())
+
+	wantErr := errors.New("test")
+	SetWorkspaceError(r, wantErr)
+	assert.Same(t, wantErr, r.Remove(ctx, ws1.ID()))
 }
 
 func TestWorkspace_Remove(t *testing.T) {
@@ -84,6 +127,10 @@ func TestWorkspace_Remove(t *testing.T) {
 
 	_ = r.Remove(ctx, ws2.ID())
 	assert.Equal(t, 1, r.data.Len())
+
+	wantErr := errors.New("test")
+	SetWorkspaceError(r, wantErr)
+	assert.Same(t, wantErr, r.Remove(ctx, ws.ID()))
 }
 
 func TestWorkspace_RemoveAll(t *testing.T) {
@@ -99,27 +146,8 @@ func TestWorkspace_RemoveAll(t *testing.T) {
 	ids := user.WorkspaceIDList{ws.ID(), ws2.ID()}
 	_ = r.RemoveAll(ctx, ids)
 	assert.Equal(t, 0, r.data.Len())
-}
 
-func TestWorkspace_Save(t *testing.T) {
-	ctx := context.Background()
-	ws := user.NewWorkspace().NewID().Name("hoge").MustBuild()
-
-	got := &Workspace{
-		data: &util.SyncMap[id.WorkspaceID, *user.Workspace]{},
-	}
-	_ = got.Save(ctx, ws)
-	assert.Equal(t, 1, got.data.Len())
-}
-
-func TestWorkspace_SaveAll(t *testing.T) {
-	ctx := context.Background()
-	ws1 := user.NewWorkspace().NewID().Name("hoge").MustBuild()
-	ws2 := user.NewWorkspace().NewID().Name("foo").MustBuild()
-
-	got := &Workspace{
-		data: &util.SyncMap[id.WorkspaceID, *user.Workspace]{},
-	}
-	_ = got.SaveAll(ctx, []*user.Workspace{ws1, ws2})
-	assert.Equal(t, 2, got.data.Len())
+	wantErr := errors.New("test")
+	SetWorkspaceError(r, wantErr)
+	assert.Same(t, wantErr, r.RemoveAll(ctx, ids))
 }

--- a/server/pkg/user/user.go
+++ b/server/pkg/user/user.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net/mail"
 
+	"github.com/reearth/reearth-cms/server/pkg/util"
+	"golang.org/x/exp/slices"
 	"golang.org/x/text/language"
 )
 
@@ -190,4 +192,19 @@ func (u *User) SetPasswordReset(pr *PasswordReset) {
 
 func (u *User) SetVerification(v *Verification) {
 	u.verification = v
+}
+
+func (u *User) Clone() *User {
+	return &User{
+		id:            u.id.Clone(),
+		name:          u.name,
+		email:         u.email,
+		password:      u.password,
+		workspace:     u.workspace.Clone(),
+		auths:         slices.Clone(u.auths),
+		lang:          u.lang,
+		theme:         u.theme,
+		verification:  util.CloneRef(u.verification),
+		passwordReset: util.CloneRef(u.passwordReset),
+	}
 }

--- a/server/pkg/user/user_test.go
+++ b/server/pkg/user/user_test.go
@@ -635,3 +635,20 @@ func Test_ValidatePassword(t *testing.T) {
 		})
 	}
 }
+
+func TestUser_Clone(t *testing.T) {
+	uid := NewID()
+	wid := NewWorkspaceID()
+	u := New().ID(uid).
+		Workspace(wid).
+		Name("xxx").
+		LangFrom("en").
+		Email("ff@xx.zz").
+		Auths([]Auth{{
+			Provider: "aaa",
+			Sub:      "sss",
+		}}).MustBuild()
+	got := u.Clone()
+	assert.Equal(t, u, got)
+	assert.NotSame(t, u, got)
+}

--- a/server/pkg/util/util.go
+++ b/server/pkg/util/util.go
@@ -30,11 +30,15 @@ func CopyURL(u *url.URL) *url.URL {
 	if u == nil {
 		return nil
 	}
+	v := CloneRef(u)
+	v.User = CloneRef(u.User)
+	return v
+}
 
-	v := *u
-	if u.User != nil {
-		ui := *u.User
-		v.User = &ui
+func CloneRef[T any](r *T) *T {
+	if r == nil {
+		return nil
 	}
-	return &v
+	r2 := *r
+	return &r2
 }


### PR DESCRIPTION
- Add `memory.SetUserError`, `memory.SetWorkspaceError` and `memory.SetProjectError` to mock errors from memory repos
- Fix test cases