### PR TITLE
fix(web): disable closing modal when uploading asset

### DIFF
--- a/web/src/components/molecules/Asset/UploadModal/UploadModal.tsx
+++ b/web/src/components/molecules/Asset/UploadModal/UploadModal.tsx
@@ -56,6 +56,8 @@ const UploadModal: React.FC<Props> = ({
       centered
       open={visible}
       onCancel={onCancel}
+      closable={!uploading}
+      maskClosable={!uploading}
       footer={
         <>
           <Button type="default" disabled={uploading} onClick={onCancel}>


### PR DESCRIPTION
# Overview
This PR fixes to disable closing modal when uploading asset.