### PR TITLE
fix(web): content table's settings menu's fixed property

### DIFF
--- a/web/src/components/molecules/Common/ResizableProTable/index.tsx
+++ b/web/src/components/molecules/Common/ResizableProTable/index.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import ProTable, {
   ProColumns,
@@ -53,8 +53,17 @@ const ResizableProTable: React.FC<Props> = ({
     }),
   }));
 
+  const nthOfType = useMemo(() => {
+    return columnsState?.value
+      ? Object.values(columnsState?.value).some(option => option.fixed === "left")
+        ? 2
+        : 1
+      : 0;
+  }, [columnsState?.value]);
+
   return (
     <StyledProTable
+      nthOfType={nthOfType}
       dataSource={dataSource}
       columns={mergeColumns}
       components={{
@@ -81,7 +90,7 @@ const ResizableProTable: React.FC<Props> = ({
 
 export default ResizableProTable;
 
-const StyledProTable = styled(ProTable)`
+const StyledProTable = styled(ProTable)<{ nthOfType: number }>`
   height: calc(100% - 102px);
   .ant-pro-card-body {
     padding-bottom: 0;
@@ -108,8 +117,17 @@ const StyledProTable = styled(ProTable)`
     height: calc(100% - 47px);
   }
   .ant-pro-table-column-setting-overlay {
-    .ant-tree-treenode:nth-of-type(-n + 2) {
-      display: none;
+    .ant-tree-block-node:only-of-type {
+      .ant-tree-treenode:nth-of-type(-n + 2) {
+        display: none;
+      }
+    }
+  }
+  .ant-pro-table-column-setting-overlay {
+    .ant-tree-block-node:nth-of-type(${({ nthOfType }) => nthOfType}) {
+      .ant-tree-treenode:nth-of-type(-n + 2) {
+        display: none;
+      }
     }
   }
 `;

--- a/web/src/components/molecules/Content/Table/index.tsx
+++ b/web/src/components/molecules/Content/Table/index.tsx
@@ -642,9 +642,9 @@ const ContentTable: React.FC<Props> = ({
         col.field.type === "MODIFICATION_DATE" ||
         col.field.type === "MODIFICATION_USER"
       ) {
-        cols[col.field.type] = { show: col.visible, order: index };
+        cols[col.field.type] = { show: col.visible, order: index, fixed: col.fixed };
       } else {
-        cols[col.field.id ?? ""] = { show: col.visible, order: index };
+        cols[col.field.id ?? ""] = { show: col.visible, order: index, fixed: col.fixed };
       }
     });
     return cols;
@@ -673,12 +673,17 @@ const ContentTable: React.FC<Props> = ({
             (col.key as string) in options && options[col.key as string].order !== undefined
               ? (options[col.key as string]?.order as number)
               : index + 2,
+          fixed:
+            (col.key as string) in options && options[col.key as string].fixed !== undefined
+              ? options[col.key as string]?.fixed
+              : options[col.fieldType as string]?.fixed,
         }))
         .sort((a, b) => a.order - b.order)
         .map(col => {
           return {
             field: col.field,
             visible: col.visible as boolean,
+            fixed: col.fixed,
           };
         });
 

--- a/web/src/components/molecules/View/types.ts
+++ b/web/src/components/molecules/View/types.ts
@@ -11,6 +11,7 @@ export type View = {
 export type Column = {
   field: FieldSelector;
   visible: boolean;
+  fixed?: "left" | "right";
 };
 
 export type ColumnSelectionInput = {


### PR DESCRIPTION
# Overview
- This PR fixes the content table's settings menu's fixed property to enable the columns to be fixed to the left or right