### PR TITLE
fix(web): clear fields on close in create project modal

### DIFF
--- a/web/src/components/molecules/Common/ProjectCreationModal/index.tsx
+++ b/web/src/components/molecules/Common/ProjectCreationModal/index.tsx
@@ -47,7 +47,8 @@ const ProjectCreationModal: React.FC<Props> = ({
 
   const handleClose = useCallback(() => {
     onClose?.(true);
-  }, [onClose]);
+    form.resetFields();
+  }, [form, onClose]);
 
   const handleFormValues = useCallback(() => {
     form


### PR DESCRIPTION
# Overview
This PR addresses a bug where form fields persist in the create project modal even after the modal is closed