### PR TITLE
fix(web): changes are not detected for some group fields

### DIFF
--- a/web/src/components/molecules/Content/Form/index.tsx
+++ b/web/src/components/molecules/Content/Form/index.tsx
@@ -226,9 +226,8 @@ const ContentForm: React.FC<Props> = ({
     (changedValues: any) => {
       const [key, value] = Object.entries(changedValues)[0];
       if (checkIfSingleGroupField(key, value)) {
-        const [groupFieldKey, groupFieldValue] = Object.entries(initialFormValues[key])[0];
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const changedFieldValue = (value as any)[groupFieldKey];
+        const [groupFieldKey, changedFieldValue] = Object.entries(value as object)[0];
+        const groupFieldValue = initialFormValues[key][groupFieldKey];
         if (
           JSON.stringify(emptyConvert(changedFieldValue)) ===
           JSON.stringify(emptyConvert(groupFieldValue))


### PR DESCRIPTION
# Overview
This PR fixes the bug that changes are not detected for some group fields.

## What I've done
Fixing the logic of detecting changes in a single group field.