### PR TITLE
fix(web): content default ordering

### DIFF
--- a/web/src/components/organisms/Project/Content/ViewsMenu/hooks.ts
+++ b/web/src/components/organisms/Project/Content/ViewsMenu/hooks.ts
@@ -78,7 +78,16 @@ export default ({ modelId, currentView, setCurrentView }: Params) => {
         filter: filterConvert(selectedView.filter as AndCondition),
       }));
     } else {
-      setCurrentView({ columns: [] });
+      //initial currentView when there is no view in the specific model
+      setCurrentView({
+        sort: {
+          field: {
+            type: "MODIFICATION_DATE",
+          },
+          direction: "DESC",
+        },
+        columns: [],
+      });
     }
   }, [selectedView, setCurrentView]);
 


### PR DESCRIPTION
# Overview
Set the default ordering for updates to 'descending.' in the content table