### PR TITLE
fix(web): tileset preview + refactor

### DIFF
--- a/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
@@ -6,7 +6,7 @@ import DownloadButton from "@reearth-cms/components/atoms/DownloadButton";
 import { DefaultOptionType } from "@reearth-cms/components/atoms/Select";
 import TilesetPreview from "@reearth-cms/components/atoms/TilesetPreview";
 import UserAvatar from "@reearth-cms/components/atoms/UserAvatar";
-import { Asset } from "@reearth-cms/components/molecules/Asset/asset.type";
+import { Asset, ViewerType } from "@reearth-cms/components/molecules/Asset/asset.type";
 import Card from "@reearth-cms/components/molecules/Asset/Asset/AssetBody/card";
 import PreviewToolbar from "@reearth-cms/components/molecules/Asset/Asset/AssetBody/previewToolbar";
 import {
@@ -17,7 +17,6 @@ import SideBarCard from "@reearth-cms/components/molecules/Asset/Asset/AssetBody
 import UnzipFileList from "@reearth-cms/components/molecules/Asset/Asset/AssetBody/UnzipFileList";
 import ViewerNotSupported from "@reearth-cms/components/molecules/Asset/Asset/AssetBody/viewerNotSupported";
 import ArchiveExtractionStatus from "@reearth-cms/components/molecules/Asset/AssetListTable/ArchiveExtractionStatus";
-import { ViewerType } from "@reearth-cms/components/organisms/Asset/Asset/hooks";
 import { useT } from "@reearth-cms/i18n";
 import { dateTimeFormat } from "@reearth-cms/utils/format";
 
@@ -60,7 +59,7 @@ const AssetMolecule: React.FC<Props> = ({
   };
   const renderPreview = () => {
     switch (true) {
-      case viewerType === "TileSet":
+      case viewerType === "cesium":
         return (
           <TilesetPreview
             viewerProps={{
@@ -83,11 +82,11 @@ const AssetMolecule: React.FC<Props> = ({
             onGetViewer={getViewer}
           />
         );
-      case viewerType === "Image":
+      case viewerType === "image":
         return <Image src={assetUrl} alt="asset-preview" />;
-      case viewerType === "SVG":
+      case viewerType === "svg":
         return <SVGPreview url={assetUrl} svgRender={svgRender} />;
-      case viewerType === "Unsupported":
+      case viewerType === "unsupported":
       default:
         return <ViewerNotSupported />;
     }

--- a/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
@@ -33,6 +33,7 @@ type Props = {
   asset: Asset;
   selectedPreviewType: PreviewType;
   isModalVisible: boolean;
+  isTileSetPreviewVisible: boolean;
   onModalCancel: () => void;
   onTypeChange: (
     value: PreviewType,
@@ -47,6 +48,7 @@ const AssetMolecule: React.FC<Props> = ({
   asset,
   selectedPreviewType,
   isModalVisible,
+  isTileSetPreviewVisible,
   onTypeChange,
   onModalCancel,
   onChangeToFullScreen,
@@ -67,9 +69,7 @@ const AssetMolecule: React.FC<Props> = ({
   };
   const renderPreview = () => {
     switch (true) {
-      case (selectedPreviewType === "GEO" ||
-        selectedPreviewType === "GEO3D" ||
-        selectedPreviewType === "MODEL3D") &&
+      case isTileSetPreviewVisible &&
         (fileFormats.includes(assetFileExt) || compressedFileFormats.includes(assetFileExt)):
         return (
           <TilesetPreview

--- a/web/src/components/molecules/Asset/Asset/AssetBody/index.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/index.tsx
@@ -13,6 +13,7 @@ export type Props = {
   asset?: Asset;
   selectedPreviewType: PreviewType;
   isModalVisible: boolean;
+  isTileSetPreviewVisible: boolean;
   commentsPanel?: JSX.Element;
   onTypeChange: (
     value: PreviewType,
@@ -28,6 +29,7 @@ const AssetWrapper: React.FC<Props> = ({
   asset,
   selectedPreviewType,
   isModalVisible,
+  isTileSetPreviewVisible,
   commentsPanel,
   onTypeChange,
   onModalCancel,
@@ -50,6 +52,7 @@ const AssetWrapper: React.FC<Props> = ({
             asset={asset}
             selectedPreviewType={selectedPreviewType}
             isModalVisible={isModalVisible}
+            isTileSetPreviewVisible={isTileSetPreviewVisible}
             onTypeChange={onTypeChange}
             onModalCancel={onModalCancel}
             onChangeToFullScreen={onChangeToFullScreen}

--- a/web/src/components/molecules/Asset/Asset/AssetBody/index.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/index.tsx
@@ -7,13 +7,15 @@ import { DefaultOptionType } from "@reearth-cms/components/atoms/Select";
 import { Asset } from "@reearth-cms/components/molecules/Asset/asset.type";
 import AssetMolecule from "@reearth-cms/components/molecules/Asset/Asset/AssetBody/Asset";
 import { PreviewType } from "@reearth-cms/components/molecules/Asset/Asset/AssetBody/previewTypeSelect";
+import { ViewerType } from "@reearth-cms/components/organisms/Asset/Asset/hooks";
 import { useT } from "@reearth-cms/i18n";
 
 export type Props = {
   asset?: Asset;
   selectedPreviewType: PreviewType;
   isModalVisible: boolean;
-  isTileSetPreviewVisible: boolean;
+  viewerType: ViewerType;
+  displayUnzipFileList: boolean;
   commentsPanel?: JSX.Element;
   onTypeChange: (
     value: PreviewType,
@@ -29,7 +31,8 @@ const AssetWrapper: React.FC<Props> = ({
   asset,
   selectedPreviewType,
   isModalVisible,
-  isTileSetPreviewVisible,
+  viewerType,
+  displayUnzipFileList,
   commentsPanel,
   onTypeChange,
   onModalCancel,
@@ -52,7 +55,8 @@ const AssetWrapper: React.FC<Props> = ({
             asset={asset}
             selectedPreviewType={selectedPreviewType}
             isModalVisible={isModalVisible}
-            isTileSetPreviewVisible={isTileSetPreviewVisible}
+            viewerType={viewerType}
+            displayUnzipFileList={displayUnzipFileList}
             onTypeChange={onTypeChange}
             onModalCancel={onModalCancel}
             onChangeToFullScreen={onChangeToFullScreen}

--- a/web/src/components/molecules/Asset/Asset/AssetBody/index.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/index.tsx
@@ -4,10 +4,9 @@ import Button from "@reearth-cms/components/atoms/Button";
 import ComplexInnerContents from "@reearth-cms/components/atoms/InnerContents/complex";
 import PageHeader from "@reearth-cms/components/atoms/PageHeader";
 import { DefaultOptionType } from "@reearth-cms/components/atoms/Select";
-import { Asset } from "@reearth-cms/components/molecules/Asset/asset.type";
+import { Asset, ViewerType } from "@reearth-cms/components/molecules/Asset/asset.type";
 import AssetMolecule from "@reearth-cms/components/molecules/Asset/Asset/AssetBody/Asset";
 import { PreviewType } from "@reearth-cms/components/molecules/Asset/Asset/AssetBody/previewTypeSelect";
-import { ViewerType } from "@reearth-cms/components/organisms/Asset/Asset/hooks";
 import { useT } from "@reearth-cms/i18n";
 
 export type Props = {

--- a/web/src/components/molecules/Asset/Asset/AssetBody/previewToolbar.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/previewToolbar.tsx
@@ -26,20 +26,25 @@ const PreviewToolbar: React.FC<Props> = ({
   handleModalCancel,
 }) => {
   const t = useT();
+  const isSVGButtonVisible = selectedPreviewType === "IMAGE" && isSVG;
+  const isFullScreenButtonVisible = selectedPreviewType !== "UNKNOWN";
+
   return (
     <>
-      {selectedPreviewType === "IMAGE" && isSVG && (
+      {isSVGButtonVisible && (
         <>
           <Button onClick={handleCodeSourceClick}>{t("Source Code")}</Button>
           <Button onClick={handleRenderClick}>{t("Render")}</Button>
         </>
       )}
-      <Button
-        type="link"
-        icon={<Icon icon="fullscreen" />}
-        size="large"
-        onClick={handleFullScreen}
-      />
+      {isFullScreenButtonVisible && (
+        <Button
+          type="link"
+          icon={<Icon icon="fullscreen" />}
+          size="large"
+          onClick={handleFullScreen}
+        />
+      )}
       <PreviewModal url={url} visible={isModalVisible} handleCancel={handleModalCancel} />
     </>
   );

--- a/web/src/components/molecules/Asset/Asset/AssetBody/previewToolbar.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/previewToolbar.tsx
@@ -1,14 +1,13 @@
 import Button from "@reearth-cms/components/atoms/Button";
 import Icon from "@reearth-cms/components/atoms/Icon";
 import PreviewModal from "@reearth-cms/components/molecules/Asset/Asset/AssetBody/previewModal";
-import { PreviewType } from "@reearth-cms/components/molecules/Asset/Asset/AssetBody/previewTypeSelect";
+import { ViewerType } from "@reearth-cms/components/organisms/Asset/Asset/hooks";
 import { useT } from "@reearth-cms/i18n";
 
 type Props = {
   url: string;
-  selectedPreviewType: PreviewType;
   isModalVisible: boolean;
-  isSVG?: boolean;
+  viewerType?: ViewerType;
   handleCodeSourceClick: () => void;
   handleRenderClick: () => void;
   handleFullScreen: () => void;
@@ -17,17 +16,16 @@ type Props = {
 
 const PreviewToolbar: React.FC<Props> = ({
   url,
-  selectedPreviewType,
   isModalVisible,
-  isSVG,
+  viewerType,
   handleCodeSourceClick,
   handleRenderClick,
   handleFullScreen,
   handleModalCancel,
 }) => {
   const t = useT();
-  const isSVGButtonVisible = selectedPreviewType === "IMAGE" && isSVG;
-  const isFullScreenButtonVisible = selectedPreviewType !== "UNKNOWN";
+  const isSVGButtonVisible = viewerType === "SVG";
+  const isFullScreenButtonVisible = viewerType !== "Unsupported";
 
   return (
     <>

--- a/web/src/components/molecules/Asset/Asset/AssetBody/previewToolbar.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/previewToolbar.tsx
@@ -1,7 +1,7 @@
 import Button from "@reearth-cms/components/atoms/Button";
 import Icon from "@reearth-cms/components/atoms/Icon";
+import { ViewerType } from "@reearth-cms/components/molecules/Asset/asset.type";
 import PreviewModal from "@reearth-cms/components/molecules/Asset/Asset/AssetBody/previewModal";
-import { ViewerType } from "@reearth-cms/components/organisms/Asset/Asset/hooks";
 import { useT } from "@reearth-cms/i18n";
 
 type Props = {
@@ -24,8 +24,8 @@ const PreviewToolbar: React.FC<Props> = ({
   handleModalCancel,
 }) => {
   const t = useT();
-  const isSVGButtonVisible = viewerType === "SVG";
-  const isFullScreenButtonVisible = viewerType !== "Unsupported";
+  const isSVGButtonVisible = viewerType === "svg";
+  const isFullScreenButtonVisible = viewerType !== "unsupported";
 
   return (
     <>

--- a/web/src/components/molecules/Asset/asset.type.ts
+++ b/web/src/components/molecules/Asset/asset.type.ts
@@ -2,6 +2,7 @@ import { PreviewType as PreviewTypeType } from "./Asset/AssetBody/previewTypeSel
 
 export type PreviewType = PreviewTypeType;
 export type ArchiveExtractionStatus = "PENDING" | "IN_PROGRESS" | "DONE" | "FAILED" | undefined;
+export type ViewerType = "cesium" | "image" | "svg" | "unsupported";
 
 export type Asset = {
   id: string;

--- a/web/src/components/organisms/Asset/Asset/hooks.ts
+++ b/web/src/components/organisms/Asset/Asset/hooks.ts
@@ -58,13 +58,18 @@ export default (assetId?: string) => {
     setSelectedPreviewType(value);
   }, []);
 
+  const isTileSetPreviewVisible =
+    selectedPreviewType === "GEO" ||
+    selectedPreviewType === "GEO3D" ||
+    selectedPreviewType === "MODEL3D";
+
   const handleFullScreen = useCallback(() => {
-    if (selectedPreviewType === "GEO") {
+    if (isTileSetPreviewVisible) {
       viewerRef?.canvas.requestFullscreen();
     } else {
       setIsModalVisible(true);
     }
-  }, [selectedPreviewType]);
+  }, [isTileSetPreviewVisible]);
 
   const handleModalCancel = useCallback(() => {
     setIsModalVisible(false);
@@ -83,6 +88,7 @@ export default (assetId?: string) => {
     selectedPreviewType,
     isModalVisible,
     collapsed,
+    isTileSetPreviewVisible,
     handleToggleCommentMenu,
     handleAssetUpdate,
     handleTypeChange,

--- a/web/src/components/organisms/Asset/Asset/hooks.ts
+++ b/web/src/components/organisms/Asset/Asset/hooks.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import Notification from "@reearth-cms/components/atoms/Notification";
-import { Asset, PreviewType } from "@reearth-cms/components/molecules/Asset/asset.type";
+import { Asset, PreviewType, ViewerType } from "@reearth-cms/components/molecules/Asset/asset.type";
 import { viewerRef } from "@reearth-cms/components/molecules/Asset/Asset/AssetBody/Asset";
 import {
   fileFormats,
@@ -18,8 +18,6 @@ import { useT } from "@reearth-cms/i18n";
 import { getExtension } from "@reearth-cms/utils/file";
 
 import { convertAsset } from "../convertAsset";
-
-export type ViewerType = "TileSet" | "Image" | "SVG" | "Unsupported";
 
 export default (assetId?: string) => {
   const t = useT();
@@ -66,7 +64,7 @@ export default (assetId?: string) => {
     setSelectedPreviewType(value);
   }, []);
 
-  const [viewerType, setViewerType] = useState<ViewerType>("Unsupported");
+  const [viewerType, setViewerType] = useState<ViewerType>("unsupported");
   const assetFileExt = getExtension(asset?.fileName);
   const isSVG = assetFileExt === "svg";
 
@@ -76,13 +74,13 @@ export default (assetId?: string) => {
         selectedPreviewType === "GEO3D" ||
         selectedPreviewType === "MODEL3D") &&
         (fileFormats.includes(assetFileExt) || compressedFileFormats.includes(assetFileExt)):
-        setViewerType("TileSet");
+        setViewerType("cesium");
         break;
       case selectedPreviewType === "IMAGE" && imageFormats.includes(assetFileExt):
-        isSVG ? setViewerType("SVG") : setViewerType("Image");
+        isSVG ? setViewerType("svg") : setViewerType("image");
         break;
       default:
-        setViewerType("Unsupported");
+        setViewerType("unsupported");
         break;
     }
   }, [asset?.previewType, assetFileExt, isSVG, selectedPreviewType]);
@@ -93,9 +91,9 @@ export default (assetId?: string) => {
   );
 
   const handleFullScreen = useCallback(() => {
-    if (viewerType === "TileSet") {
+    if (viewerType === "cesium") {
       viewerRef?.canvas.requestFullscreen();
-    } else if (viewerType === "Image" || viewerType === "SVG") {
+    } else if (viewerType === "image" || viewerType === "svg") {
       setIsModalVisible(true);
     }
   }, [viewerType]);

--- a/web/src/components/organisms/Asset/Asset/index.tsx
+++ b/web/src/components/organisms/Asset/Asset/index.tsx
@@ -15,6 +15,7 @@ const Asset: React.FC = () => {
     selectedPreviewType,
     isModalVisible,
     collapsed,
+    isTileSetPreviewVisible,
     handleToggleCommentMenu,
     handleAssetUpdate,
     handleTypeChange,
@@ -48,6 +49,7 @@ const Asset: React.FC = () => {
       asset={asset}
       selectedPreviewType={selectedPreviewType}
       isModalVisible={isModalVisible}
+      isTileSetPreviewVisible={isTileSetPreviewVisible}
       onTypeChange={handleTypeChange}
       onModalCancel={handleModalCancel}
       onChangeToFullScreen={handleFullScreen}

--- a/web/src/components/organisms/Asset/Asset/index.tsx
+++ b/web/src/components/organisms/Asset/Asset/index.tsx
@@ -15,7 +15,8 @@ const Asset: React.FC = () => {
     selectedPreviewType,
     isModalVisible,
     collapsed,
-    isTileSetPreviewVisible,
+    viewerType,
+    displayUnzipFileList,
     handleToggleCommentMenu,
     handleAssetUpdate,
     handleTypeChange,
@@ -49,7 +50,8 @@ const Asset: React.FC = () => {
       asset={asset}
       selectedPreviewType={selectedPreviewType}
       isModalVisible={isModalVisible}
-      isTileSetPreviewVisible={isTileSetPreviewVisible}
+      viewerType={viewerType}
+      displayUnzipFileList={displayUnzipFileList}
       onTypeChange={handleTypeChange}
       onModalCancel={handleModalCancel}
       onChangeToFullScreen={handleFullScreen}

--- a/web/src/utils/file.ts
+++ b/web/src/utils/file.ts
@@ -1,5 +1,5 @@
-export const getExtension = (filename: string) => {
-  if (!filename.includes(".")) return "";
+export const getExtension = (filename?: string) => {
+  if (!filename || !filename.includes(".")) return "";
 
   return filename.toLowerCase().slice(filename.lastIndexOf(".") + 1, filename.length);
 };


### PR DESCRIPTION
# Overview
In this PR I did the following:
1- Fixed tileset preview full screen button for `GEO3D` and `MODEL3D` types.
2- Hide full screen button with `Unsupported` viewer type.
3- I refactored the way the asset viewer is displayed.