### PR TITLE
ci: fix frontend deploying action

### DIFF
--- a/.github/workflows/deploy_aws.yml
+++ b/.github/workflows/deploy_aws.yml
@@ -1,7 +1,6 @@
 name: deploy-aws
 on:
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
 
 env:
   # server

--- a/.github/workflows/deploy_aws.yml
+++ b/.github/workflows/deploy_aws.yml
@@ -26,7 +26,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v3
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/deploy_aws.yml
+++ b/.github/workflows/deploy_aws.yml
@@ -1,6 +1,7 @@
 name: deploy-aws
 on:
-  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
 
 env:
   # server
@@ -18,10 +19,32 @@ jobs:
       run:
         working-directory: web
     steps:
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: lts/*         
+          node-version: lts/*
+      - uses: actions/checkout@v3
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install
+        run: yarn install
+      - name: Lint
+        run: yarn run lint
+      - name: Test
+        run: yarn run coverage
+      - name: Send coverage report
+        uses: codecov/codecov-action@v1
+        with:
+          flags: web
+      - name: Check translations
+        run: yarn i18n --fail-on-update
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -30,18 +53,8 @@ jobs:
           aws-region: us-east-1
       - name: Install Amplify CLI
         run: yarn global add @aws-amplify/cli
-      - name: Download artifact
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: ci_web.yml
-          workflow_conclusion: success
-          branch: main
-          name: reearth-cms-web     
-      - name: Extract artifact
-        run: tar -xf reearth-cms-web.tar.gz   
-      - name: Initialize Amplify
-        run: amplify init --appId ${{ secrets.AWS_AMPLIFY_APP_ID }} --envName test --yes
+      - name: Pull Amplify project
+        run: amplify pull --appId ${{ secrets.AWS_AMPLIFY_APP_ID }} --envName test --yes
       - name: Build and Deploy to Amplify
         run: amplify publish --appId ${{ secrets.AWS_AMPLIFY_APP_ID }} --envName test --yes
 

--- a/web/amplify.yml
+++ b/web/amplify.yml
@@ -6,7 +6,7 @@ frontend:
         - yarn
     build:
       commands:
-        - yarn build
+        - yarn build 
   artifacts:
     baseDirectory: dist
     files:


### PR DESCRIPTION
# Overview
To effectively deploy your project using Amplify, it's crucial to grant Amplify access to the 'web/amplify.yml' file and the 'amplify' folder. These resources are indispensable as they contain the necessary configurations that Amplify requires to correctly deploy your project.

We have also discontinued the use of 'web_ci'. Its utility has been found lacking due to the creation of artifacts with the built project that doesn't sufficiently meet the demands of Amplify. The 'web_ci' process didn't deliver the level of completeness that the Amplify service necessitates for a successful and efficient project deployment.