### PR TITLE
ci: fix Docker image name for web image

### DIFF
--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -20,8 +20,8 @@ env:
 
   # web
   WEB_IMAGE:  reearth/reearth-cms-web:nightly
-  WEB_IMAGE_NAME: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/reearth/reearth-cms-worker:nightly
-  WEB_IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-cms-worker:nightly
+  WEB_IMAGE_NAME: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/reearth/reearth-cms-web:nightly
+  WEB_IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-cms-web:nightly
 
   # worker
   WORKER_IMAGE:  reearth/reearth-cms-worker:nightly


### PR DESCRIPTION
# Overview

I made a bad copy-and-paste... 
The name of the `web` Docker image is incorrect, so I've fixed it to have `-web` suffix.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
