### PR TITLE
feat(web): add schema menu

### DIFF
--- a/web/src/components/molecules/Schema/SchemaMenu.tsx
+++ b/web/src/components/molecules/Schema/SchemaMenu.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import type { MenuInfo } from "rc-menu/lib/interface";
 import React from "react";
 
 import Button from "@reearth-cms/components/atoms/Button";
@@ -23,7 +24,7 @@ const SchemaMenu: React.FC<Props> = ({
   handleModalOpen,
   selectModel,
 }) => {
-  const onClick = (e: any) => {
+  const onClick = (e: MenuInfo) => {
     selectModel(e.key);
   };
 

--- a/web/src/components/molecules/Schema/SchemaMenu.tsx
+++ b/web/src/components/molecules/Schema/SchemaMenu.tsx
@@ -67,7 +67,7 @@ const SchemaStyledMenuTitle = styled.h1`
   font-weight: 400;
   font-size: 14px;
   line-height: 22px;
-  color: rgba(0, 0, 0, 0.45);
+  color: #00000073;
 `;
 
 const SchemaStyledTitle = styled.h2`

--- a/web/src/components/molecules/Schema/SchemaMenu.tsx
+++ b/web/src/components/molecules/Schema/SchemaMenu.tsx
@@ -1,0 +1,87 @@
+import styled from "@emotion/styled";
+import React from "react";
+
+import Button from "@reearth-cms/components/atoms/Button";
+import Icon from "@reearth-cms/components/atoms/Icon";
+import Menu from "@reearth-cms/components/atoms/Menu";
+import { Model } from "@reearth-cms/components/molecules/Schema/types";
+
+export interface Props {
+  defaultSelectedKeys?: string[];
+}
+
+export interface Props {
+  defaultSelectedKeys?: string[];
+  models?: Model[];
+  handleModalOpen: () => void;
+  selectModel: (modelId: string) => void;
+}
+
+const SchemaMenu: React.FC<Props> = ({
+  defaultSelectedKeys,
+  models,
+  handleModalOpen,
+  selectModel,
+}) => {
+  const onClick = (e: any) => {
+    selectModel(e.key);
+  };
+
+  return (
+    <SchemaStyledMenu>
+      <SchemaStyledTitle>Schema</SchemaStyledTitle>
+      <SchemaAction>
+        <SchemaStyledMenuTitle>Models</SchemaStyledMenuTitle>
+        <SchemaAddButton
+          onClick={handleModalOpen}
+          color="#1890FF"
+          icon={<Icon icon="plus" />}
+          type="text">
+          Add
+        </SchemaAddButton>
+      </SchemaAction>
+      <Menu
+        onClick={onClick}
+        defaultSelectedKeys={defaultSelectedKeys}
+        mode="inline"
+        items={models?.map(model => ({ label: model.name, key: model.id }))}
+      />
+    </SchemaStyledMenu>
+  );
+};
+
+const SchemaAction = styled.div`
+  display: flex;
+  padding: 24px;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const SchemaAddButton = styled(Button)`
+  color: #1890ff;
+  &:hover,
+  &:active,
+  &:focus {
+    color: #1890ff;
+  }
+`;
+
+const SchemaStyledMenuTitle = styled.h1`
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 22px;
+  color: rgba(0, 0, 0, 0.45);
+`;
+
+const SchemaStyledTitle = styled.h2`
+  padding: 24px;
+`;
+
+const SchemaStyledMenu = styled.div`
+  background-color: #fff;
+  height: 100%;
+  border-right: 1px solid #f0f0f0;
+`;
+
+export default SchemaMenu;

--- a/web/src/components/molecules/Schema/SchemaMenu.tsx
+++ b/web/src/components/molecules/Schema/SchemaMenu.tsx
@@ -32,11 +32,7 @@ const SchemaMenu: React.FC<Props> = ({
       <SchemaStyledTitle>Schema</SchemaStyledTitle>
       <SchemaAction>
         <SchemaStyledMenuTitle>Models</SchemaStyledMenuTitle>
-        <SchemaAddButton
-          onClick={handleModalOpen}
-          color="#1890FF"
-          icon={<Icon icon="plus" />}
-          type="text">
+        <SchemaAddButton onClick={handleModalOpen} icon={<Icon icon="plus" />} type="text">
           Add
         </SchemaAddButton>
       </SchemaAction>

--- a/web/src/components/molecules/Schema/types.ts
+++ b/web/src/components/molecules/Schema/types.ts
@@ -1,0 +1,35 @@
+export type Model = {
+  id: string;
+  name: string;
+  description: string;
+  key: string;
+  schema: Schema;
+};
+
+export type Schema = {
+  id: string;
+  fields: Field[];
+};
+
+export type Field = {
+  id: string;
+  type: FieldType;
+  title: string;
+  description: string | null | undefined;
+  required: boolean;
+  unique: boolean;
+};
+
+export type FieldType =
+  | "Text"
+  | "TextArea"
+  | "RichText"
+  | "MarkdownText"
+  | "Asset"
+  | "Date"
+  | "Bool"
+  | "Select"
+  | "Tag"
+  | "Integer"
+  | "Reference"
+  | "URL";

--- a/web/src/components/molecules/Schema/types.ts
+++ b/web/src/components/molecules/Schema/types.ts
@@ -1,7 +1,7 @@
 export type Model = {
   id: string;
   name: string;
-  description: string;
+  description?: string;
   key: string;
   schema: Schema;
 };


### PR DESCRIPTION
# Overview

## What I've done
Added a new molecule component for showing a list of models, and the ability to create new models.
Also added typescript types for both `model` and `field`.

## How I tested
Tested in the acceptance test

## Screenshot
![schema](https://user-images.githubusercontent.com/78056580/186075775-73cce20e-0b2f-4e78-92fa-103c21e3a59e.png)

## Which point I want you to review particularly
Syntax issues