### PR TITLE
feat(web): make the project alias readonly instead of disabled

### DIFF
--- a/web/src/components/molecules/Accessibility/index.tsx
+++ b/web/src/components/molecules/Accessibility/index.tsx
@@ -155,7 +155,7 @@ const Accessibility: React.FC<Props> = ({
               <Input
                 value={aliasState}
                 suffix={<Icon icon="copy" onClick={handleCopy} />}
-                disabled
+                contentEditable={false}
               />
             </Form.Item>
           </ItemsWrapper>


### PR DESCRIPTION
# Overview
This PR makes the project alias readonly instead of disabled