### PR TITLE
feat(web): wrap environment variables with '""' for Re:Earth config

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -34,6 +34,17 @@ ENV PORT=8080
 # Ref: https://cloud.google.com/load-balancing/docs/https#target-proxies
 ENV REAL_IP_HEADER=X-Forwarded-For
 
+# Default values.
+# Cesium Ion access token is not a secret.
+ENV REEARTH_CMS_CESIUM_ION_ACCESS_TOKEN=null
+
+# All values in reearth_config.json must have a default value.
+ENV REEARTH_CMS_API=null
+ENV REEARTH_CMS_COVER_IMAGE_URL=null
+ENV REEARTH_CMS_EDITOR_URL=null
+ENV REEARTH_CMS_LOGO_URL=null
+ENV REEARTH_CMS_MULTI_TENANT=null
+
 COPY --from=builder --chown=nginx:nginx /app/dist /usr/share/nginx/html
 COPY --chown=nginx:nginx docker/nginx.conf.template /etc/nginx/templates/nginx.conf.template 
 COPY --chown=nginx:nginx docker/40-envsubst-on-reearth-config.sh /docker-entrypoint.d

--- a/web/docker/40-envsubst-on-reearth-config.sh
+++ b/web/docker/40-envsubst-on-reearth-config.sh
@@ -5,4 +5,13 @@ set -e
 _REEARTH_CONFIG_TEMPLATE_FILE="/opt/reearth-cms/reearth_config.json.template"
 _REEARTH_CONFIG_OUTPUT_FILE="/usr/share/nginx/html/reearth_config.json"
 
+# Wrap with "" if the value doesn't start with '{' and end with '}' (JSON) or "null".
+wrap_reearth_cms_variables() {
+    for var in $(env | grep '^REEARTH_CMS_' | cut -d= -f1); do
+        value=$(printenv "$var")
+        [ "$value" != "null" ] && ! echo "$value" | grep -qE '^\{.*\}$' && export "$var=\"${value}\""
+    done
+}
+
+wrap_reearth_cms_variables $@
 envsubst < "$_REEARTH_CONFIG_TEMPLATE_FILE" > "$_REEARTH_CONFIG_OUTPUT_FILE"

--- a/web/docker/reearth_config.json.template
+++ b/web/docker/reearth_config.json.template
@@ -1,5 +1,11 @@
 {
-    "auth0Audience": "$AUTH0_AUDIENCE",
-    "auth0ClientId": "$AUTH0_CLIENT_ID",
-    "auth0Domain": "$AUTH0_DOMAIN"
+    "api": $REEARTH_CMS_API,
+    "auth0Audience": $REEARTH_CMS_AUTH0_AUDIENCE,
+    "auth0ClientId": $REEARTH_CMS_AUTH0_CLIENT_ID,
+    "auth0Domain": $REEARTH_CMS_AUTH0_DOMAIN,
+    "cesiumIonAccessToken": $REEARTH_CMS_CESIUM_ION_ACCESS_TOKEN,
+    "coverImageUrl": $REEARTH_CMS_COVER_IMAGE_URL,
+    "editorUrl": $REEARTH_CMS_EDITOR_URL,
+    "logoUrl": $REEARTH_CMS_LOGO_URL,
+    "multiTenant": $REEARTH_CMS_MULTI_TENANT
 }


### PR DESCRIPTION
# Overview

I have added some of the missing configuration to `reearth_config.json.template` and the default values to `Dockerfile`.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
