### PR TITLE
fix(server): swapped maintaining projects and owning projects

### DIFF
--- a/server/internal/app/auth_client.go
+++ b/server/internal/app/auth_client.go
@@ -265,7 +265,7 @@ func operatorProjects(ctx context.Context, cfg *ServerConfig, w user.WorkspaceLi
 		}
 		cur = pi.EndCursor
 	}
-	return rp, wp, op, mp, nil
+	return rp, wp, mp, op, nil
 }
 
 func generateIntegrationOperator(ctx context.Context, cfg *ServerConfig, i *integration.Integration, lang string) (*usecase.Operator, error) {


### PR DESCRIPTION
# Overview
In this PR, the issue of swapped "maintaining projects" and "owning projects" has been fixed.