### PR TITLE
fix(web): disable the buttons to change the state of an item based on the item's status

### DIFF
--- a/web/src/components/molecules/Content/Form/index.tsx
+++ b/web/src/components/molecules/Content/Form/index.tsx
@@ -424,6 +424,7 @@ const ContentForm: React.FC<Props> = ({
         key: "addToRequest",
         label: t("Add to Request"),
         onClick: onAddItemToRequestModalOpen,
+        disabled: item?.status === "PUBLIC",
       },
       {
         key: "unpublish",
@@ -431,6 +432,7 @@ const ContentForm: React.FC<Props> = ({
         onClick: () => {
           if (itemId) onUnpublish([itemId]);
         },
+        disabled: item?.status === "DRAFT" || item?.status === "REVIEW",
       },
     ];
     if (showPublishAction) {
@@ -438,10 +440,19 @@ const ContentForm: React.FC<Props> = ({
         key: "NewRequest",
         label: t("New Request"),
         onClick: onModalOpen,
+        disabled: item?.status === "PUBLIC",
       });
     }
     return menuItems;
-  }, [itemId, showPublishAction, onAddItemToRequestModalOpen, onUnpublish, onModalOpen, t]);
+  }, [
+    t,
+    onAddItemToRequestModalOpen,
+    item?.status,
+    showPublishAction,
+    itemId,
+    onUnpublish,
+    onModalOpen,
+  ]);
 
   const handlePublishSubmit = useCallback(async () => {
     if (!itemId || !unpublishedItems) return;
@@ -474,12 +485,19 @@ const ContentForm: React.FC<Props> = ({
               {itemId && (
                 <>
                   {showPublishAction && (
-                    <Button type="primary" onClick={handlePublishSubmit} loading={publishLoading}>
+                    <Button
+                      type="primary"
+                      onClick={handlePublishSubmit}
+                      loading={publishLoading}
+                      disabled={item?.status === "PUBLIC"}>
                       {t("Publish")}
                     </Button>
                   )}
                   {!showPublishAction && (
-                    <Button type="primary" onClick={onModalOpen}>
+                    <Button
+                      type="primary"
+                      onClick={onModalOpen}
+                      disabled={item?.status === "PUBLIC"}>
                       {t("New Request")}
                     </Button>
                   )}


### PR DESCRIPTION
# Overview
This PR fixes to disable the buttons to change the state of an item based on the item's status.
