### PR TITLE
fix(web): set the default ordering in content table

### DIFF
--- a/web/src/components/organisms/Project/Content/ContentList/hooks.ts
+++ b/web/src/components/organisms/Project/Content/ContentList/hooks.ts
@@ -5,7 +5,13 @@ import Notification from "@reearth-cms/components/atoms/Notification";
 import { ExtendedColumns } from "@reearth-cms/components/molecules/Content/Table/types";
 import { ContentTableField, ItemStatus } from "@reearth-cms/components/molecules/Content/types";
 import { Request } from "@reearth-cms/components/molecules/Request/types";
-import { AndConditionInput, Column, FieldType, ItemSort, SortDirection } from "@reearth-cms/components/molecules/View/types";
+import {
+  AndConditionInput,
+  Column,
+  FieldType,
+  ItemSort,
+  SortDirection,
+} from "@reearth-cms/components/molecules/View/types";
 import {
   convertItem,
   convertComment,
@@ -24,7 +30,6 @@ import { toGraphAndConditionInput, toGraphItemSort } from "@reearth-cms/utils/va
 
 import { renderField } from "./renderFields";
 import { fileName } from "./utils";
-
 
 export type CurrentViewType = {
   sort?: ItemSort;

--- a/web/src/components/organisms/Project/Content/ContentList/hooks.ts
+++ b/web/src/components/organisms/Project/Content/ContentList/hooks.ts
@@ -5,7 +5,7 @@ import Notification from "@reearth-cms/components/atoms/Notification";
 import { ExtendedColumns } from "@reearth-cms/components/molecules/Content/Table/types";
 import { ContentTableField, ItemStatus } from "@reearth-cms/components/molecules/Content/types";
 import { Request } from "@reearth-cms/components/molecules/Request/types";
-import { AndConditionInput, Column, ItemSort } from "@reearth-cms/components/molecules/View/types";
+import { AndConditionInput, Column, FieldType, ItemSort, SortDirection } from "@reearth-cms/components/molecules/View/types";
 import {
   convertItem,
   convertComment,
@@ -26,10 +26,18 @@ import { toGraphAndConditionInput, toGraphItemSort } from "@reearth-cms/utils/va
 import { renderTags } from "./renderFields";
 import { fileName } from "./utils";
 
+
 export type CurrentViewType = {
   sort?: ItemSort;
   filter?: AndConditionInput;
   columns?: Column[];
+};
+
+const DefaultOrder = {
+  direction: "DESC" as SortDirection,
+  field: {
+    type: "MODIFICATION_DATE" as FieldType,
+  },
 };
 
 export default () => {
@@ -82,7 +90,8 @@ export default () => {
           q: searchTerm,
         },
         pagination: { first: pageSize, offset: (page - 1) * pageSize },
-        sort: currentView.sort ? toGraphItemSort(currentView.sort) : undefined,
+        //if no order in the current view, then show data in default order
+        sort: currentView.sort ? toGraphItemSort(currentView.sort) : toGraphItemSort(DefaultOrder),
         filter: currentView.filter
           ? {
               and: toGraphAndConditionInput(currentView.filter),

--- a/web/src/components/organisms/Project/Content/ContentList/hooks.ts
+++ b/web/src/components/organisms/Project/Content/ContentList/hooks.ts
@@ -37,7 +37,7 @@ export type CurrentViewType = {
   columns?: Column[];
 };
 
-const DefaultOrder = {
+const defaultViewSort = {
   direction: "DESC" as SortDirection,
   field: {
     type: "MODIFICATION_DATE" as FieldType,
@@ -94,8 +94,10 @@ export default () => {
           q: searchTerm,
         },
         pagination: { first: pageSize, offset: (page - 1) * pageSize },
-        //if no order in the current view, then show data in default order
-        sort: currentView.sort ? toGraphItemSort(currentView.sort) : toGraphItemSort(DefaultOrder),
+        //if there is no sort in the current view, show data in the default view sort
+        sort: currentView.sort
+          ? toGraphItemSort(currentView.sort)
+          : toGraphItemSort(defaultViewSort),
         filter: currentView.filter
           ? {
               and: toGraphAndConditionInput(currentView.filter),

--- a/web/src/components/organisms/Project/Content/ViewsMenu/hooks.ts
+++ b/web/src/components/organisms/Project/Content/ViewsMenu/hooks.ts
@@ -80,12 +80,6 @@ export default ({ modelId, currentView, setCurrentView }: Params) => {
     } else {
       //initial currentView when there is no view in the specific model
       setCurrentView({
-        sort: {
-          field: {
-            type: "MODIFICATION_DATE",
-          },
-          direction: "DESC",
-        },
         columns: [],
       });
     }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   server: {
     port: 3000,
     open: true,
+    host: "127.0.0.1",
   },
   envPrefix: "REEARTH_CMS_",
   plugins: [react(), yaml(), cesium(), serverHeaders(), config()],


### PR DESCRIPTION
# Overview
Set the default ordering in the content table.
Set the default ordering for "updated At" to "descend".
