### PR TITLE
fix(web): download button is not showing

### DIFF
--- a/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
@@ -178,7 +178,7 @@ const AssetMolecule: React.FC<Props> = ({
             />
           </Card>
         )}
-        <DownloadButton ghost selected={asset ? [asset] : undefined} displayDefaultIcon />
+        <DownloadButton selected={asset ? [asset] : undefined} displayDefaultIcon />
       </BodyWrapper>
       <SideBarWrapper>
         <SideBarCard title={t("Asset Type")}>


### PR DESCRIPTION
# Overview
This PR fixes the bug where the download button is not showing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the visual styling of the `DownloadButton` for improved user experience. 

- **Bug Fixes**
	- Removed the `ghost` prop from the `DownloadButton`, enhancing its appearance in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->