### PR TITLE
fix(web): disable use request for reader role

### DIFF
--- a/web/src/components/molecules/ProjectSettings/RequestOptions.tsx
+++ b/web/src/components/molecules/ProjectSettings/RequestOptions.tsx
@@ -129,6 +129,7 @@ const ProjectRequestOptions: React.FC<Props> = ({ project, onProjectRequestRoles
                 setRequestRoles(requestRoles?.filter(role => role !== "reader"));
               }
             }}
+            disabled={true}
           />
         ),
       },


### PR DESCRIPTION
# Overview
Use request option has been disabled for reader role in the project settings