### PR TITLE
feat(server,worker): add authentication for AWS SNS subscriptions

### DIFF
--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -59,9 +59,16 @@ func initEcho(cfg *ServerConfig) *echo.Echo {
 	internalJWTMiddleware := echo.WrapMiddleware(lo.Must(
 		appx.AuthMiddleware(cfg.Config.JWTProviders(), adapter.ContextAuthInfo, true),
 	))
-	m2mJWTMiddleware := echo.WrapMiddleware(lo.Must(
-		appx.AuthMiddleware(cfg.Config.AuthM2M.JWTProvider(), adapter.ContextAuthInfo, false),
-	))
+
+	var authenticateMiddleware echo.MiddlewareFunc
+	if cfg.Config.AWSTask.NotifyToken != "" {
+		authenticateMiddleware = AuthTokenMiddleware(cfg.Config.AWSTask.NotifyToken, adapter.ContextAuthInfo)
+	} else {
+		authenticateMiddleware = echo.WrapMiddleware(lo.Must(
+			appx.AuthMiddleware(cfg.Config.AuthM2M.JWTProvider(), adapter.ContextAuthInfo, false),
+		))
+	}
+
 	usecaseMiddleware := UsecaseMiddleware(cfg.Repos, cfg.Gateways, cfg.AcRepos, cfg.AcGateways, interactor.ContainerConfig{
 		SignupSecret:    cfg.Config.SignupSecret,
 		AuthSrvUIDomain: cfg.Config.Host_Web,
@@ -78,7 +85,7 @@ func initEcho(cfg *ServerConfig) *echo.Echo {
 	)
 	api.POST(
 		"/notify", NotifyHandler(),
-		m2mJWTMiddleware,
+		authenticateMiddleware,
 		M2MAuthMiddleware(cfg.Config.AuthM2M.Email),
 		usecaseMiddleware,
 	)

--- a/server/internal/app/auth_client.go
+++ b/server/internal/app/auth_client.go
@@ -165,13 +165,13 @@ func M2MAuthMiddleware(email string) echo.MiddlewareFunc {
 				if ai.EmailVerified == nil || !*ai.EmailVerified || ai.Email != email {
 					return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 				}
-				op, err := generateMachineOperator()
-				if err != nil {
-					return err
-				}
-				ctx = adapter.AttachOperator(ctx, op)
-				c.SetRequest(c.Request().WithContext(ctx))
 			}
+			op, err := generateMachineOperator()
+			if err != nil {
+				return err
+			}
+			ctx = adapter.AttachOperator(ctx, op)
+			c.SetRequest(c.Request().WithContext(ctx))
 			return next(c)
 		}
 	}

--- a/server/internal/app/usecase.go
+++ b/server/internal/app/usecase.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"net/http"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/reearth/reearth-cms/server/internal/adapter"
@@ -39,6 +41,17 @@ func ContextMiddleware(fn func(ctx context.Context) context.Context) echo.Middle
 		return func(c echo.Context) error {
 			req := c.Request()
 			c.SetRequest(req.WithContext(fn(req.Context())))
+			return next(c)
+		}
+	}
+}
+
+func AuthTokenMiddleware(token string, key any) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if !strings.Contains(c.QueryParam("token"), token) {
+				return echo.NewHTTPError(http.StatusUnauthorized, "Invalid token")
+			}
 			return next(c)
 		}
 	}

--- a/server/internal/infrastructure/aws/taskrunner.go
+++ b/server/internal/infrastructure/aws/taskrunner.go
@@ -22,8 +22,9 @@ type TaskRunner struct {
 }
 
 type TaskConfig struct {
-	TopicARN   string
-	WebhookARN string
+	TopicARN    string
+	WebhookARN  string
+	NotifyToken string
 }
 
 func NewTaskRunner(ctx context.Context, conf *TaskConfig) (gateway.TaskRunner, error) {


### PR DESCRIPTION
# Overview
Add support because AWS SNS has the following differences from GCP.
* Authentication required when building SNS subscription
* SNS https endpoint does not support jwt authentication
