### PR TITLE
fix(server): remove the root file from asset files 

### DIFF
--- a/server/internal/infrastructure/aws/file.go
+++ b/server/internal/infrastructure/aws/file.go
@@ -48,8 +48,7 @@ func NewFile(ctx context.Context, bucketName, baseURL, cacheControl string) (gat
 		baseURL = fmt.Sprintf("https://%s.s3.amazonaws.com/", bucketName)
 	}
 
-	var err error
-	u, _ = url.Parse(baseURL)
+	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, rerror.NewE(i18n.T("invalid base URL"))
 	}

--- a/server/internal/infrastructure/gcp/file.go
+++ b/server/internal/infrastructure/gcp/file.go
@@ -42,8 +42,7 @@ func NewFile(bucketName, base, cacheControl string) (gateway.File, error) {
 		base = fmt.Sprintf("https://storage.googleapis.com/%s", bucketName)
 	}
 
-	var err error
-	u, _ = url.Parse(base)
+	u, err := url.Parse(base)
 	if err != nil {
 		return nil, rerror.NewE(i18n.T("invalid base URL"))
 	}

--- a/server/internal/infrastructure/mongo/asset_file.go
+++ b/server/internal/infrastructure/mongo/asset_file.go
@@ -10,7 +10,6 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/id"
 	"github.com/reearth/reearthx/mongox"
 	"github.com/reearth/reearthx/rerror"
-	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -66,10 +65,8 @@ func (r *AssetFile) FindByID(ctx context.Context, id id.AssetID) (*asset.File, e
 		})); err != nil {
 			return nil, err
 		}
-		files := lo.Filter(afc.Result().Model(), func(af *asset.File, _ int) bool {
-			return af.Path() != f.Path()
-		})
-		// f = asset.FoldFiles(afc.Result().Model(), f)
+		files := afc.Result().Model()
+		// f = asset.FoldFiles(files, f)
 		f.SetFiles(files)
 	} else if len(f.Children()) > 0 {
 		f.SetFiles(f.FlattenChildren())

--- a/server/internal/infrastructure/mongo/asset_file.go
+++ b/server/internal/infrastructure/mongo/asset_file.go
@@ -69,7 +69,7 @@ func (r *AssetFile) FindByID(ctx context.Context, id id.AssetID) (*asset.File, e
 		files := lo.Filter(afc.Result().Model(), func(af *asset.File, _ int) bool {
 			return af.Path() != f.Path()
 		})
-		// f = asset.FoldFiles(files, f)
+		// f = asset.FoldFiles(afc.Result().Model(), f)
 		f.SetFiles(files)
 	} else if len(f.Children()) > 0 {
 		f.SetFiles(f.FlattenChildren())

--- a/server/internal/infrastructure/mongo/asset_file.go
+++ b/server/internal/infrastructure/mongo/asset_file.go
@@ -10,6 +10,7 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/id"
 	"github.com/reearth/reearthx/mongox"
 	"github.com/reearth/reearthx/rerror"
+	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -65,7 +66,9 @@ func (r *AssetFile) FindByID(ctx context.Context, id id.AssetID) (*asset.File, e
 		})); err != nil {
 			return nil, err
 		}
-		files := afc.Result().Model()
+		files := lo.Filter(afc.Result().Model(), func(af *asset.File, _ int) bool {
+			return af.Path() != f.Path()
+		})
 		// f = asset.FoldFiles(files, f)
 		f.SetFiles(files)
 	} else if len(f.Children()) > 0 {

--- a/server/pkg/asset/file.go
+++ b/server/pkg/asset/file.go
@@ -61,7 +61,9 @@ func (f *File) Files() []*File {
 }
 
 func (f *File) SetFiles(s []*File) {
-	f.files = slices.Clone(s)
+	f.files = lo.Filter(s, func(af *File, _ int) bool {
+		return af.Path() != f.Path()
+	})
 }
 
 func (f *File) FilePaths() []string {

--- a/server/pkg/asset/file_test.go
+++ b/server/pkg/asset/file_test.go
@@ -70,6 +70,19 @@ func TestFile_Files(t *testing.T) {
 	}, f.FlattenChildren())
 }
 
+func TestFile_SetFiles(t *testing.T) {
+	root := NewFile().Build()
+	files := []*File{NewFile().Path("aaa/a/a.txt").Build(), NewFile().Path("aaa/b.txt").Build()}
+	root.SetFiles(files)
+	assert.Equal(t, files, root.files)
+
+	root2 := NewFile().Path("aaa.zip").Build()
+	files2 := []*File{NewFile().Path("aaa.zip").Build(), NewFile().Path("aaa/a/a.txt").Build(), NewFile().Path("aaa/b.txt").Build()}
+	expected := []*File{NewFile().Path("aaa/a/a.txt").Build(), NewFile().Path("aaa/b.txt").Build()}
+	root2.SetFiles(files2)
+	assert.Equal(t, expected, root2.files)
+}
+
 func Test_FoldFiles(t *testing.T) {
 	assert.Equal(t,
 		&File{


### PR DESCRIPTION
# Overview
This PR fixes the bug where the root file is added to the `asset.files` slice