### PR TITLE
feat(web): add copy action

### DIFF
--- a/web/src/components/atoms/Icon/icons.ts
+++ b/web/src/components/atoms/Icon/icons.ts
@@ -43,6 +43,7 @@ import {
   FileTwoTone,
   PictureTwoTone,
   LoadingOutlined,
+  CopyOutlined,
 } from "@ant-design/icons";
 
 import ArrowSquareOut from "./Icons/arrowSquareOut.svg";
@@ -123,4 +124,5 @@ export default {
   loading: LoadingOutlined,
   linked: Linked,
   unzip: Unzip,
+  copy: CopyOutlined,
 };

--- a/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
@@ -115,7 +115,17 @@ const AssetMolecule: React.FC<Props> = ({
         </Card>
         {displayUnzipFileList && asset.file && (
           <Card
-            title={asset.fileName}
+            title={
+              <>
+                {asset.fileName}{" "}
+                <CopyIcon
+                  icon="copy"
+                  onClick={() => {
+                    navigator.clipboard.writeText(asset.url);
+                  }}
+                />
+              </>
+            }
             toolbar={
               <>
                 <ArchiveExtractionStatus archiveExtractionStatus={asset.archiveExtractionStatus} />
@@ -166,6 +176,13 @@ const AssetMolecule: React.FC<Props> = ({
     </BodyContainer>
   );
 };
+
+const CopyIcon = styled(Icon)<{ selected?: boolean }>`
+  margin-left: 16px;
+  &:active {
+    color: #096dd9;
+  }
+`;
 
 const UnzipButton = styled(Button)`
   margin-left: 24px;

--- a/web/src/components/molecules/Asset/Asset/AssetBody/UnzipFileList.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/UnzipFileList.tsx
@@ -45,13 +45,24 @@ const UnzipFileList: React.FC<Props> = ({
         }
 
         return {
-          title: file.name,
+          title: (
+            <>
+              {file.name}
+              <CopyIcon
+                selected={selectedKeys[0] === key}
+                icon="copy"
+                onClick={() => {
+                  navigator.clipboard.writeText(assetBaseUrl + file.path);
+                }}
+              />
+            </>
+          ),
           key: key,
           children: children,
           file: file,
         };
       }) || [],
-    [],
+    [selectedKeys, assetBaseUrl],
   );
 
   useEffect(() => {
@@ -67,10 +78,11 @@ const UnzipFileList: React.FC<Props> = ({
 
   const onSelect: TreeProps<FileNode>["onSelect"] = useCallback(
     (keys: Key[], { node: { file } }: { node: FileNode }) => {
+      if (!keys[0] || keys[0] === selectedKeys[0]) return;
       previewFile(file);
       setSelectedKeys(keys);
     },
-    [previewFile],
+    [previewFile, selectedKeys],
   );
 
   const onExpand: TreeProps["onExpand"] = (keys: Key[]) => {
@@ -129,6 +141,14 @@ const ExtractionFailedWrapper = styled.div`
 
 const ExtractionFailedIcon = styled(Icon)`
   margin-bottom: 28px;
+`;
+
+const CopyIcon = styled(Icon)<{ selected?: boolean }>`
+  margin-left: 16px;
+  visibility: ${({ selected }) => (selected ? "visible" : "hidden")};
+  &:active {
+    color: #096dd9;
+  }
 `;
 
 const ExtractionFailedText = styled.p`

--- a/web/src/components/molecules/Asset/Asset/AssetBody/card.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/card.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { CSSProperties, ReactNode } from "react";
 
 type Props = {
-  title: string;
+  title: string | JSX.Element;
   toolbar?: ReactNode;
   children?: ReactNode;
   style?: CSSProperties;


### PR DESCRIPTION
# Overview
This PR adds the CopyOutlined icon to asset file names and supports copying the file URL to the clipboard on click. The icon is only visible when an item is selected in the Tree component.

# What I've done
- Added the CopyOutlined icon to the web/src/components/atoms/Icon/icons.ts file.
- Modified the web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx file to include the CopyOutlined icon next to the asset file name.
- Created a CopyIcon styled component for the copy icon's styles.
- Updated the web/src/components/molecules/Asset/Asset/AssetBody/UnzipFileList.tsx file to show the CopyOutlined icon next to the file names in the Tree component.
- Made the CopyOutlined icon visible only when an item is selected in the Tree component.
- Changed the title prop type in the web/src/components/molecules/Asset/Asset/AssetBody/card.tsx file to accept a string or a JSX.Element.

# What I haven't done
N/A

# How I tested
- Tested the new functionality manually by clicking the CopyOutlined icon and verifying that the file URL is copied to the clipboard.
- Ensured the CopyOutlined icon is visible only when an item is selected in the Tree component.