### PR TITLE
fix(web): remove useless key validating when updating some value other than key

### DIFF
--- a/web/src/components/molecules/Common/ProjectCreationModal/index.tsx
+++ b/web/src/components/molecules/Common/ProjectCreationModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect } from "react";
+import React, { useCallback, useState, useEffect, useRef } from "react";
 
 import Button from "@reearth-cms/components/atoms/Button";
 import Form from "@reearth-cms/components/atoms/Form";
@@ -38,6 +38,7 @@ const ProjectCreationModal: React.FC<Props> = ({
   const [form] = Form.useForm<FormValues>();
   const [isLoading, setIsLoading] = useState(false);
   const [isDisabled, setIsDisabled] = useState(true);
+  const prevAlias = useRef<string>();
 
   const values = Form.useWatch([], form);
   useEffect(() => {
@@ -86,6 +87,21 @@ const ProjectCreationModal: React.FC<Props> = ({
     setIsDisabled(true);
   }, [form, onClose]);
 
+  const aliasValidate = useCallback(
+    async (value: string) => {
+      if (prevAlias.current === value) {
+        return Promise.resolve();
+      } else {
+        prevAlias.current = value;
+        if (value.length >= 5 && validateKey(value) && (await onProjectAliasCheck(value))) {
+          return Promise.resolve();
+        }
+      }
+      return Promise.reject();
+    },
+    [onProjectAliasCheck],
+  );
+
   return (
     <Modal
       open={open}
@@ -121,10 +137,7 @@ const ProjectCreationModal: React.FC<Props> = ({
               message: t("Project alias is not valid"),
               required: true,
               validator: async (_, value) => {
-                if (value.length >= 5 && validateKey(value) && (await onProjectAliasCheck(value))) {
-                  return Promise.resolve();
-                }
-                return Promise.reject();
+                await aliasValidate(value);
               },
             },
           ]}>

--- a/web/src/components/molecules/Common/ProjectCreationModal/index.tsx
+++ b/web/src/components/molecules/Common/ProjectCreationModal/index.tsx
@@ -38,7 +38,7 @@ const ProjectCreationModal: React.FC<Props> = ({
   const [form] = Form.useForm<FormValues>();
   const [isLoading, setIsLoading] = useState(false);
   const [isDisabled, setIsDisabled] = useState(true);
-  const prevAlias = useRef<string>();
+  const prevAlias = useRef<{ alias: string; isSuccess: boolean }>();
 
   const values = Form.useWatch([], form);
   useEffect(() => {
@@ -89,15 +89,15 @@ const ProjectCreationModal: React.FC<Props> = ({
 
   const aliasValidate = useCallback(
     async (value: string) => {
-      if (prevAlias.current === value) {
+      if (prevAlias.current?.alias === value) {
+        return prevAlias.current?.isSuccess ? Promise.resolve() : Promise.reject();
+      } else if (value.length >= 5 && validateKey(value) && (await onProjectAliasCheck(value))) {
+        prevAlias.current = { alias: value, isSuccess: true };
         return Promise.resolve();
       } else {
-        prevAlias.current = value;
-        if (value.length >= 5 && validateKey(value) && (await onProjectAliasCheck(value))) {
-          return Promise.resolve();
-        }
+        prevAlias.current = { alias: value, isSuccess: false };
+        return Promise.reject();
       }
-      return Promise.reject();
     },
     [onProjectAliasCheck],
   );

--- a/web/src/components/molecules/Schema/FieldModal/FieldCreationModalWithSteps/index.tsx
+++ b/web/src/components/molecules/Schema/FieldModal/FieldCreationModalWithSteps/index.tsx
@@ -37,8 +37,8 @@ interface Props {
   open: boolean;
   isLoading: boolean;
   handleReferencedModelGet: (modelId: string) => void;
-  handleCorrespondingFieldKeyUnique: (key: string, fieldId?: string) => boolean;
-  handleFieldKeyUnique: (key: string, fieldId?: string) => boolean;
+  handleCorrespondingFieldKeyUnique: (key: string) => boolean;
+  handleFieldKeyUnique: (key: string) => boolean;
   onClose: () => void;
   onSubmit: (values: FormValues) => Promise<void>;
   onUpdate: (values: FormValues) => Promise<void>;
@@ -300,7 +300,7 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
     (value: string, prevKey: typeof prevFieldKey, handleKeyUnique: typeof handleFieldKeyUnique) => {
       if (prevKey.current?.key === value) {
         return prevKey.current?.isSuccess ? Promise.resolve() : Promise.reject();
-      } else if (validateKey(value) && handleKeyUnique(value, selectedField?.id)) {
+      } else if (validateKey(value) && handleKeyUnique(value)) {
         prevKey.current = { key: value, isSuccess: true };
         return Promise.resolve();
       } else {
@@ -308,7 +308,7 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
         return Promise.reject();
       }
     },
-    [selectedField?.id],
+    [],
   );
 
   return (

--- a/web/src/components/molecules/Schema/FieldModal/FieldCreationModalWithSteps/index.tsx
+++ b/web/src/components/molecules/Schema/FieldModal/FieldCreationModalWithSteps/index.tsx
@@ -36,6 +36,8 @@ interface Props {
   selectedField: Field | null;
   open: boolean;
   isLoading: boolean;
+  handleReferencedModelGet: (modelId: string) => void;
+  handleCorrespondingFieldKeyUnique: (key: string, fieldId?: string) => boolean;
   handleFieldKeyUnique: (key: string, fieldId?: string) => boolean;
   onClose: () => void;
   onSubmit: (values: FormValues) => Promise<void>;
@@ -48,13 +50,15 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
   selectedField,
   open,
   isLoading,
+  handleReferencedModelGet,
+  handleCorrespondingFieldKeyUnique,
   handleFieldKeyUnique,
   onClose,
   onSubmit,
   onUpdate,
 }) => {
   const t = useT();
-  const [selectedModel, setSelectedModel] = useState<string>();
+  const [selectedModelId, setSelectedModelId] = useState<string>();
   const schemaIdRef = useRef<string>();
   const [modelForm] = Form.useForm();
   const [field1Form] = Form.useForm();
@@ -64,6 +68,8 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
   const [activeTab, setActiveTab] = useState<FieldModalTabs>("settings");
   const [isDisabled, setIsDisabled] = useState(true);
   const isDisabledCache = useRef<boolean>(true);
+  const prevFieldKey = useRef<{ key: string; isSuccess: boolean }>();
+  const prevCorrespondingKey = useRef<{ key: string; isSuccess: boolean }>();
 
   const formValidate = useCallback((form: FormInstance) => {
     if (form.getFieldValue("model") || (form.getFieldValue("title") && form.getFieldValue("key"))) {
@@ -97,7 +103,7 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
       direction: selectedField?.typeProperty?.correspondingField ? 2 : 1,
     });
 
-    setSelectedModel(selectedField?.typeProperty?.modelId);
+    setSelectedModelId(selectedField?.typeProperty?.modelId);
     setNumSteps(selectedField?.typeProperty?.correspondingField ? 2 : 1);
     setIsDisabled(!selectedField);
     field1Form.setFieldsValue({
@@ -108,7 +114,7 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
         ...selectedField.typeProperty.correspondingField,
       });
     }
-  }, [modelForm, selectedField, field1Form, field2Form, setNumSteps, setSelectedModel]);
+  }, [modelForm, selectedField, field1Form, field2Form, setNumSteps, setSelectedModelId]);
 
   const initialValues: FormValues = useMemo(
     () => ({
@@ -158,10 +164,10 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
 
   const handleSelectModel = useCallback(
     (modelId: string, option: { schemaId: string }) => {
-      setSelectedModel(modelId);
+      setSelectedModelId(modelId);
       schemaIdRef.current = option.schemaId;
     },
-    [setSelectedModel],
+    [setSelectedModelId],
   );
 
   const clearFormFields = useCallback(() => {
@@ -187,6 +193,13 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
     setIsDisabled(isDisabledCache.current);
   }, [currentStep]);
 
+  const handleSettingField = useCallback(() => {
+    if (numSteps === 2 && selectedModelId) {
+      handleReferencedModelGet(selectedModelId);
+    }
+    nextStep();
+  }, [handleReferencedModelGet, nextStep, numSteps, selectedModelId]);
+
   const handleFirstField = useCallback(() => {
     field1Form
       .validateFields()
@@ -194,7 +207,7 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
         values.type = "Reference";
         values.typeProperty = {
           reference: {
-            modelId: selectedModel,
+            modelId: selectedModelId,
             schemaId: schemaIdRef.current,
             correspondingField: null,
           },
@@ -215,7 +228,7 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
       });
   }, [
     field1Form,
-    selectedModel,
+    selectedModelId,
     currentStep,
     numSteps,
     nextStep,
@@ -231,7 +244,7 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
         .then(async fields2Values => {
           field1FormValues.typeProperty = {
             reference: {
-              modelId: selectedModel ?? "",
+              modelId: selectedModelId ?? "",
               schemaId: schemaIdRef.current ?? "",
               correspondingField: {
                 ...fields2Values,
@@ -251,7 +264,7 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
         .then(async fields2Values => {
           field1FormValues.typeProperty = {
             reference: {
-              modelId: selectedModel ?? "",
+              modelId: selectedModelId ?? "",
               schemaId: schemaIdRef.current ?? "",
               correspondingField: {
                 ...fields2Values,
@@ -266,7 +279,7 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
           setActiveTab("settings");
         });
     }
-  }, [onClose, onSubmit, onUpdate, selectedField, field1FormValues, field2Form, selectedModel]);
+  }, [onClose, onSubmit, onUpdate, selectedField, field1FormValues, field2Form, selectedModelId]);
 
   const handleNameChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>, fieldForm: FormInstance) => {
@@ -281,6 +294,21 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
       keyReplace(e, { form: fieldForm, key: "key" });
     },
     [],
+  );
+
+  const keyValidate = useCallback(
+    (value: string, prevKey: typeof prevFieldKey, handleKeyUnique: typeof handleFieldKeyUnique) => {
+      if (prevKey.current?.key === value) {
+        return prevKey.current?.isSuccess ? Promise.resolve() : Promise.reject();
+      } else if (validateKey(value) && handleKeyUnique(value, selectedField?.id)) {
+        prevKey.current = { key: value, isSuccess: true };
+        return Promise.resolve();
+      } else {
+        prevKey.current = { key: value, isSuccess: false };
+        return Promise.reject();
+      }
+    },
+    [selectedField?.id],
   );
 
   return (
@@ -319,7 +347,7 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
             <div key="placeholder" />
           )}
           {currentStep === 0 && (
-            <Button key="next" type="primary" onClick={nextStep} disabled={isDisabled}>
+            <Button key="next" type="primary" onClick={handleSettingField} disabled={isDisabled}>
               {t("Next")}
             </Button>
           )}
@@ -359,7 +387,7 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
             name="model"
             label={t("Select the model to reference")}
             rules={[{ required: true, message: t("Please select the model!") }]}>
-            <Select value={selectedModel} onSelect={handleSelectModel} disabled={isUpdate}>
+            <Select value={selectedModelId} onSelect={handleSelectModel} disabled={isUpdate}>
               {models?.map(model => (
                 <Select.Option key={model.id} value={model.id} schemaId={model.schema.id}>
                   {model.name}{" "}
@@ -419,17 +447,8 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
                   {
                     message: t("Key is not valid"),
                     required: true,
-                    validator: (_, value) => {
-                      if (!validateKey(value)) return Promise.reject();
-                      const isKeyAvailable = handleFieldKeyUnique(
-                        value,
-                        selectedField ? selectedField?.id : undefined,
-                      );
-                      if (isKeyAvailable) {
-                        return Promise.resolve();
-                      } else {
-                        return Promise.reject();
-                      }
+                    validator: async (_, value) => {
+                      await keyValidate(value, prevFieldKey, handleFieldKeyUnique);
                     },
                   },
                 ]}>
@@ -450,7 +469,7 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
                   label={t("Set Options")}
                   rules={[
                     {
-                      validator: (_, values) => {
+                      validator: async (_, values) => {
                         if (!values || values.length < 1) {
                           return Promise.reject(new Error("At least 1 option"));
                         }
@@ -525,14 +544,12 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
                   {
                     message: t("Key is not valid"),
                     required: true,
-                    validator: (_, value) => {
-                      if (!validateKey(value)) return Promise.reject();
-                      const isKeyAvailable = handleFieldKeyUnique(value);
-                      if (isKeyAvailable) {
-                        return Promise.resolve();
-                      } else {
-                        return Promise.reject();
-                      }
+                    validator: async (_, value) => {
+                      await keyValidate(
+                        value,
+                        prevCorrespondingKey,
+                        handleCorrespondingFieldKeyUnique,
+                      );
                     },
                   },
                 ]}>
@@ -553,7 +570,7 @@ const FieldCreationModalWithSteps: React.FC<Props> = ({
                   label={t("Set Options")}
                   rules={[
                     {
-                      validator: (_, values) => {
+                      validator: async (_, values) => {
                         if (!values || values.length < 1) {
                           return Promise.reject(new Error("At least 1 option"));
                         }

--- a/web/src/components/molecules/Schema/FieldModal/hooks.ts
+++ b/web/src/components/molecules/Schema/FieldModal/hooks.ts
@@ -1,6 +1,6 @@
 import { CheckboxChangeEvent } from "antd/lib/checkbox";
 import dayjs from "dayjs";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, useRef } from "react";
 
 import Form from "@reearth-cms/components/atoms/Form";
 import { keyAutoFill, keyReplace } from "@reearth-cms/components/molecules/Common/Form/utils";
@@ -12,6 +12,7 @@ import {
   FormTypes,
 } from "@reearth-cms/components/molecules/Schema/types";
 import { transformDayjsToString } from "@reearth-cms/utils/format";
+import { validateKey } from "@reearth-cms/utils/regex";
 
 export default (
   selectedType: FieldType,
@@ -19,6 +20,7 @@ export default (
   selectedField: Field | null,
   onClose: () => void,
   onSubmit: (values: FormValues) => Promise<void>,
+  handleFieldKeyUnique: (key: string, fieldId?: string) => boolean,
 ) => {
   const [form] = Form.useForm<FormTypes>();
   const [buttonDisabled, setButtonDisabled] = useState(true);
@@ -26,6 +28,7 @@ export default (
   const selectedValues = Form.useWatch("values", form);
   const selectedTags = Form.useWatch("tags", form);
   const [multipleValue, setMultipleValue] = useState(false);
+  const prevKey = useRef<string>();
 
   const handleMultipleChange = useCallback(
     (e: CheckboxChangeEvent) => {
@@ -252,6 +255,18 @@ export default (
     [selectedType],
   );
 
+  const keyValidate = useCallback((value: string) => {
+    if (prevKey.current === value) {
+      return Promise.resolve();
+    } else {
+      prevKey.current = value;
+      if (validateKey(value) && handleFieldKeyUnique(value, selectedField?.id)) {
+        return Promise.resolve();
+      }
+    }
+    return Promise.reject();
+  }, []);
+
   return {
     form,
     buttonDisabled,
@@ -267,5 +282,6 @@ export default (
     handleModalReset,
     isRequiredDisabled,
     isUniqueDisabled,
+    keyValidate,
   };
 };

--- a/web/src/components/molecules/Schema/FieldModal/hooks.ts
+++ b/web/src/components/molecules/Schema/FieldModal/hooks.ts
@@ -28,7 +28,7 @@ export default (
   const selectedValues = Form.useWatch("values", form);
   const selectedTags = Form.useWatch("tags", form);
   const [multipleValue, setMultipleValue] = useState(false);
-  const prevKey = useRef<string>();
+  const prevKey = useRef<{ key: string; isSuccess: boolean }>();
 
   const handleMultipleChange = useCallback(
     (e: CheckboxChangeEvent) => {
@@ -255,17 +255,20 @@ export default (
     [selectedType],
   );
 
-  const keyValidate = useCallback((value: string) => {
-    if (prevKey.current === value) {
-      return Promise.resolve();
-    } else {
-      prevKey.current = value;
-      if (validateKey(value) && handleFieldKeyUnique(value, selectedField?.id)) {
+  const keyValidate = useCallback(
+    (value: string) => {
+      if (prevKey.current?.key === value) {
+        return prevKey.current?.isSuccess ? Promise.resolve() : Promise.reject();
+      } else if (validateKey(value) && handleFieldKeyUnique(value, selectedField?.id)) {
+        prevKey.current = { key: value, isSuccess: true };
         return Promise.resolve();
+      } else {
+        prevKey.current = { key: value, isSuccess: false };
+        return Promise.reject();
       }
-    }
-    return Promise.reject();
-  }, []);
+    },
+    [selectedField?.id],
+  );
 
   return {
     form,

--- a/web/src/components/molecules/Schema/FieldModal/index.tsx
+++ b/web/src/components/molecules/Schema/FieldModal/index.tsx
@@ -29,7 +29,7 @@ import {
   SortDirection,
 } from "@reearth-cms/components/organisms/Project/Asset/AssetList/hooks";
 import { useT } from "@reearth-cms/i18n";
-import { MAX_KEY_LENGTH, validateKey } from "@reearth-cms/utils/regex";
+import { MAX_KEY_LENGTH } from "@reearth-cms/utils/regex";
 
 import useHooks from "./hooks";
 
@@ -137,7 +137,8 @@ const FieldModal: React.FC<Props> = ({
     handleModalReset,
     isRequiredDisabled,
     isUniqueDisabled,
-  } = useHooks(selectedType, isMeta, selectedField, onClose, onSubmit);
+    keyValidate,
+  } = useHooks(selectedType, isMeta, selectedField, onClose, onSubmit, handleFieldKeyUnique);
 
   const requiredMark = (label: React.ReactNode, { required }: { required: boolean }) => (
     <>
@@ -194,11 +195,8 @@ const FieldModal: React.FC<Props> = ({
                 {
                   message: t("Key is not valid"),
                   required: true,
-                  validator: (_, value) => {
-                    if (validateKey(value) && handleFieldKeyUnique(value, selectedField?.id)) {
-                      return Promise.resolve();
-                    }
-                    return Promise.reject();
+                  validator: async (_, value) => {
+                    await keyValidate(value);
                   },
                 },
               ]}>

--- a/web/src/components/molecules/Schema/FormModal.tsx
+++ b/web/src/components/molecules/Schema/FormModal.tsx
@@ -40,7 +40,7 @@ const FormModal: React.FC<Props> = ({
   const [form] = Form.useForm<FormType>();
   const [isLoading, setIsLoading] = useState(false);
   const [isDisabled, setIsDisabled] = useState(true);
-  const prevKey = useRef<string>();
+  const prevKey = useRef<{ key: string; isSuccess: boolean }>();
 
   const values = Form.useWatch([], form);
   useEffect(() => {
@@ -152,15 +152,15 @@ const FormModal: React.FC<Props> = ({
 
   const keyValidate = useCallback(
     async (value: string) => {
-      if (prevKey.current === value) {
+      if (prevKey.current?.key === value) {
+        return prevKey.current?.isSuccess ? Promise.resolve() : Promise.reject();
+      } else if (value.length >= 3 && validateKey(value) && (await onKeyCheck(value, data?.key))) {
+        prevKey.current = { key: value, isSuccess: true };
         return Promise.resolve();
       } else {
-        prevKey.current = value;
-        if (value.length >= 3 && validateKey(value) && (await onKeyCheck(value, data?.key))) {
-          return Promise.resolve();
-        }
+        prevKey.current = { key: value, isSuccess: false };
+        return Promise.reject();
       }
-      return Promise.reject();
     },
     [data?.key, onKeyCheck],
   );

--- a/web/src/components/organisms/Project/Schema/hooks.ts
+++ b/web/src/components/organisms/Project/Schema/hooks.ts
@@ -136,13 +136,14 @@ export default () => {
   }, []);
 
   const handleFieldKeyUnique = useCallback(
-    (key: string, fieldId?: string) => keyUniqueCheck(key, fieldId, currentModel),
-    [currentModel],
+    (key: string) => keyUniqueCheck(key, selectedField?.id, currentModel),
+    [selectedField?.id, currentModel],
   );
 
   const handleCorrespondingFieldKeyUnique = useCallback(
-    (key: string, fieldId?: string) => keyUniqueCheck(key, fieldId, referencedModel),
-    [referencedModel],
+    (key: string) =>
+      keyUniqueCheck(key, selectedField?.typeProperty?.correspondingField?.id, referencedModel),
+    [selectedField?.typeProperty?.correspondingField?.id, referencedModel],
   );
 
   const [createNewField, { loading: fieldCreationLoading }] = useCreateFieldMutation({

--- a/web/src/components/organisms/Project/Schema/hooks.ts
+++ b/web/src/components/organisms/Project/Schema/hooks.ts
@@ -21,6 +21,7 @@ import {
   useUpdateFieldMutation,
   useUpdateFieldsMutation,
   useGetModelsQuery,
+  useGetModelLazyQuery,
   useGetGroupsQuery,
   useGetGroupQuery,
   Model as GQLModel,
@@ -62,6 +63,24 @@ export default () => {
       ?.map<Model | undefined>(model => fromGraphQLModel(model as GQLModel))
       .filter((model): model is Model => !!model);
   }, [modelsData?.models.nodes]);
+
+  const [getModel, { data: modelData }] = useGetModelLazyQuery({
+    fetchPolicy: "cache-and-network",
+  });
+
+  const handleReferencedModelGet = useCallback(
+    (modelId: string) => {
+      getModel({
+        variables: { id: modelId },
+      });
+    },
+    [getModel],
+  );
+
+  const referencedModel = useMemo<Model | undefined>(
+    () => fromGraphQLModel(modelData?.node as GQLModel),
+    [modelData?.node],
+  );
 
   const { data: groupsData } = useGetGroupsQuery({
     variables: {
@@ -111,13 +130,19 @@ export default () => {
     [navigate, projectId, workspaceId],
   );
 
+  const keyUniqueCheck = useCallback((key: string, fieldId?: string, model?: Model) => {
+    const sameKeyField = model?.schema.fields.find(field => field.key === key);
+    return !sameKeyField || sameKeyField.id === fieldId;
+  }, []);
+
   const handleFieldKeyUnique = useCallback(
-    (key: string, fieldId?: string): boolean => {
-      return !currentModel?.schema.fields.some(
-        field => field.key === key && (!fieldId || (fieldId && fieldId !== field.id)),
-      );
-    },
+    (key: string, fieldId?: string) => keyUniqueCheck(key, fieldId, currentModel),
     [currentModel],
+  );
+
+  const handleCorrespondingFieldKeyUnique = useCallback(
+    (key: string, fieldId?: string) => keyUniqueCheck(key, fieldId, referencedModel),
+    [referencedModel],
   );
 
   const [createNewField, { loading: fieldCreationLoading }] = useCreateFieldMutation({
@@ -556,6 +581,8 @@ export default () => {
     handleFieldUpdateModalOpen,
     handleFieldModalClose,
     handleFieldCreate,
+    handleReferencedModelGet,
+    handleCorrespondingFieldKeyUnique,
     handleFieldKeyUnique,
     handleFieldUpdate,
     handleFieldOrder,

--- a/web/src/components/organisms/Project/Schema/index.tsx
+++ b/web/src/components/organisms/Project/Schema/index.tsx
@@ -59,6 +59,8 @@ const ProjectSchema: React.FC = () => {
     handleFieldUpdateModalOpen,
     handleFieldModalClose,
     handleFieldCreate,
+    handleReferencedModelGet,
+    handleCorrespondingFieldKeyUnique,
     handleFieldKeyUnique,
     handleFieldUpdate,
     handleFieldOrder,
@@ -126,6 +128,8 @@ const ProjectSchema: React.FC = () => {
           selectedField={selectedField}
           open={fieldModalShown}
           isLoading={fieldUpdateLoading || fieldCreationLoading}
+          handleReferencedModelGet={handleReferencedModelGet}
+          handleCorrespondingFieldKeyUnique={handleCorrespondingFieldKeyUnique}
           handleFieldKeyUnique={handleFieldKeyUnique}
           onClose={handleFieldModalClose}
           onSubmit={handleFieldCreate}


### PR DESCRIPTION
# Overview
This PR removes useless key validating when updating some value other than key.

## What I've done
- Fixing validation failure due to auto filling
- Fixing validation of Reference field