### PR TITLE
perf(server): speed up Asset.FindByProject

### DIFF
--- a/server/internal/infrastructure/mongo/asset.go
+++ b/server/internal/infrastructure/mongo/asset.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	assetIndexes       = []string{"project", "!createdat,!id"}
+	assetIndexes       = []string{"project,!createdat,!id"}
 	assetUniqueIndexes = []string{"id"}
 )
 
@@ -79,7 +79,7 @@ func (r *Asset) FindByProject(ctx context.Context, id id.ProjectID, uFilter repo
 		"project": id.String(),
 	}
 
-	if uFilter.Keyword != nil {
+	if uFilter.Keyword != nil && *uFilter.Keyword != "" {
 		filter = mongox.And(filter, "", bson.M{
 			"filename": bson.M{
 				"$regex": primitive.Regex{Pattern: fmt.Sprintf(".*%s.*", regexp.QuoteMeta(*uFilter.Keyword)), Options: "i"},

--- a/server/internal/infrastructure/mongo/asset.go
+++ b/server/internal/infrastructure/mongo/asset.go
@@ -18,7 +18,12 @@ import (
 )
 
 var (
-	assetIndexes       = []string{"project,!createdat,!id"}
+	assetIndexes = []string{
+		"project,!createdat,!id",
+		"project,createdat,id",
+		"project,!size,!id",
+		"project,size,id",
+	}
 	assetUniqueIndexes = []string{"id"}
 )
 


### PR DESCRIPTION
fixed to not add a condition when keyword is an empty string
modified index to be more efficient

# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
