### PR TITLE
fix(web): model fixes

### DIFF
--- a/web/src/components/molecules/Schema/FieldModal/FieldCreationModal/index.tsx
+++ b/web/src/components/molecules/Schema/FieldModal/FieldCreationModal/index.tsx
@@ -127,7 +127,7 @@ const FieldCreationModal: React.FC<Props> = ({
       onOk={handleSubmit}>
       <Form form={form} layout="vertical" initialValues={initialValues}>
         <Tabs defaultActiveKey="settings">
-          <TabPane tab={t("Settings")} key="setting">
+          <TabPane tab={t("Settings")} key="setting" forceRender>
             <Form.Item
               name="title"
               label={t("Display name")}
@@ -214,7 +214,7 @@ const FieldCreationModal: React.FC<Props> = ({
               <Checkbox>{t("Support multiple values")}</Checkbox>
             </Form.Item>
           </TabPane>
-          <TabPane tab="Validation" key="validation">
+          <TabPane tab="Validation" key="validation" forceRender>
             <FieldValidationProps selectedType={selectedType} />
             <Form.Item
               name="required"
@@ -229,7 +229,7 @@ const FieldCreationModal: React.FC<Props> = ({
               <Checkbox>{t("Set field as unique")}</Checkbox>
             </Form.Item>
           </TabPane>
-          <TabPane tab={t("Default value")} key="defaultValue">
+          <TabPane tab={t("Default value")} key="defaultValue" forceRender>
             <FieldDefaultInputs selectedValues={selectedValues} selectedType={selectedType} />
           </TabPane>
         </Tabs>

--- a/web/src/components/molecules/Schema/FieldModal/FieldDefaultInputs/URLField/index.tsx
+++ b/web/src/components/molecules/Schema/FieldModal/FieldDefaultInputs/URLField/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import Form from "@reearth-cms/components/atoms/Form";
 import Input from "@reearth-cms/components/atoms/Input";
+import { validateURL } from "@reearth-cms/utils/regex";
 
 const URLField: React.FC = () => {
   return (
@@ -12,14 +13,7 @@ const URLField: React.FC = () => {
         {
           message: "URL is not valid",
           validator: async (_, value) => {
-            if (
-              !/^(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)(?::\d{2,5})?(?:[/?#]\S*)?$/i.test(
-                value,
-              ) &&
-              value.length > 0
-            )
-              return Promise.reject();
-
+            if (!validateURL(value) && value?.length > 0) return Promise.reject();
             return Promise.resolve();
           },
         },

--- a/web/src/components/molecules/Schema/FieldModal/FieldUpdateModal/index.tsx
+++ b/web/src/components/molecules/Schema/FieldModal/FieldUpdateModal/index.tsx
@@ -143,7 +143,7 @@ const FieldUpdateModal: React.FC<Props> = ({
       onOk={handleSubmit}>
       <Form form={form} layout="vertical" initialValues={initialValues}>
         <Tabs defaultActiveKey="settings">
-          <TabPane tab={t("Setting")} key="setting">
+          <TabPane tab={t("Setting")} key="setting" forceRender>
             <Form.Item
               name="title"
               label={t("Display name")}
@@ -229,10 +229,10 @@ const FieldUpdateModal: React.FC<Props> = ({
               <Checkbox>{t("Support multiple values")}</Checkbox>
             </Form.Item>
           </TabPane>
-          <TabPane tab={t("Validation")} key="validation">
+          <TabPane tab={t("Validation")} key="validation" forceRender>
             <FieldValidationInputs selectedType={selectedType} />
           </TabPane>
-          <TabPane tab={t("Default value")} key="defaultValue">
+          <TabPane tab={t("Default value")} key="defaultValue" forceRender>
             <FieldDefaultInputs selectedValues={selectedValues} selectedType={selectedType} />
           </TabPane>
         </Tabs>


### PR DESCRIPTION
# Fixes
- [ ] FE: unique and required ’s value should be sent to the backend when Field is created
- [ ] FE: URL field should not be always required ( now it’s required nevertheless required is selected or not )
- [ ] FE: unique and required should be saved ( now user cannot save it )
- [ ] FE: User should be able to create the field without switching tab to “validation” or “default value” ( now by switching the tab, user can create )