### PR TITLE
fix(web): cesium base url version

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -13,8 +13,9 @@ import { configDefaults } from "vitest/config";
 
 // https://vitejs.dev/config/
 export default defineConfig(() => {
-  const packageJson = JSON.parse(readFileSync(resolve(__dirname, "package.json"), "utf-8"));
-  const cesiumVersion = packageJson.dependencies?.["cesium"];
+  const cesiumPackageJson = JSON.parse(
+    readFileSync(resolve(__dirname, "node_modules", "cesium", "package.json"), "utf-8"),
+  );
 
   return {
     server: {
@@ -26,9 +27,7 @@ export default defineConfig(() => {
     plugins: [
       react(),
       yaml(),
-      cesium({
-        cesiumBaseUrl: `cesium-${cesiumVersion}/`,
-      }),
+      cesium({ cesiumBaseUrl: `cesium-${cesiumPackageJson.version}/` }),
       serverHeaders(),
       config(),
     ],


### PR DESCRIPTION
# Overview
This PR fixes the cesium version in cesiumBaseUrl inside vite.config.ts file
Now the cesium version is coming from `node_modules/cesium/package.json` instead of `package.json`
