### PR TITLE
fix(server): change format date to date-time

### DIFF
--- a/server/pkg/integrationapi/asset.go
+++ b/server/pkg/integrationapi/asset.go
@@ -13,7 +13,7 @@ func NewAsset(a *asset.Asset, url string) (*Asset, error) {
 	return &Asset{
 		Id:          a.ID().Ref(),
 		ContentType: lo.ToPtr(a.File().ContentType()),
-		CreatedAt:   ToDate(a.CreatedAt()),
+		CreatedAt:   lo.ToPtr(a.CreatedAt()),
 		Name:        lo.ToPtr(a.File().Name()),
 		PreviewType: ToPreviewType(a.PreviewType()),
 		ProjectId:   a.Project().Ref(),

--- a/server/pkg/integrationapi/comment.go
+++ b/server/pkg/integrationapi/comment.go
@@ -25,6 +25,6 @@ func NewComment(c *thread.Comment) *Comment {
 		AuthorId:   &authorID,
 		AuthorType: &authorType,
 		Content:    lo.ToPtr(c.Content()),
-		CreatedAt:  ToDate(c.CreatedAt()),
+		CreatedAt:  lo.ToPtr(c.CreatedAt()),
 	}
 }

--- a/server/pkg/integrationapi/convert.go
+++ b/server/pkg/integrationapi/convert.go
@@ -4,9 +4,7 @@ package integrationapi
 
 import (
 	"errors"
-	"time"
 
-	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/reearth/reearth-cms/server/pkg/asset"
 	"github.com/reearth/reearth-cms/server/pkg/item"
 )
@@ -40,10 +38,4 @@ func New(obj any, v string, urlResolver asset.URLResolver) (res any, err error) 
 	}
 
 	return
-}
-
-func ToDate(t time.Time) *openapi_types.Date {
-	return &openapi_types.Date{
-		Time: t,
-	}
 }

--- a/server/pkg/integrationapi/item.go
+++ b/server/pkg/integrationapi/item.go
@@ -41,7 +41,7 @@ func NewItem(i *item.Item) Item {
 		Id:        i.ID().Ref(),
 		ModelId:   i.Model().Ref().StringRef(),
 		Fields:    &fs,
-		CreatedAt: ToDate(i.ID().Timestamp()),
-		UpdatedAt: ToDate(i.Timestamp()),
+		CreatedAt: lo.ToPtr(i.ID().Timestamp()),
+		UpdatedAt: lo.ToPtr(i.Timestamp()),
 	}
 }

--- a/server/pkg/integrationapi/schema.go
+++ b/server/pkg/integrationapi/schema.go
@@ -32,6 +32,6 @@ func NewSchema(i *schema.Schema) Schema {
 		Id:        i.ID().Ref(),
 		ProjectId: i.Project().Ref(),
 		Fields:    &fs,
-		CreatedAt: ToDate(i.ID().Timestamp()),
+		CreatedAt: lo.ToPtr(i.ID().Timestamp()),
 	}
 }

--- a/server/pkg/integrationapi/types.gen.go
+++ b/server/pkg/integrationapi/types.gen.go
@@ -4,6 +4,8 @@
 package integrationapi
 
 import (
+	"time"
+
 	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/reearth/reearth-cms/server/pkg/id"
 )
@@ -105,16 +107,16 @@ const (
 
 // Asset defines model for asset.
 type Asset struct {
-	ContentType *string             `json:"contentType,omitempty"`
-	CreatedAt   *openapi_types.Date `json:"createdAt,omitempty"`
-	File        *File               `json:"file,omitempty"`
-	Id          *id.AssetID         `json:"id,omitempty"`
-	Name        *string             `json:"name,omitempty"`
-	PreviewType *AssetPreviewType   `json:"previewType,omitempty"`
-	ProjectId   *id.ProjectID       `json:"projectId,omitempty"`
-	TotalSize   *float32            `json:"totalSize,omitempty"`
-	UpdatedAt   *openapi_types.Date `json:"updatedAt,omitempty"`
-	Url         *string             `json:"url,omitempty"`
+	ContentType *string           `json:"contentType,omitempty"`
+	CreatedAt   *time.Time        `json:"createdAt,omitempty"`
+	File        *File             `json:"file,omitempty"`
+	Id          *id.AssetID       `json:"id,omitempty"`
+	Name        *string           `json:"name,omitempty"`
+	PreviewType *AssetPreviewType `json:"previewType,omitempty"`
+	ProjectId   *id.ProjectID     `json:"projectId,omitempty"`
+	TotalSize   *float32          `json:"totalSize,omitempty"`
+	UpdatedAt   *time.Time        `json:"updatedAt,omitempty"`
+	Url         *string           `json:"url,omitempty"`
 }
 
 // AssetPreviewType defines model for Asset.PreviewType.
@@ -122,11 +124,11 @@ type AssetPreviewType string
 
 // Comment defines model for comment.
 type Comment struct {
-	AuthorId   *any                `json:"authorId,omitempty"`
-	AuthorType *CommentAuthorType  `json:"authorType,omitempty"`
-	Content    *string             `json:"content,omitempty"`
-	CreatedAt  *openapi_types.Date `json:"createdAt,omitempty"`
-	Id         *id.CommentID       `json:"id,omitempty"`
+	AuthorId   *any               `json:"authorId,omitempty"`
+	AuthorType *CommentAuthorType `json:"authorType,omitempty"`
+	Content    *string            `json:"content,omitempty"`
+	CreatedAt  *time.Time         `json:"createdAt,omitempty"`
+	Id         *id.CommentID      `json:"id,omitempty"`
 }
 
 // CommentAuthorType defines model for Comment.AuthorType.
@@ -150,11 +152,11 @@ type File struct {
 
 // Item defines model for item.
 type Item struct {
-	CreatedAt *openapi_types.Date `json:"createdAt,omitempty"`
-	Fields    *[]Field            `json:"fields,omitempty"`
-	Id        *id.ItemID          `json:"id,omitempty"`
-	ModelId   *string             `json:"modelId,omitempty"`
-	UpdatedAt *openapi_types.Date `json:"updatedAt,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
+	Fields    *[]Field   `json:"fields,omitempty"`
+	Id        *id.ItemID `json:"id,omitempty"`
+	ModelId   *string    `json:"modelId,omitempty"`
+	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
 }
 
 // RefOrVersion defines model for refOrVersion.
@@ -168,11 +170,11 @@ type RefOrVersionRef string
 
 // Schema defines model for schema.
 type Schema struct {
-	CreatedAt *openapi_types.Date `json:"createdAt,omitempty"`
-	Fields    *[]SchemaField      `json:"fields,omitempty"`
-	Id        *id.SchemaID        `json:"id,omitempty"`
-	ProjectId *id.ProjectID       `json:"projectId,omitempty"`
-	UpdatedAt *openapi_types.Date `json:"updatedAt,omitempty"`
+	CreatedAt *time.Time     `json:"createdAt,omitempty"`
+	Fields    *[]SchemaField `json:"fields,omitempty"`
+	Id        *id.SchemaID   `json:"id,omitempty"`
+	ProjectId *id.ProjectID  `json:"projectId,omitempty"`
+	UpdatedAt *time.Time     `json:"updatedAt,omitempty"`
 }
 
 // SchemaField defines model for schemaField.
@@ -195,13 +197,13 @@ type Version struct {
 
 // VersionedItem defines model for versionedItem.
 type VersionedItem struct {
-	CreatedAt *openapi_types.Date   `json:"createdAt,omitempty"`
+	CreatedAt *time.Time            `json:"createdAt,omitempty"`
 	Fields    *[]Field              `json:"fields,omitempty"`
 	Id        *id.ItemID            `json:"id,omitempty"`
 	ModelId   *string               `json:"modelId,omitempty"`
 	Parents   *[]openapi_types.UUID `json:"parents,omitempty"`
 	Refs      *[]string             `json:"refs,omitempty"`
-	UpdatedAt *openapi_types.Date   `json:"updatedAt,omitempty"`
+	UpdatedAt *time.Time            `json:"updatedAt,omitempty"`
 	Version   *openapi_types.UUID   `json:"version,omitempty"`
 }
 

--- a/server/schemas/integration.yml
+++ b/server/schemas/integration.yml
@@ -588,10 +588,10 @@ components:
             $ref: '#/components/schemas/schemaField'
         createdAt:
           type: string
-          format: date
+          format: date-time
         updatedAt:
           type: string
-          format: date
+          format: date-time
     valueType:
       type: string
       enum:
@@ -649,10 +649,10 @@ components:
             $ref: '#/components/schemas/field'
         createdAt:
           type: string
-          format: date
+          format: date-time
         updatedAt:
           type: string
-          format: date
+          format: date-time
     versionedItem:
       type: object
       properties:
@@ -667,10 +667,10 @@ components:
             $ref: '#/components/schemas/field'
         createdAt:
           type: string
-          format: date
+          format: date-time
         updatedAt:
           type: string
-          format: date
+          format: date-time
         version:
           type: string
           format: uuid
@@ -732,10 +732,10 @@ components:
           $ref: '#/components/schemas/file'
         createdAt:
           type: string
-          format: date
+          format: date-time
         updatedAt:
           type: string
-          format: date
+          format: date-time
     comment:
       type: object
       properties:
@@ -754,7 +754,7 @@ components:
           type: string
         createdAt:
           type: string
-          format: date
+          format: date-time
     file:
       type: object
       properties:


### PR DESCRIPTION
# Overview
Changed the format of created at in the integration API from date to date-time.
This allows it to have information such as hours and minutes.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
[TIcket](https://www.notion.so/eukarya/BE-add-time-minutes-sec-to-integrationAPI-s-response-a2ab7d81609d4edfa4cfee60f9bda805)