### PR TITLE
feat(web): add copy icon to all asset types

### DIFF
--- a/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { Viewer as CesiumViewer } from "cesium";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 
 import Button from "@reearth-cms/components/atoms/Button";
 import DownloadButton from "@reearth-cms/components/atoms/DownloadButton";
@@ -95,11 +95,6 @@ const AssetMolecule: React.FC<Props> = ({
     }
   }, [assetFileExt, assetUrl, svgRender, viewerType]);
 
-  const showCopyIcon = useMemo(() => {
-    const copyableTypes: PreviewType[] = ["IMAGE", "IMAGE_SVG", "GEO", "MODEL_3D", "GEO_3D_TILES"];
-    return asset.previewType && copyableTypes.includes(asset.previewType);
-  }, [asset.previewType]);
-
   return (
     <BodyContainer>
       <BodyWrapper>
@@ -107,14 +102,12 @@ const AssetMolecule: React.FC<Props> = ({
           title={
             <>
               {asset.fileName}{" "}
-              {showCopyIcon && (
-                <CopyIcon
-                  icon="copy"
-                  onClick={() => {
-                    navigator.clipboard.writeText(asset.url);
-                  }}
-                />
-              )}
+              <CopyIcon
+                icon="copy"
+                onClick={() => {
+                  navigator.clipboard.writeText(asset.url);
+                }}
+              />
             </>
           }
           toolbar={
@@ -132,17 +125,7 @@ const AssetMolecule: React.FC<Props> = ({
         </Card>
         {displayUnzipFileList && asset.file && (
           <Card
-            title={
-              <>
-                {asset.fileName}{" "}
-                <CopyIcon
-                  icon="copy"
-                  onClick={() => {
-                    navigator.clipboard.writeText(asset.url);
-                  }}
-                />
-              </>
-            }
+            title={asset.fileName}
             toolbar={
               <>
                 <ArchiveExtractionStatus archiveExtractionStatus={asset.archiveExtractionStatus} />

--- a/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
@@ -95,10 +95,10 @@ const AssetMolecule: React.FC<Props> = ({
     }
   }, [assetFileExt, assetUrl, svgRender, viewerType]);
 
-  const showCopyIcon = useMemo(
-    () => asset.previewType === "IMAGE" || asset.previewType === "IMAGE_SVG",
-    [asset.previewType],
-  );
+  const showCopyIcon = useMemo(() => {
+    const copyableTypes: PreviewType[] = ["IMAGE", "IMAGE_SVG", "GEO", "MODEL_3D", "GEO_3D_TILES"];
+    return asset.previewType && copyableTypes.includes(asset.previewType);
+  }, [asset.previewType]);
 
   return (
     <BodyContainer>

--- a/web/src/components/molecules/Asset/Asset/AssetBody/UnzipFileList.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/UnzipFileList.tsx
@@ -45,13 +45,24 @@ const UnzipFileList: React.FC<Props> = ({
         }
 
         return {
-          title: file.name,
+          title: (
+            <>
+              {file.name}
+              <CopyIcon
+                selected={selectedKeys[0] === key}
+                icon="copy"
+                onClick={() => {
+                  navigator.clipboard.writeText(assetBaseUrl + file.path);
+                }}
+              />
+            </>
+          ),
           key: key,
           children: children,
           file: file,
         };
       }) || [],
-    [],
+    [selectedKeys, assetBaseUrl],
   );
 
   useEffect(() => {
@@ -130,6 +141,14 @@ const ExtractionFailedWrapper = styled.div`
 
 const ExtractionFailedIcon = styled(Icon)`
   margin-bottom: 28px;
+`;
+
+const CopyIcon = styled(Icon)<{ selected?: boolean }>`
+  margin-left: 16px;
+  visibility: ${({ selected }) => (selected ? "visible" : "hidden")};
+  &:active {
+    color: #096dd9;
+  }
 `;
 
 const ExtractionFailedText = styled.p`

--- a/web/src/components/molecules/Asset/Asset/AssetBody/UnzipFileList.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/UnzipFileList.tsx
@@ -45,24 +45,13 @@ const UnzipFileList: React.FC<Props> = ({
         }
 
         return {
-          title: (
-            <>
-              {file.name}
-              <CopyIcon
-                selected={selectedKeys[0] === key}
-                icon="copy"
-                onClick={() => {
-                  navigator.clipboard.writeText(assetBaseUrl + file.path);
-                }}
-              />
-            </>
-          ),
+          title: file.name,
           key: key,
           children: children,
           file: file,
         };
       }) || [],
-    [selectedKeys, assetBaseUrl],
+    [],
   );
 
   useEffect(() => {
@@ -141,14 +130,6 @@ const ExtractionFailedWrapper = styled.div`
 
 const ExtractionFailedIcon = styled(Icon)`
   margin-bottom: 28px;
-`;
-
-const CopyIcon = styled(Icon)<{ selected?: boolean }>`
-  margin-left: 16px;
-  visibility: ${({ selected }) => (selected ? "visible" : "hidden")};
-  &:active {
-    color: #096dd9;
-  }
 `;
 
 const ExtractionFailedText = styled.p`


### PR DESCRIPTION
# Overview
- Copy icon has been added to all asset types
- Copy icon has been removed from unzip file list component's title