### PR TITLE
fix(server): skip update when PreviewType cannot be detected

### DIFF
--- a/server/internal/usecase/interactor/asset.go
+++ b/server/internal/usecase/interactor/asset.go
@@ -355,7 +355,9 @@ func (i *Asset) UpdateFiles(ctx context.Context, aid id.AssetID, s *asset.Archiv
 			})
 
 			a.UpdateArchiveExtractionStatus(s)
-			a.UpdatePreviewType(detectPreviewType(files))
+			if previewType := detectPreviewType(files); previewType != nil {
+				a.UpdatePreviewType(previewType)
+			}
 
 			f := asset.FoldFiles(assetFiles, srcfile)
 


### PR DESCRIPTION
# Overview
when the decompress event was notified, the PreviewType was detected from the decompressed asset and updated,
but if the PreviewType could not be detected, it was updated to an empty string.
fixed to not update when it could not be detected.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
