### PR TITLE
feat(web): add new font weight

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap');
 body {
     margin: 0;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;


### PR DESCRIPTION
# Overview
Roboto 400 is used in the Figma design (as a default font weight), and not included in the project

## What I've done
Added font-weight **400** to the project
