### PR TITLE
fix(server): run server without cloudtasks and m2m config

### DIFF
--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -53,7 +53,7 @@ func initEcho(ctx context.Context, cfg *ServerConfig) *echo.Echo {
 		appx.AuthMiddleware(cfg.Config.JWTProviders(), contextAuthInfo, false),
 	))
 	m2mJWTMiddleware := echo.WrapMiddleware(lo.Must(
-		appx.AuthMiddleware([]appx.JWTProvider{cfg.Config.AuthM2M.JWTProvider()}, contextAuthInfo, false),
+		appx.AuthMiddleware(cfg.Config.AuthM2M.JWTProvider(), contextAuthInfo, false),
 	))
 	usecaseMiddleware := UsecaseMiddleware(cfg.Repos, cfg.Gateways, interactor.ContainerConfig{
 		SignupSecret:    cfg.Config.SignupSecret,

--- a/server/internal/app/config.go
+++ b/server/internal/app/config.go
@@ -148,13 +148,23 @@ func (a AuthConfig) JWTProvider() appx.JWTProvider {
 	}
 }
 
-func (a AuthM2MConfig) JWTProvider() appx.JWTProvider {
-	return appx.JWTProvider{
-		ISS: a.ISS,
+func (a AuthM2MConfig) JWTProvider() []appx.JWTProvider {
+	domain := a.ISS
+	if a.ISS == "" {
+		return nil
+	}
+	if !strings.HasPrefix(domain, "https://") && !strings.HasPrefix(domain, "http://") {
+		domain = "https://" + domain
+	}
+	if !strings.HasSuffix(domain, "/") {
+		domain = domain + "/"
+	}
+	return []appx.JWTProvider{{
+		ISS: domain,
 		AUD: a.AUD,
 		ALG: a.ALG,
 		TTL: a.TTL,
-	}
+	}}
 }
 
 // Decode is a custom decoder for AuthConfigs

--- a/server/internal/app/repo.go
+++ b/server/internal/app/repo.go
@@ -64,12 +64,15 @@ func initReposAndGateways(ctx context.Context, conf *Config, debug bool) (*repo.
 	gateways.Authenticator = auth0.New(conf.Auth0.Domain, conf.Auth0.ClientID, conf.Auth0.ClientSecret)
 
 	// CloudTasks
-	taskRunner, err := gcp.NewTaskRunner(ctx, &conf.CloudTasks)
-	if err != nil {
-		log.Fatalln(fmt.Sprintf("task runner: init error: %+v", err))
+	if conf.CloudTasks.GCPProject != "" && conf.CloudTasks.GCPRegion != "" || conf.CloudTasks.QueueName != "" {
+		taskRunner, err := gcp.NewTaskRunner(ctx, &conf.CloudTasks)
+		if err != nil {
+			log.Fatalln(fmt.Sprintf("task runner: init error: %+v", err))
+		}
+		gateways.TaskRunner = taskRunner
+	} else {
+		log.Infof("task runner: not used")
 	}
-
-	gateways.TaskRunner = taskRunner
 
 	return repos, gateways
 }


### PR DESCRIPTION
# What
* Made cloud tasks optional
* Made M2M config optional

# Why
* Because it was inconvenient that developers needed to set it on dev env