### PR TITLE
fix(server): add missing item fields to filter

### DIFF
--- a/server/pkg/item/item.go
+++ b/server/pkg/item/item.go
@@ -102,11 +102,15 @@ func (i *Item) FilterFields(list id.FieldIDList) *Item {
 	})
 
 	return &Item{
-		id:        i.id,
-		schema:    i.schema,
-		project:   i.project,
-		fields:    fields,
-		timestamp: i.timestamp,
+		id:          i.id,
+		schema:      i.schema,
+		model:       i.model,
+		project:     i.project,
+		fields:      fields,
+		timestamp:   i.timestamp,
+		thread:      i.thread,
+		user:        i.user,
+		integration: i.integration,
 	}
 }
 

--- a/server/pkg/item/item.go
+++ b/server/pkg/item/item.go
@@ -100,18 +100,8 @@ func (i *Item) FilterFields(list id.FieldIDList) *Item {
 	fields := lo.Filter(i.fields, func(f *Field, i int) bool {
 		return list.Has(f.FieldID())
 	})
-
-	return &Item{
-		id:          i.id,
-		schema:      i.schema,
-		model:       i.model,
-		project:     i.project,
-		fields:      fields,
-		timestamp:   i.timestamp,
-		thread:      i.thread,
-		user:        i.user,
-		integration: i.integration,
-	}
+	i.UpdateFields(fields)
+	return i
 }
 
 func (i *Item) HasField(fid id.FieldID, value any) bool {

--- a/server/pkg/item/item.go
+++ b/server/pkg/item/item.go
@@ -100,7 +100,7 @@ func (i *Item) FilterFields(list id.FieldIDList) *Item {
 	fields := lo.Filter(i.fields, func(f *Field, i int) bool {
 		return list.Has(f.FieldID())
 	})
-	i.UpdateFields(fields)
+	i.fields = fields
 	return i
 }
 


### PR DESCRIPTION
# Overview
item filter which is used for filtering the items according to the schema fields is missing some newly added fields
## What I've done
keep the original item and only update fields
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
