### PR TITLE
chore: update renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,13 +4,41 @@
     ":semanticCommits",
     ":semanticCommitScopeDisabled",
     ":maintainLockFilesWeekly",
-    ":enableVulnerabilityAlertsWithLabel(security)"
+    ":enableVulnerabilityAlertsWithLabel(security)",
+    ":semanticCommitTypeAll(chore)"
   ],
+  "lockFileMaintenance": false,
+  "rangeStrategy": "bump",
+  "separateMajorMinor": false,
   "postUpdateOptions": [
     "gomodTidy",
     "gomodUpdateImportPaths"
   ],
   "packageRules": [
+    {
+      "enabledManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "cesium"
+      ],
+      "groupName": "cesium",
+      "schedule": ["before 3:00 am on the 4th day of the month"]
+    },
+    {
+      "enabledManagers": [
+        "npm"
+      ],
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "excludePackageNames": [
+        "cesium"
+      ],
+      "groupName": "all dependencies",
+      "groupSlug": "all",
+      "schedule": ["before 3:00 am on the 4th day of the month"]
+    },
     {
       "enabledManagers": [
         "gomod"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,8 +4,7 @@
     ":semanticCommits",
     ":semanticCommitScopeDisabled",
     ":maintainLockFilesWeekly",
-    ":enableVulnerabilityAlertsWithLabel(security)",
-    ":semanticCommitTypeAll(chore)"
+    ":enableVulnerabilityAlertsWithLabel(security)"
   ],
   "postUpdateOptions": [
     "gomodTidy",
@@ -13,26 +12,47 @@
   ],
   "packageRules": [
     {
-      "matchPaths": [
-        "server/**"
+      "enabledManagers": [
+        "gomod"
       ],
       "matchPackagePatterns": [
         "*"
       ],
-      "groupName": "all dependencies of server",
-      "groupSlug": "server",
-      "schedule": ["before 3:00 am on the 4th day of the month"]
+      "groupName": "dependencies",
+      "groupSlug": "gomod",
+      "semanticCommitType": "chore",
+      "schedule": [
+        "before 3:00 am on the 4th day of the month"
+      ]
     },
     {
-      "matchPaths": [
-        "web/**"
+      "enabledManagers": [
+        "dockerfile",
+        "docker-compose"
       ],
       "matchPackagePatterns": [
         "*"
       ],
-      "groupName": "all dependencies of web",
-      "groupSlug": "web",
-      "schedule": ["before 3:00 am on the 4th day of the month"]
+      "groupName": "docker dependencies",
+      "groupSlug": "docker",
+      "semanticCommitType": "chore",
+      "schedule": [
+        "before 3:00 am on the 4th day of the month"
+      ]
+    },
+    {
+      "enabledManagers": [
+        "github-actions"
+      ],
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "groupName": "github actions dependencies",
+      "groupSlug": "github-actions",
+      "semanticCommitType": "ci",
+      "schedule": [
+        "before 3:00 am on the 4th day of the month"
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Title: 
Unified Renovate Configuration Across Web and Server Directories

# Description:

This pull request aims to simplify and unify the Renovate configuration for our project. Previously, we had separate configuration files for our web (frontend) and server (backend) directories. The changes in this PR will enable us to manage the dependencies of both frontend and backend in a single place, providing a more streamlined and efficient dependency management process.

Key changes include:

- Consolidating the `extends` field to use the same configuration base and shared settings across all dependencies.
- Setting the `lockFileMaintenance`, `rangeStrategy`, and `separateMajorMinor` flags at the root level to be applicable across all dependency types.
- Enabling `gomodTidy` and `gomodUpdateImportPaths` post-update options for Go modules.
- Consolidating the `packageRules` to accommodate dependencies from both web and server directories. The rules are now structured to target specific package managers (`npm`, `gomod`, `dockerfile`, `docker-compose`, and `github-actions`) and have unified schedules for updates.
- Dependency groups are clearly defined, maintaining the previous grouping of `cesium`, `all dependencies`, `gomod dependencies`, `docker dependencies`, and `github-actions dependencies`. 

By implementing these changes, we aim to simplify the process of keeping our dependencies updated across both frontend and backend, ensuring that we leverage Renovate to its full potential. Feedback on this PR is appreciated, and please don't hesitate to reach out if there are any concerns or queries.

