### PR TITLE
ci: add `web-build` to deploy-test workflow's dependencies

### DIFF
--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -1,7 +1,7 @@
 name: deploy-test
 on:
   workflow_run:
-    workflows: [server-build, ci-web, worker-build]
+    workflows: [server-build, ci-web, web-build, worker-build]
     types: [completed]
     branches: [main]
 concurrency:


### PR DESCRIPTION
# Overview

Added the missing `web-build` workflow dependency to `deploy-test` workflow so that it will be deployed on web (frontend) update.

https://github.com/reearth/reearth-cms/pull/1253

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
