### PR TITLE
fix(web): hide createdAt and updatedAt from filters

### DIFF
--- a/web/src/components/molecules/Content/Table/index.tsx
+++ b/web/src/components/molecules/Content/Table/index.tsx
@@ -422,15 +422,16 @@ const ContentTable: React.FC<Props> = ({
       };
 
       return [
-        ...((actionsColumns ?? [])
-          .filter(column => column.key === "CREATION_DATE" || column.key === "MODIFICATION_DATE")
-          .map(column => ({
-            key: column.key,
-            label: column.title,
-            onClick: () => {
-              optionClick(isFilter.current, column);
-            },
-          })) as any),
+        // TODO: Uncomment this when we have a way to filter by creation/modification date
+        // ...((actionsColumns ?? [])
+        //   .filter(column => column.key === "CREATION_DATE" || column.key === "MODIFICATION_DATE")
+        //   .map(column => ({
+        //     key: column.key,
+        //     label: column.title,
+        //     onClick: () => {
+        //       optionClick(isFilter.current, column);
+        //     },
+        //   })) as any),
         ...((contentTableColumns ?? [])
           .filter(column => !!column.title && typeof column.title === "string")
           .map(column => ({
@@ -442,7 +443,7 @@ const ContentTable: React.FC<Props> = ({
           })) as any),
       ];
     },
-    [actionsColumns, contentTableColumns, currentWorkspace?.members],
+    [/*actionsColumns,*/ contentTableColumns, currentWorkspace?.members],
   );
 
   const defaultItems = getOptions(false);


### PR DESCRIPTION
# Overview
- This PR hides the `createdAt` and `updatedAt` fields from the filter dropdown