### PR TITLE
feat(server): enhance preview type detection for more file types

### DIFF
--- a/server/internal/usecase/interactor/asset.go
+++ b/server/internal/usecase/interactor/asset.go
@@ -147,7 +147,7 @@ func (i *Asset) Create(ctx context.Context, inp interfaces.CreateAssetParam, op 
 				Project(inp.ProjectID).
 				FileName(path.Base(file.Name)).
 				Size(uint64(file.Size)).
-				Type(asset.PreviewTypeFromContentType(file.ContentType)).
+				Type(asset.DetectPreviewType(file)).
 				UUID(uuid).
 				Thread(th.ID()).
 				ArchiveExtractionStatus(es)

--- a/server/pkg/asset/preview_type.go
+++ b/server/pkg/asset/preview_type.go
@@ -1,9 +1,20 @@
 package asset
 
 import (
+	"path/filepath"
 	"strings"
 
+	"github.com/reearth/reearth-cms/server/pkg/file"
 	"github.com/samber/lo"
+)
+
+var (
+	imageExtensions   = []string{"jpg", "jpeg", "png", "gif", "tiff", "webp"}
+	imageSVGExtension = "svg"
+	geoExtensions     = []string{"kml", "czml", "topojson", "geojson"}
+	geoMvtExtension   = "mvt"
+	model3dExtensions = []string{"gltf", "glb"}
+	csvExtension      = "csv"
 )
 
 type PreviewType string
@@ -59,14 +70,49 @@ func PreviewTypeFromRef(p *string) *PreviewType {
 	return &pp
 }
 
-func PreviewTypeFromContentType(c string) *PreviewType {
+func DetectPreviewType(f *file.File) *PreviewType {
+	pt := PreviewTypeFromContentType(f.ContentType)
+	if pt != PreviewTypeUnknown {
+		return lo.ToPtr(pt)
+	}
+	ext := filepath.Ext(f.Name)
+	pt = PreviewTypeFromExtension(ext)
+	return lo.ToPtr(pt)
+}
+
+func PreviewTypeFromContentType(c string) PreviewType {
 	if strings.HasPrefix(c, "image/") {
 		if strings.HasPrefix(c, "image/svg") {
-			return lo.ToPtr(PreviewTypeImageSvg)
+			return PreviewTypeImageSvg
 		}
-		return lo.ToPtr(PreviewTypeImage)
+		return PreviewTypeImage
 	}
-	return lo.ToPtr(PreviewTypeUnknown)
+	if strings.HasPrefix(c, "text/csv") {
+		return PreviewTypeCSV
+	}
+	return PreviewTypeUnknown
+}
+
+func PreviewTypeFromExtension(ext string) PreviewType {
+	if lo.Contains(imageExtensions, ext) {
+		return PreviewTypeImage
+	}
+	if ext == imageSVGExtension {
+		return PreviewTypeImageSvg
+	}
+	if lo.Contains(geoExtensions, ext) {
+		return PreviewTypeGeo
+	}
+	if ext == geoMvtExtension {
+		return PreviewTypeGeoMvt
+	}
+	if lo.Contains(model3dExtensions, ext) {
+		return PreviewTypeModel3d
+	}
+	if ext == csvExtension {
+		return PreviewTypeCSV
+	}
+	return PreviewTypeUnknown
 }
 
 func (p PreviewType) String() string {

--- a/server/pkg/asset/preview_type.go
+++ b/server/pkg/asset/preview_type.go
@@ -9,12 +9,12 @@ import (
 )
 
 var (
-	imageExtensions   = []string{"jpg", "jpeg", "png", "gif", "tiff", "webp"}
-	imageSVGExtension = "svg"
-	geoExtensions     = []string{"kml", "czml", "topojson", "geojson"}
-	geoMvtExtension   = "mvt"
-	model3dExtensions = []string{"gltf", "glb"}
-	csvExtension      = "csv"
+	imageExtensions   = []string{".jpg", ".jpeg", ".png", ".gif", ".tiff", ".webp"}
+	imageSVGExtension = ".svg"
+	geoExtensions     = []string{".kml", ".czml", ".topojson", ".geojson"}
+	geoMvtExtension   = ".mvt"
+	model3dExtensions = []string{".gltf", ".glb"}
+	csvExtension      = ".csv"
 )
 
 type PreviewType string

--- a/server/pkg/asset/preview_type_test.go
+++ b/server/pkg/asset/preview_type_test.go
@@ -209,19 +209,24 @@ func TestPreviewType_PreviewTypeFromRef(t *testing.T) {
 
 func TestPreviewType_PreviewTypeFromContentType(t *testing.T) {
 	c1 := "image/png"
-	want1 := lo.ToPtr(PreviewTypeImage)
+	want1 := PreviewTypeImage
 	got1 := PreviewTypeFromContentType(c1)
 	assert.Equal(t, want1, got1)
 
 	c2 := "video/mp4"
-	want2 := lo.ToPtr(PreviewTypeUnknown)
+	want2 := PreviewTypeUnknown
 	got2 := PreviewTypeFromContentType(c2)
 	assert.Equal(t, want2, got2)
 
 	c3 := "image/svg"
-	want3 := lo.ToPtr(PreviewTypeImageSvg)
+	want3 := PreviewTypeImageSvg
 	got3 := PreviewTypeFromContentType(c3)
 	assert.Equal(t, want3, got3)
+
+	c4 := "text/csv"
+	want4 := PreviewTypeCSV
+	got4 := PreviewTypeFromContentType(c4)
+	assert.Equal(t, want4, got4)
 }
 
 func TestPreviewType_String(t *testing.T) {

--- a/server/pkg/asset/preview_type_test.go
+++ b/server/pkg/asset/preview_type_test.go
@@ -3,6 +3,7 @@ package asset
 import (
 	"testing"
 
+	"github.com/reearth/reearth-cms/server/pkg/file"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 )
@@ -207,6 +208,24 @@ func TestPreviewType_PreviewTypeFromRef(t *testing.T) {
 	}
 }
 
+func TestPreviewType_DetectPreviewType(t *testing.T) {
+	f1 := file.File{
+		Name:        "image.png",
+		ContentType: "image/png",
+	}	
+	want1 := PreviewTypeImage
+	got1 := DetectPreviewType(&f1)
+	assert.Equal(t, want1, *got1)
+
+	f2 := file.File{
+		Name:        "file.geojson",
+		ContentType: "application/json",
+	}	
+	want2 := PreviewTypeGeo
+	got2 := DetectPreviewType(&f2)
+	assert.Equal(t, want2, *got2)
+}
+
 func TestPreviewType_PreviewTypeFromContentType(t *testing.T) {
 	c1 := "image/png"
 	want1 := PreviewTypeImage
@@ -227,6 +246,38 @@ func TestPreviewType_PreviewTypeFromContentType(t *testing.T) {
 	want4 := PreviewTypeCSV
 	got4 := PreviewTypeFromContentType(c4)
 	assert.Equal(t, want4, got4)
+}
+
+func TestPreviewType_PreviewTypeFromExtension(t *testing.T) {
+	ext1 := ".png"
+	want1 := PreviewTypeImage
+	got1 := PreviewTypeFromExtension(ext1)
+	assert.Equal(t, want1, got1)
+
+	ext2 := ".kml"
+	want2 := PreviewTypeGeo
+	got2 := PreviewTypeFromExtension(ext2)
+	assert.Equal(t, want2, got2)
+
+	ext3 := ".svg"
+	want3 := PreviewTypeImageSvg
+	got3 := PreviewTypeFromExtension(ext3)
+	assert.Equal(t, want3, got3)
+
+	ext4 := ".csv"
+	want4 := PreviewTypeCSV
+	got4 := PreviewTypeFromExtension(ext4)
+	assert.Equal(t, want4, got4)
+
+	ext5 := ".glb"
+	want5 := PreviewTypeModel3d
+	got5 := PreviewTypeFromExtension(ext5)
+	assert.Equal(t, want5, got5)
+
+	ext6 := ".mvt"
+	want6 := PreviewTypeGeoMvt
+	got6 := PreviewTypeFromExtension(ext6)
+	assert.Equal(t, want6, got6)
 }
 
 func TestPreviewType_String(t *testing.T) {


### PR DESCRIPTION
# Overview
This PR enhances preview type detection for more file types like czml, geojson, kml, csv, gltf, glb, topojson and mvt