### PR TITLE
ci: add missing checkout before deploy server workflow

### DIFF
--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -56,6 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.repository.full_name == 'reearth/reearth-cms' && github.event.workflow_run.name == 'server-build' && github.event.workflow_run.conclusion != 'failure' && github.event.workflow_run.head_branch == 'main'
     steps:
+      - uses: actions/checkout@v4
+
       - uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
# Overview

As the title says, I added the missing `actions/checkout` in deploy server workflow.

This is required before `google-github-actions/auth@v2`. 

> Run the actions/checkout@v4 step before this action. Omitting the checkout step or putting it after auth will cause future steps to be unable to authenticate.
>
Ref: [Prerequisites, google-github-actions/auth](https://github.com/google-github-actions/auth)

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
