### PR TITLE
fix(web): display updateBy's value in item's details

### DIFF
--- a/web/src/components/organisms/Project/Content/convertItem.ts
+++ b/web/src/components/organisms/Project/Content/convertItem.ts
@@ -13,7 +13,7 @@ export const convertItem = (GQLItem: GQLItem | undefined): Item | undefined => {
     })),
     status: GQLItem.status,
     createdBy: GQLItem.createdBy?.name,
-    updatedBy: GQLItem.createdBy?.name,
+    updatedBy: GQLItem.updatedBy?.name,
     createdAt: GQLItem.createdAt,
     updatedAt: GQLItem.updatedAt,
     schemaId: GQLItem.schemaId,


### PR DESCRIPTION
# Overview
- Display updated by instead of created by in item details page