### PR TITLE
fix(web): integer field min, max and default value

### DIFF
--- a/web/src/components/molecules/Common/MultiValueField/index.tsx
+++ b/web/src/components/molecules/Common/MultiValueField/index.tsx
@@ -29,7 +29,7 @@ const MultiValueField: React.FC<Props> = ({
     (e: ChangeEvent<HTMLInputElement>, id: number) => {
       onChange?.(
         value?.map((valueItem, index) =>
-          index === id ? (typeof e === "number" ? e : e.target.value) : valueItem,
+          index === id ? (typeof e === "number" ? e : e?.target.value) : valueItem,
         ),
       );
     },

--- a/web/src/components/molecules/Common/MultiValueField/index.tsx
+++ b/web/src/components/molecules/Common/MultiValueField/index.tsx
@@ -26,7 +26,7 @@ const MultiValueField: React.FC<Props> = ({
 }) => {
   const t = useT();
   const handleInput = useCallback(
-    (e: ChangeEvent<HTMLInputElement>, id: number) => {
+    (e: ChangeEvent<HTMLInputElement | undefined>, id: number) => {
       onChange?.(
         value?.map((valueItem, index) =>
           index === id ? (typeof e === "number" ? e : e?.target.value) : valueItem,

--- a/web/src/components/molecules/Schema/FieldModal/FieldCreationModal/index.tsx
+++ b/web/src/components/molecules/Schema/FieldModal/FieldCreationModal/index.tsx
@@ -148,7 +148,11 @@ const FieldCreationModal: React.FC<Props> = ({
           };
         } else if (selectedType === "Integer") {
           values.typeProperty = {
-            integer: { defaultValue: values.defaultValue, min: values.min, max: values.max },
+            integer: {
+              defaultValue: values.defaultValue ?? null,
+              min: values.min ?? null,
+              max: values.max ?? null,
+            },
           };
         } else if (selectedType === "URL") {
           values.typeProperty = {

--- a/web/src/components/molecules/Schema/FieldModal/FieldCreationModal/index.tsx
+++ b/web/src/components/molecules/Schema/FieldModal/FieldCreationModal/index.tsx
@@ -148,7 +148,7 @@ const FieldCreationModal: React.FC<Props> = ({
           };
         } else if (selectedType === "Integer") {
           values.typeProperty = {
-            integer: { defaultValue: values.defaultValue, min: +values.min, max: +values.max },
+            integer: { defaultValue: values.defaultValue, min: values.min, max: values.max },
           };
         } else if (selectedType === "URL") {
           values.typeProperty = {

--- a/web/src/components/molecules/Schema/FieldModal/FieldUpdateModal/index.tsx
+++ b/web/src/components/molecules/Schema/FieldModal/FieldUpdateModal/index.tsx
@@ -165,7 +165,7 @@ const FieldUpdateModal: React.FC<Props> = ({
           };
         } else if (selectedType === "Integer") {
           values.typeProperty = {
-            integer: { defaultValue: +values.defaultValue, min: +values.min, max: +values.max },
+            integer: { defaultValue: values.defaultValue, min: values.min, max: values.max },
           };
         } else if (selectedType === "URL") {
           values.typeProperty = {

--- a/web/src/components/molecules/Schema/FieldModal/FieldUpdateModal/index.tsx
+++ b/web/src/components/molecules/Schema/FieldModal/FieldUpdateModal/index.tsx
@@ -165,7 +165,11 @@ const FieldUpdateModal: React.FC<Props> = ({
           };
         } else if (selectedType === "Integer") {
           values.typeProperty = {
-            integer: { defaultValue: values.defaultValue, min: values.min, max: values.max },
+            integer: {
+              defaultValue: values.defaultValue ?? null,
+              min: values.min ?? null,
+              max: values.max ?? null,
+            },
           };
         } else if (selectedType === "URL") {
           values.typeProperty = {

--- a/web/src/components/molecules/Schema/FieldModal/FieldValidationInputs/index.tsx
+++ b/web/src/components/molecules/Schema/FieldModal/FieldValidationInputs/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import Form from "@reearth-cms/components/atoms/Form";
-import Input from "@reearth-cms/components/atoms/Input";
+import InputNumber from "@reearth-cms/components/atoms/InputNumber";
 import { useT } from "@reearth-cms/i18n";
 
 import { FieldType } from "../../types";
@@ -15,15 +15,15 @@ const FieldValidationInputs: React.FC<Props> = ({ selectedType }) => {
   return selectedType ? (
     selectedType === "Text" || selectedType === "TextArea" || selectedType === "MarkdownText" ? (
       <Form.Item name="maxLength" label={t("Set maximum length")}>
-        <Input type="number" />
+        <InputNumber type="number" />
       </Form.Item>
     ) : selectedType === "Integer" ? (
       <>
         <Form.Item name="min" label={t("Set minimum value")}>
-          <Input type="number" />
+          <InputNumber type="number" />
         </Form.Item>
         <Form.Item name="max" label={t("Set maximum value")}>
-          <Input type="number" />
+          <InputNumber type="number" />
         </Form.Item>
       </>
     ) : null


### PR DESCRIPTION
# Overview
In this PR I fixed the following:
- When integer field value is being created or updated with default values existed the frontend sends null.
- When min, max and default values are null the frontend sends 0 instead of null.
