### PR TITLE
fix(web): editor URL setting

### DIFF
--- a/web/src/components/molecules/Common/Header/index.tsx
+++ b/web/src/components/molecules/Common/Header/index.tsx
@@ -39,10 +39,12 @@ const HeaderMolecule: React.FC<Props> = ({
   const t = useT();
   const { logout } = useAuth();
   const navigate = useNavigate();
-  const url =
-    window.REEARTH_CONFIG?.editorUrl &&
-    currentWorkspace?.id &&
-    new URL(currentWorkspace.id, window.REEARTH_CONFIG?.editorUrl);
+  const url = useMemo(() => {
+    if (window.REEARTH_CONFIG?.editorUrl && currentWorkspace?.id) {
+      return new URL(`dashboard/${currentWorkspace.id}`, window.REEARTH_CONFIG?.editorUrl);
+    }
+    return undefined;
+  }, [currentWorkspace?.id]);
 
   const currentIsPersonal = useMemo(
     () => currentWorkspace?.id === personalWorkspace?.id,

--- a/web/src/components/molecules/Common/Header/index.tsx
+++ b/web/src/components/molecules/Common/Header/index.tsx
@@ -39,6 +39,10 @@ const HeaderMolecule: React.FC<Props> = ({
   const t = useT();
   const { logout } = useAuth();
   const navigate = useNavigate();
+  const url =
+    window.REEARTH_CONFIG?.editorUrl &&
+    currentWorkspace?.id &&
+    new URL(currentWorkspace.id, window.REEARTH_CONFIG?.editorUrl);
 
   const currentIsPersonal = useMemo(
     () => currentWorkspace?.id === personalWorkspace?.id,
@@ -146,14 +150,13 @@ const HeaderMolecule: React.FC<Props> = ({
       )}
       <Spacer />
       <AccountDropdown name={username} items={AccountItems} personal={true} />
-      <LinkWrapper>
-        <EditorLink
-          rel="noopener noreferrer"
-          href={`${window.REEARTH_CONFIG?.webDomain}dashboard/${currentWorkspace?.id}`}
-          target="_blank">
-          {t("Go to Editor")}
-        </EditorLink>
-      </LinkWrapper>
+      {url && (
+        <LinkWrapper>
+          <EditorLink rel="noreferrer" href={url.href} target="_blank">
+            {t("Go to Editor")}
+          </EditorLink>
+        </LinkWrapper>
+      )}
     </MainHeader>
   );
 };

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -15,21 +15,21 @@ export type Config = {
   logoUrl?: string;
   coverImageUrl?: string;
   cesiumIonAccessToken?: string;
-  webDomain: string;
+  editorUrl: string;
 };
 
 const env = import.meta.env;
 
 export const defaultConfig: Config = {
   api: env.REEARTH_CMS_API || "/api",
-  auth0Audience: env.REEARTH_CMS_AUTH0_AUDIENCE || "https://api.test.reearth.dev",
-  auth0Domain: env.REEARTH_CMS_AUTH0_DOMAIN || "reearth-oss-test.eu.auth0.com",
-  auth0ClientId: env.REEARTH_CMS_AUTH0_CLIENT_ID || "k6F1sgFikzVkkcW9Cpz7Ztvwq5cBRXlv",
+  auth0Audience: env.REEARTH_CMS_AUTH0_AUDIENCE,
+  auth0Domain: env.REEARTH_CMS_AUTH0_DOMAIN,
+  auth0ClientId: env.REEARTH_CMS_AUTH0_CLIENT_ID,
   authProvider: env.REEARTH_CMS_AUTH_PROVIDER || "auth0",
   logoUrl: env.REEARTH_CMS_LOGO_URL,
   coverImageUrl: env.REEARTH_CMS_COVER_URL,
   cesiumIonAccessToken: env.REEARTH_CMS_CESIUM_ION_ACCESS_TOKEN || "",
-  webDomain: env.REEARTH_WEB_DOMAIN || "https://test.reearth.dev/",
+  editorUrl: env.REEARTH_CMS_EDITOR_DOMAIN,
 };
 
 export default async function loadConfig() {
@@ -67,7 +67,7 @@ declare global {
       authProvider?: string;
       logoUrl?: string;
       coverImageUrl?: string;
-      webDomain: string;
+      editorUrl: string;
     };
     REEARTH_E2E_ACCESS_TOKEN?: string;
   }

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -29,7 +29,7 @@ export const defaultConfig: Config = {
   logoUrl: env.REEARTH_CMS_LOGO_URL,
   coverImageUrl: env.REEARTH_CMS_COVER_URL,
   cesiumIonAccessToken: env.REEARTH_CMS_CESIUM_ION_ACCESS_TOKEN || "",
-  editorUrl: env.REEARTH_CMS_EDITOR_DOMAIN,
+  editorUrl: env.REEARTH_CMS_EDITOR_URL,
 };
 
 export default async function loadConfig() {


### PR DESCRIPTION
# Overview
This PR makes it possible to config `editorUrl` in `reearth_config.json`.
If you set `http(s)://ANY_DOMAIN(/)` to the value, the `Go to Editor` button shows up.