### PR TITLE
fix(web): contents overflows layout

### DIFF
--- a/web/src/components/atoms/InnerContents/complex.tsx
+++ b/web/src/components/atoms/InnerContents/complex.tsx
@@ -24,7 +24,7 @@ export default ComplexInnerContents;
 const PaddedContent = styled.div`
   display: flex;
   margin: 16px 0 0 16px;
-  height: calc(100vh - 66px);
+  min-height: calc(100vh - 66px);
 `;
 
 const Main = styled.div`


### PR DESCRIPTION
# Overview
When we have a large number of schema fields, content overflows the layout:
![1](https://user-images.githubusercontent.com/78056580/199671287-8ee490d7-62c7-4980-9f41-575619a45994.png)
and
![2](https://user-images.githubusercontent.com/78056580/199671290-e2b1d240-b848-4396-a7b7-9b37964674fd.png)

After the fix:
![3](https://user-images.githubusercontent.com/78056580/199671407-b8a95160-1e97-4db7-a5e0-7a8ddcda4882.png)
