### PR TITLE
fix(web): infobox bug

### DIFF
--- a/web/src/components/molecules/Asset/Viewers/Geo3dViewer/index.tsx
+++ b/web/src/components/molecules/Asset/Viewers/Geo3dViewer/index.tsx
@@ -1,5 +1,5 @@
 import { Viewer as CesiumViewer } from "cesium";
-import { ComponentProps, useEffect } from "react";
+import { ComponentProps, useCallback, useEffect, useState } from "react";
 
 import ResiumViewer from "@reearth-cms/components/atoms/ResiumViewer";
 import { compressedFileFormats } from "@reearth-cms/components/molecules/Common/Asset";
@@ -15,6 +15,11 @@ type Props = {
 };
 
 const Geo3dViewer: React.FC<Props> = ({ viewerProps, url, setAssetUrl, onGetViewer }) => {
+  const [featureSelected, selectFeature] = useState(false);
+  const handleSelect = useCallback((e: string | undefined) => {
+    selectFeature(!!e);
+  }, []);
+
   useEffect(() => {
     const assetExtension = getExtension(url);
     if (compressedFileFormats.includes(assetExtension)) {
@@ -25,7 +30,11 @@ const Geo3dViewer: React.FC<Props> = ({ viewerProps, url, setAssetUrl, onGetView
   }, [setAssetUrl, url]);
 
   return (
-    <ResiumViewer {...viewerProps} onGetViewer={onGetViewer}>
+    <ResiumViewer
+      {...viewerProps}
+      onGetViewer={onGetViewer}
+      entitySelected={featureSelected}
+      onSelect={handleSelect}>
       <Cesium3dTileSetComponent url={url} />
     </ResiumViewer>
   );

--- a/web/src/components/molecules/Asset/Viewers/GeoViewer/index.tsx
+++ b/web/src/components/molecules/Asset/Viewers/GeoViewer/index.tsx
@@ -1,5 +1,5 @@
 import { Viewer as CesiumViewer } from "cesium";
-import { ComponentProps, useCallback } from "react";
+import { ComponentProps, useCallback, useState } from "react";
 
 import ResiumViewer from "@reearth-cms/components/atoms/ResiumViewer";
 import { getExtension } from "@reearth-cms/utils/file";
@@ -17,6 +17,10 @@ type Props = {
 
 // TODO: One generic component for these three datatypes should be created instead.
 const GeoViewer: React.FC<Props> = ({ viewerProps, url, assetFileExt, onGetViewer }) => {
+  const [featureSelected, selectFeature] = useState(false);
+  const handleSelect = useCallback((e: string | undefined) => {
+    selectFeature(!!e);
+  }, []);
   const ext = getExtension(url) ?? assetFileExt;
   const renderAsset = useCallback(() => {
     switch (ext) {
@@ -31,7 +35,12 @@ const GeoViewer: React.FC<Props> = ({ viewerProps, url, assetFileExt, onGetViewe
   }, [ext, url]);
 
   return (
-    <ResiumViewer showDescription={ext === "czml"} {...viewerProps} onGetViewer={onGetViewer}>
+    <ResiumViewer
+      showDescription={ext === "czml"}
+      {...viewerProps}
+      onGetViewer={onGetViewer}
+      entitySelected={featureSelected}
+      onSelect={handleSelect}>
       {renderAsset()}
     </ResiumViewer>
   );

--- a/web/src/components/molecules/Asset/Viewers/MvtViewer/Imagery.tsx
+++ b/web/src/components/molecules/Asset/Viewers/MvtViewer/Imagery.tsx
@@ -22,6 +22,7 @@ const normalOffset = new HeadingPitchRange(0, Math.toRadians(-90.0), 200000);
 
 type Props = {
   url: string;
+  entitySelected?: boolean;
   handleProperties: (prop: Property) => void;
   selectFeature: (selected: boolean) => void;
 };
@@ -36,7 +37,12 @@ type TileCoordinates = {
   level: number;
 };
 
-export const Imagery: React.FC<Props> = ({ url, handleProperties, selectFeature }) => {
+export const Imagery: React.FC<Props> = ({
+  url,
+  entitySelected,
+  handleProperties,
+  selectFeature,
+}) => {
   const { viewer } = useCesium() as { viewer: Viewer | undefined };
   const [selectedFeature, setSelectFeature] = useState<string>();
   const [urlTemplate, setUrlTemplate] = useState<URLTemplate>(url as URLTemplate);
@@ -97,6 +103,12 @@ export const Imagery: React.FC<Props> = ({ url, handleProperties, selectFeature 
   useEffect(() => {
     loadData(url);
   }, [loadData, url]);
+
+  useEffect(() => {
+    if (!entitySelected) {
+      setSelectFeature(undefined);
+    }
+  }, [entitySelected]);
 
   useEffect(() => {
     const imageryProvider = new MVTImageryProvider({

--- a/web/src/components/molecules/Asset/Viewers/MvtViewer/index.tsx
+++ b/web/src/components/molecules/Asset/Viewers/MvtViewer/index.tsx
@@ -38,7 +38,12 @@ const MvtViewer: React.FC<Props> = ({ viewerProps, url, onGetViewer }) => {
       properties={attributes}
       entitySelected={featureSelected}
       onSelect={handleSelect}>
-      <Imagery url={url} handleProperties={setProperties} selectFeature={selectFeature} />
+      <Imagery
+        url={url}
+        entitySelected={featureSelected}
+        handleProperties={setProperties}
+        selectFeature={selectFeature}
+      />
     </ResiumViewer>
   );
 };


### PR DESCRIPTION
# Overview
Fix infobox for 3d Tiles, CZML, and other GIS data.
Remove the red color and change it to orange when unselecting an MVT property.