### PR TITLE
fix(server): skip version validation for metadata Items

### DIFF
--- a/server/internal/usecase/interactor/item.go
+++ b/server/internal/usecase/interactor/item.go
@@ -347,10 +347,6 @@ func (i Item) Update(ctx context.Context, param interfaces.UpdateItemParam, oper
 		if err != nil {
 			return nil, err
 		}
-
-		if param.Version != nil && itm.Version() != *param.Version {
-			return nil, interfaces.ErrItemConflicted
-		}
 		itv := itm.Value()
 		if !operator.CanUpdate(itv) {
 			return nil, interfaces.ErrOperationDenied
@@ -359,6 +355,11 @@ func (i Item) Update(ctx context.Context, param interfaces.UpdateItemParam, oper
 		m, err := i.repos.Model.FindByID(ctx, itv.Model())
 		if err != nil {
 			return nil, err
+		}
+
+		isMetadata := m.Metadata() != nil && itv.Schema() == *m.Metadata()
+		if !isMetadata && param.Version != nil && itm.Version() != *param.Version {
+			return nil, interfaces.ErrItemConflicted
 		}
 
 		s, err := i.repos.Schema.FindByID(ctx, itv.Schema())


### PR DESCRIPTION
The "item has been changed before you change it" error appears when trying to update a metadata item. As the version is not important for meta Items I have skipped the version validation for metadata items 