### PR TITLE
feat(web): prevent multi creation clicks

### DIFF
--- a/web/src/components/molecules/Content/Details/index.tsx
+++ b/web/src/components/molecules/Content/Details/index.tsx
@@ -22,6 +22,7 @@ export type Props = {
   initialFormValues: { [key: string]: any };
   itemId?: string;
   loading: boolean;
+  requestCreationLoading: boolean;
   assetList: Asset[];
   fileList: UploadFile[];
   loadingAssets: boolean;
@@ -84,6 +85,7 @@ const ContentDetailsMolecule: React.FC<Props> = ({
   initialFormValues,
   itemId,
   loading,
+  requestCreationLoading,
   assetList,
   fileList,
   loadingAssets,
@@ -140,6 +142,7 @@ const ContentDetailsMolecule: React.FC<Props> = ({
       center={
         <ContentForm
           requests={requests}
+          requestCreationLoading={requestCreationLoading}
           onRequestTableChange={onRequestTableChange}
           requestModalLoading={requestModalLoading}
           requestModalTotalCount={requestModalTotalCount}

--- a/web/src/components/molecules/Content/Form/index.tsx
+++ b/web/src/components/molecules/Content/Form/index.tsx
@@ -48,6 +48,7 @@ export interface Props {
   uploadUrl: { url: string; autoUnzip: boolean };
   uploadType: UploadType;
   requestModalShown: boolean;
+  requestCreationLoading: boolean;
   addItemToRequestModalShown: boolean;
   workspaceUserMembers: Member[];
   totalCount: number;
@@ -116,6 +117,7 @@ const ContentForm: React.FC<Props> = ({
   requestModalTotalCount,
   requestModalPage,
   requestModalPageSize,
+  requestCreationLoading,
   onUnpublish,
   onAssetTableChange,
   onUploadModalCancel,
@@ -442,6 +444,7 @@ const ContentForm: React.FC<Props> = ({
             open={requestModalShown}
             onClose={onModalClose}
             onSubmit={onRequestCreate}
+            requestCreationLoading={requestCreationLoading}
             workspaceUserMembers={workspaceUserMembers}
           />
           <LinkItemRequestModal

--- a/web/src/components/molecules/Content/RequestCreationModal/index.tsx
+++ b/web/src/components/molecules/Content/RequestCreationModal/index.tsx
@@ -21,6 +21,7 @@ export type FormValues = {
 
 export type Props = {
   open?: boolean;
+  requestCreationLoading: boolean;
   itemId: string;
   workspaceUserMembers: Member[];
   onClose?: (refetch?: boolean) => void;
@@ -41,6 +42,7 @@ const initialValues: FormValues = {
 
 const RequestCreationModal: React.FC<Props> = ({
   open,
+  requestCreationLoading,
   itemId,
   workspaceUserMembers,
   onClose,
@@ -74,7 +76,12 @@ const RequestCreationModal: React.FC<Props> = ({
     onClose?.(true);
   }, [onClose]);
   return (
-    <Modal visible={open} onCancel={handleClose} onOk={handleSubmit} title={t("New Request")}>
+    <Modal
+      open={open}
+      onCancel={handleClose}
+      onOk={handleSubmit}
+      confirmLoading={requestCreationLoading}
+      title={t("New Request")}>
       <Form form={form} layout="vertical" initialValues={initialValues}>
         <Form.Item
           name="title"

--- a/web/src/components/molecules/Schema/FieldModal/FieldCreationModal/index.tsx
+++ b/web/src/components/molecules/Schema/FieldModal/FieldCreationModal/index.tsx
@@ -37,6 +37,7 @@ export type FormValues = {
 
 export type Props = {
   open?: boolean;
+  fieldCreationLoading: boolean;
   selectedType: FieldType;
   handleFieldKeyUnique: (key: string, fieldId?: string) => boolean;
   onClose?: (refetch?: boolean) => void;
@@ -80,6 +81,7 @@ const initialValues: FormValues = {
 
 const FieldCreationModal: React.FC<Props> = ({
   open,
+  fieldCreationLoading,
   selectedType,
   onClose,
   onSubmit,
@@ -209,9 +211,10 @@ const FieldCreationModal: React.FC<Props> = ({
           </FieldThumbnail>
         ) : null
       }
-      visible={open}
+      open={open}
       onCancel={() => onClose?.(true)}
       onOk={handleSubmit}
+      confirmLoading={fieldCreationLoading}
       okButtonProps={{ disabled: buttonDisabled }}
       afterClose={handleModalReset}>
       <Form

--- a/web/src/components/molecules/Schema/FieldModal/FieldUpdateModal/index.tsx
+++ b/web/src/components/molecules/Schema/FieldModal/FieldUpdateModal/index.tsx
@@ -38,6 +38,7 @@ export interface FormValues {
 
 export interface Props {
   open?: boolean;
+  fieldUpdateLoading: boolean;
   selectedType: FieldType;
   selectedField?: Field | null;
   handleFieldKeyUnique: (key: string, fieldId?: string) => boolean;
@@ -82,6 +83,7 @@ const initialValues: FormValues = {
 
 const FieldUpdateModal: React.FC<Props> = ({
   open,
+  fieldUpdateLoading,
   onClose,
   onSubmit,
   handleFieldKeyUnique,
@@ -227,9 +229,10 @@ const FieldUpdateModal: React.FC<Props> = ({
           </FieldThumbnail>
         ) : null
       }
-      visible={open}
+      open={open}
       onCancel={() => onClose?.(true)}
       onOk={handleSubmit}
+      confirmLoading={fieldUpdateLoading}
       okButtonProps={{ disabled: buttonDisabled }}
       afterClose={handleModalReset}>
       <Form

--- a/web/src/components/organisms/Project/Content/ContentDetails/hooks.ts
+++ b/web/src/components/organisms/Project/Content/ContentDetails/hooks.ts
@@ -170,7 +170,7 @@ export default () => {
     );
   }, [currentWorkspace]);
 
-  const [createRequestMutation] = useCreateRequestMutation({
+  const [createRequestMutation, { loading: requestCreationLoading }] = useCreateRequestMutation({
     refetchQueries: ["GetRequests"],
   });
 
@@ -236,6 +236,7 @@ export default () => {
   return {
     requests,
     itemId,
+    requestCreationLoading,
     currentModel,
     currentItem,
     initialFormValues,

--- a/web/src/components/organisms/Project/Content/ContentDetails/index.tsx
+++ b/web/src/components/organisms/Project/Content/ContentDetails/index.tsx
@@ -17,6 +17,7 @@ const ContentDetails: React.FC = () => {
     initialFormValues,
     itemCreationLoading,
     itemUpdatingLoading,
+    requestCreationLoading,
     collapsedModelMenu,
     collapsedCommentsPanel,
     requestModalShown,
@@ -67,6 +68,7 @@ const ContentDetails: React.FC = () => {
   return (
     <ContentDetailsMolecule
       requests={requests}
+      requestCreationLoading={requestCreationLoading}
       onRequestTableChange={handleRequestTableChange}
       requestModalTotalCount={requestModalTotalCount}
       requestModalPage={requestModalPage}

--- a/web/src/components/organisms/Project/Schema/hooks.ts
+++ b/web/src/components/organisms/Project/Schema/hooks.ts
@@ -48,11 +48,11 @@ export default () => {
     [currentModel],
   );
 
-  const [createNewField] = useCreateFieldMutation({
+  const [createNewField, { loading: fieldCreationLoading }] = useCreateFieldMutation({
     refetchQueries: ["GetModels"],
   });
 
-  const [updateField] = useUpdateFieldMutation({
+  const [updateField, { loading: fieldUpdateLoading }] = useUpdateFieldMutation({
     refetchQueries: ["GetModels"],
   });
 
@@ -201,6 +201,8 @@ export default () => {
     currentModel,
     selectedType,
     collapsed,
+    fieldCreationLoading,
+    fieldUpdateLoading,
     collapse,
     handleModelSelect,
     handleFieldCreationModalClose,

--- a/web/src/components/organisms/Project/Schema/index.tsx
+++ b/web/src/components/organisms/Project/Schema/index.tsx
@@ -45,6 +45,8 @@ const ProjectSchema: React.FC = () => {
     currentModel,
     selectedType,
     collapsed,
+    fieldCreationLoading,
+    fieldUpdateLoading,
     collapse,
     handleModelSelect,
     handleFieldCreationModalClose,
@@ -76,6 +78,7 @@ const ProjectSchema: React.FC = () => {
         <FieldCreationModal
           selectedType={selectedType}
           open={fieldCreationModalShown}
+          fieldCreationLoading={fieldCreationLoading}
           handleFieldKeyUnique={handleFieldKeyUnique}
           onClose={handleFieldCreationModalClose}
           onSubmit={handleFieldCreate}
@@ -103,6 +106,7 @@ const ProjectSchema: React.FC = () => {
       )}
       {selectedType && (
         <FieldUpdateModal
+          fieldUpdateLoading={fieldUpdateLoading}
           selectedType={selectedType}
           open={fieldUpdateModalShown}
           selectedField={selectedField}


### PR DESCRIPTION
# Overview
This PR improves loading state handling.

## What I've done
- Updated the content details component and its related molecules and forms.
- Added a request creation modal and handled loading state.
- Implemented field creation and update modals in the project schema.

## How I tested
- Conducted testing to ensure the updated components and modals are functioning correctly.
