### PR TITLE
fix(server): jwt echo middleware

### DIFF
--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -9,11 +9,8 @@ import (
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-	"github.com/reearth/reearth-cms/server/internal/adapter"
 	"github.com/reearth/reearth-cms/server/internal/usecase/interactor"
-	"github.com/reearth/reearthx/appx"
 	"github.com/reearth/reearthx/rerror"
-	"github.com/samber/lo"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho"
 )
 
@@ -41,9 +38,7 @@ func initEcho(ctx context.Context, cfg *ServerConfig) *echo.Echo {
 		)
 	}
 	e.Use(
-		echo.WrapMiddleware(lo.Must(
-			appx.AuthMiddleware(cfg.Config.JWTProviders(), adapter.ContextAuthInfo, false),
-		)),
+		jwtEchoMiddleware(cfg),
 		authMiddleware(cfg),
 	)
 

--- a/server/internal/app/auth_client.go
+++ b/server/internal/app/auth_client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/reearth/reearth-cms/server/internal/usecase/interfaces"
 	"github.com/reearth/reearth-cms/server/pkg/id"
 	"github.com/reearth/reearth-cms/server/pkg/user"
+	"github.com/reearth/reearthx/appx"
 	"github.com/reearth/reearthx/usecasex"
 	"github.com/samber/lo"
 )
@@ -51,6 +52,14 @@ func authMiddleware(cfg *ServerConfig) echo.MiddlewareFunc {
 			return next(c)
 		}
 	}
+}
+
+func jwtEchoMiddleware(cfg *ServerConfig) echo.MiddlewareFunc {
+	mw, err := appx.AuthMiddleware(cfg.Config.JWTProviders(), adapter.ContextAuthInfo, true)
+	if err != nil {
+		panic(err)
+	}
+	return echo.WrapMiddleware(mw)
 }
 
 func generateOperator(ctx context.Context, cfg *ServerConfig, u *user.User) (*usecase.Operator, error) {

--- a/server/internal/app/auth_client.go
+++ b/server/internal/app/auth_client.go
@@ -55,10 +55,7 @@ func authMiddleware(cfg *ServerConfig) echo.MiddlewareFunc {
 }
 
 func jwtEchoMiddleware(cfg *ServerConfig) echo.MiddlewareFunc {
-	mw, err := appx.AuthMiddleware(cfg.Config.JWTProviders(), adapter.ContextAuthInfo, true)
-	if err != nil {
-		panic(err)
-	}
+	mw := lo.Must(appx.AuthMiddleware(cfg.Config.JWTProviders(), adapter.ContextAuthInfo, true))
 	return echo.WrapMiddleware(mw)
 }
 


### PR DESCRIPTION
# Overview
In this PR I fixed JWT echo middleware to be sent with rest api requests.

## What I have done
I changed 
`appx.AuthMiddleware(cfg.Config.JWTProviders(), adapter.ContextAuthInfo, false)`
into
`appx.AuthMiddleware(cfg.Config.JWTProviders(), adapter.ContextAuthInfo, true)`
and wrapped the middleware inside `jwtEchoMiddleware` function.