### PR TITLE
feat(server): update version validation

### DIFF
--- a/server/internal/usecase/interactor/request.go
+++ b/server/internal/usecase/interactor/request.go
@@ -219,8 +219,12 @@ func (r Request) Approve(ctx context.Context, requestID id.RequestID, operator *
 
 	// apply changes to items (publish items)
 	for _, item := range req.Items() {
-		// publish the approved version
-		if err := r.repos.Item.UpdateRef(ctx, item.Item(), version.Public, item.Pointer().Ref()); err != nil {
+		// If approved version is already on public, no change and no error
+		if item.Pointer().IsRef(version.Public) {
+			continue
+		}
+		// publish the latest version
+		if err := r.repos.Item.UpdateRef(ctx, item.Item(), version.Public, version.Latest.OrVersion().Ref()); err != nil {
 			return nil, err
 		}
 	}

--- a/server/internal/usecase/interactor/request.go
+++ b/server/internal/usecase/interactor/request.go
@@ -219,10 +219,6 @@ func (r Request) Approve(ctx context.Context, requestID id.RequestID, operator *
 
 	// apply changes to items (publish items)
 	for _, item := range req.Items() {
-		// If approved version is already on public, no change and no error
-		if item.Pointer().IsRef(version.Public) {
-			continue
-		}
 		// publish the latest version
 		if err := r.repos.Item.UpdateRef(ctx, item.Item(), version.Public, version.Latest.OrVersion().Ref()); err != nil {
 			return nil, err

--- a/server/internal/usecase/interactor/request.go
+++ b/server/internal/usecase/interactor/request.go
@@ -220,7 +220,7 @@ func (r Request) Approve(ctx context.Context, requestID id.RequestID, operator *
 	// apply changes to items (publish items)
 	for _, item := range req.Items() {
 		// publish the latest version
-		if err := r.repos.Item.UpdateRef(ctx, item.Item(), version.Public, version.Latest.OrVersion().Ref()); err != nil {
+		if err := r.repos.Item.UpdateRef(ctx, item.Item(), version.Public, item.Pointer().Ref()); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
# Overview
- Item can belong to multiple request
- When request is approved, the latest version will be published
- If approved version is already on public, no change and no error
- When request is created for an item whose latest version is public, it should returns error
## What I've done
- When request is approved, the latest version will be published
- If approved version is already on public, no change and no error
## What I haven't done
already implemented:
- Item can belong to multiple request
- When request is created for an item whose latest version is public, it should returns error
## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
