### PR TITLE
feat(web): add schema redirection item to project menu

### DIFF
--- a/web/src/components/molecules/Common/projectMenu/index.tsx
+++ b/web/src/components/molecules/Common/projectMenu/index.tsx
@@ -8,18 +8,24 @@ import Menu from "@reearth-cms/components/atoms/Menu";
 export interface Props {
   inlineCollapsed: boolean;
   workspaceId?: string;
+  projectId?: string;
   defaultSelectedKeys?: string[];
 }
 
 const topItems: ItemType[] = [
   { label: "Overview", key: "home", icon: <Icon icon="dashboard" /> },
-  { label: "Schema", key: "list", icon: <Icon icon="unorderedList" /> },
+  { label: "Schema", key: "schema", icon: <Icon icon="unorderedList" /> },
   { label: "Content", key: "content", icon: <Icon icon="table" /> },
   { label: "Asset", key: "asset", icon: <Icon icon="file" /> },
   { label: "Request", key: "request", icon: <Icon icon="pullRequest" /> },
 ];
 
-const ProjectMenu: React.FC<Props> = ({ inlineCollapsed, workspaceId, defaultSelectedKeys }) => {
+const ProjectMenu: React.FC<Props> = ({
+  inlineCollapsed,
+  workspaceId,
+  projectId,
+  defaultSelectedKeys,
+}) => {
   const navigate = useNavigate();
   const items: ItemType[] = [
     {
@@ -37,6 +43,8 @@ const ProjectMenu: React.FC<Props> = ({ inlineCollapsed, workspaceId, defaultSel
   const onClick = (e: any) => {
     if (e.key === "home") {
       navigate(`/dashboard/${workspaceId}`);
+    } else if (e.key === "schema") {
+      navigate(`/workspaces/${workspaceId}/${projectId}/schema`);
     }
   };
 

--- a/web/src/components/organisms/Project/settings/index.tsx
+++ b/web/src/components/organisms/Project/settings/index.tsx
@@ -98,6 +98,7 @@ const ProjectSettings: React.FC = () => {
             onCollapse={value => setCollapsed(value)}
             style={{ backgroundColor: "#fff" }}>
             <ProjectMenu
+              projectId={projectId}
               defaultSelectedKeys={["settings"]}
               inlineCollapsed={collapsed}
               workspaceId={currentWorkspace?.id}


### PR DESCRIPTION
# Overview
The schema item in the project menu is an active

## What I've done
Passed the `project id` to the menu and added redirection to the schema page

## How I tested
Tested in the acceptance test
