### PR TITLE
feat(server): init worker app with multi-module workspaces

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,7 @@
   "go.lintTool": "golangci-lint",
   "go.lintFlags": [
     "--config=${workspaceFolder}/.golangci.yml"
-  ]
+  ],
+  "gopls": { "experimentalWorkspaceModule": true}
+
 }

--- a/go.work
+++ b/go.work
@@ -1,0 +1,6 @@
+go 1.18
+
+use (
+	./server
+	./worker
+)

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -12,12 +12,12 @@ RUN go mod download
 COPY cmd/ /app/cmd/
 COPY internal/ /app/internal/
 
-RUN CGO_ENABLED=0 go build -tags "${TAG}" "-ldflags=-X main.version=${VERSION} -s -w -buildid=" -trimpath ./cmd/reearth-worker
+RUN CGO_ENABLED=0 go build -tags "${TAG}" "-ldflags=-X main.version=${VERSION} -s -w -buildid=" -trimpath ./cmd/reearth-cms-worker
 
 FROM scratch
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=build /app/reearth-worker /app/reearth-worker
+COPY --from=build /app/reearth-cms-worker /app/reearth-cms-worker
 
 WORKDIR /app
 

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1.18-alpine AS build
+ARG TAG=release
+ARG REV
+ARG VERSION
+
+RUN apk add --update --no-cache git ca-certificates build-base
+
+COPY go.mod go.sum main.go /app/
+WORKDIR /app
+RUN go mod download
+
+COPY cmd/ /app/cmd/
+COPY internal/ /app/internal/
+
+RUN CGO_ENABLED=0 go build -tags "${TAG}" "-ldflags=-X main.version=${VERSION} -s -w -buildid=" -trimpath ./cmd/reearth-worker
+
+FROM scratch
+
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build /app/reearth-worker /app/reearth-worker
+
+WORKDIR /app
+
+CMD [ "./reearth-worker" ]

--- a/worker/cmd/reearth-cms-worker/debug.go
+++ b/worker/cmd/reearth-cms-worker/debug.go
@@ -1,0 +1,5 @@
+//go:build !release
+
+package main
+
+const debug = true

--- a/worker/cmd/reearth-cms-worker/main.go
+++ b/worker/cmd/reearth-cms-worker/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/reearth/reearth-cms/worker/internal/app"
+
+var version = ""
+
+func main() {
+	app.Start(debug, version)
+}

--- a/worker/cmd/reearth-cms-worker/release.go
+++ b/worker/cmd/reearth-cms-worker/release.go
@@ -1,0 +1,5 @@
+//go:build release
+
+package main
+
+const debug = false

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  reearth-cms-worker:
+    build:
+      context: .
+    ports:
+      - '8080:8080'
+    # env_file:
+    #   - ./.env
+    volumes:
+      - ./data:/reearth/data

--- a/worker/go.mod
+++ b/worker/go.mod
@@ -1,0 +1,5 @@
+module github.com/reearth/reearth-cms/worker
+
+go 1.18
+
+require github.com/joho/godotenv v1.4.0 // indirect

--- a/worker/go.sum
+++ b/worker/go.sum
@@ -1,0 +1,2 @@
+github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
+github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/worker/internal/app/app.go
+++ b/worker/internal/app/app.go
@@ -1,0 +1,15 @@
+package app
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "Hello, World")
+}
+
+func Start(debug bool, version string) {
+	http.HandleFunc("/", handler)
+	http.ListenAndServe(":8080", nil)
+}

--- a/worker/main.go
+++ b/worker/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}


### PR DESCRIPTION
# What
* Create worker dir
* Introduce [multi-module workspaces](https://go.dev/doc/tutorial/workspaces) so that we can have multiple modules even in the same workspace 
* Add Dockerfile
* Add a simple server which returns "hello world"

# Why
* Since Go1.18 supports the multi-module workspaces feature which allows us to have multiple modules under a single workspace though we couldn't do that and were forced to have a hacky way, I've introduced that to take the full advantage of mono-repo. 

# Point of Review
* If there is any problem with directory structure, Dockerfile, etc

# Things you don't need to review
* The implementation of a simple server since it's a temporary development
* GitHub actions workflow file will be implemented later