### PR TITLE
fix: add missing repository URL argument for `configure-docker` command

### DIFF
--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -81,6 +81,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.repository.full_name == 'reearth/reearth-cms' && github.event.workflow_run.name == 'worker-build' && github.event.workflow_run.conclusion != 'failure' && github.event.workflow_run.head_branch == 'main'
     steps:
+      - uses: actions/checkout@v4
+      
       - uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
       - name: docker push
         run: |
           docker pull $IMAGE
@@ -87,7 +87,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
       - name: docker push
         run: |
           docker pull $WORKER_IMAGE


### PR DESCRIPTION
# Overview

To set the Docker's credential helper.

Ref: [Using a credential helper, Google Cloud](https://cloud.google.com/artifact-registry/docs/docker/pushing-and-pulling#cred-helper)

Other examples: https://github.com/reearth/reearth-visualizer/blob/e87230d8ff008a68f2fa85aa13f0eead3acbb321/.github/workflows/deploy_server_nightly.yml#L23

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
