### PR TITLE
fix(web): group field values sometimes disapper after refreshing page

### DIFF
--- a/web/e2e/project/item/fields/boolean.spec.ts
+++ b/web/e2e/project/item/fields/boolean.spec.ts
@@ -30,16 +30,18 @@ test("Boolean field creating and updating has succeeded", async ({ page }) => {
   await expect(page.locator("label")).toContainText("boolean1");
   await expect(page.getByRole("main")).toContainText("boolean1 description");
 
-  await page.getByRole("button", { name: "Save" }).click();
-  await closeNotification(page);
-  await page.getByLabel("Back").click();
-  await expect(page.getByRole("switch", { name: "close" })).toBeVisible();
-  await page.getByRole("cell").getByLabel("edit").locator("svg").click();
   await page.getByLabel("boolean1").click();
   await page.getByRole("button", { name: "Save" }).click();
   await closeNotification(page);
   await page.getByLabel("Back").click();
-  await expect(page.getByRole("switch", { name: "check" })).toBeVisible();
+  await expect(page.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+  await page.getByRole("cell").getByLabel("edit").locator("svg").click();
+  await expect(page.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+  await page.getByLabel("boolean1").click();
+  await page.getByRole("button", { name: "Save" }).click();
+  await closeNotification(page);
+  await page.getByLabel("Back").click();
+  await expect(page.getByRole("switch")).toHaveAttribute("aria-checked", "false");
 });
 
 test("Boolean field editing has succeeded", async ({ page }) => {
@@ -61,7 +63,7 @@ test("Boolean field editing has succeeded", async ({ page }) => {
   await page.getByRole("button", { name: "Save" }).click();
   await closeNotification(page);
   await page.getByLabel("Back").click();
-  await expect(page.getByRole("switch", { name: "check" })).toBeVisible();
+  await expect(page.getByRole("switch")).toHaveAttribute("aria-checked", "true");
   await page.getByText("Schema").click();
   await page.getByRole("img", { name: "ellipsis" }).locator("svg").click();
   await page.getByLabel("Display name").click();

--- a/web/e2e/project/item/fields/int.spec.ts
+++ b/web/e2e/project/item/fields/int.spec.ts
@@ -38,6 +38,7 @@ test("Int field creating and updating has succeeded", async ({ page }) => {
   await expect(page.getByRole("cell", { name: "1", exact: true })).toBeVisible();
 
   await page.getByRole("cell").getByLabel("edit").locator("svg").click();
+  await expect(page.getByLabel("int1")).toHaveValue("1");
   await page.getByLabel("int1").click();
   await page.getByLabel("int1").fill("2");
   await page.getByRole("button", { name: "Save" }).click();

--- a/web/e2e/project/item/fields/url.spec.ts
+++ b/web/e2e/project/item/fields/url.spec.ts
@@ -38,6 +38,7 @@ test("URL field creating and updating has succeeded", async ({ page }) => {
   await expect(page.getByRole("cell", { name: "http://test1.com", exact: true })).toBeVisible();
 
   await page.getByRole("cell").getByLabel("edit").locator("svg").click();
+  await expect(page.getByLabel("url1")).toHaveValue("http://test1.com");
   await page.getByLabel("url1").click();
   await page.getByLabel("url1").fill("http://test2.com");
   await page.getByRole("button", { name: "Save" }).click();

--- a/web/src/components/organisms/Project/Content/ContentDetails/hooks.ts
+++ b/web/src/components/organisms/Project/Content/ContentDetails/hooks.ts
@@ -383,6 +383,7 @@ export default () => {
   const [initialFormValues, setInitialFormValues] = useState<Record<string, any>>({});
 
   useEffect(() => {
+    if (itemLoading) return;
     const handleInitialValuesSet = async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const initialValues: Record<string, any> = {};
@@ -430,7 +431,7 @@ export default () => {
       setInitialFormValues(initialValues);
     };
     handleInitialValuesSet();
-  }, [currentItem, currentModel, handleGroupGet, updateValueConvert, valueGet]);
+  }, [itemLoading, currentItem, currentModel, handleGroupGet, updateValueConvert, valueGet]);
 
   const initialMetaFormValues: Record<string, unknown> = useMemo(() => {
     const initialValues: Record<string, unknown> = {};


### PR DESCRIPTION
# Overview
This PR fixes the bug group field values sometimes disapper after refreshing page.