### PR TITLE
ci: update Cesium ION token of `reearth-cms-web` Cloud Run service

### DIFF
--- a/.github/workflows/cron_ion_token_test.yml
+++ b/.github/workflows/cron_ion_token_test.yml
@@ -4,20 +4,17 @@ on:
     - cron: "0 0 2 * *"
   workflow_dispatch:
 env:
-  GCS_DOMAIN: gs://cms.test.reearth.dev
-  REEARTH_CONFIG_FILENAME: reearth_config.json
+  CMS_WEB: reearth-cms-web
+  REGION: us-central1
 jobs:
   update_ion_token:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: google-github-actions/auth@v2
         with:
           service_account: ${{ secrets.GCP_SA_EMAIL }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER}}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - name: Download reearth config
-        run: gsutil cp "${{ env.GCS_DOMAIN }}/${{ env.REEARTH_CONFIG_FILENAME }}" .
       - name: Get Cesium Ion token
         id: ion_token
         run: |
@@ -36,9 +33,9 @@ jobs:
           " \
           )
           echo "token=${ION_TOKEN}" >> $GITHUB_OUTPUT
-      - name: Update Ion token in reearth config
+      - name: Update Cloud Run
         run: |
-          echo $(cat ${{ env.REEARTH_CONFIG_FILENAME }} | jq -r '.cesiumIonAccessToken |= "${{ steps.ion_token.outputs.token }}"') > ${{ env.REEARTH_CONFIG_FILENAME }}
-          echo $(cat ${{ env.REEARTH_CONFIG_FILENAME }})
-      - name: Upload reearth config
-        run: gsutil -h "Cache-Control:no-store" cp reearth_config.json "${{ env.GCS_DOMAIN }}/${{ env.REEARTH_CONFIG_FILENAME }}"
+          gcloud run services update $CMS_WEB \
+            --update-env-vars REEARTH_CMS_CESIUM_ION_ACCESS_TOKEN=${{ steps.ion_token.outputs.token }} \
+            --region $REGION \
+            --platform managed


### PR DESCRIPTION
# Overview

Because now the Re:Earth CMS frontend (web) has been Docker-ized, we must update the environment variables instead of updating the `reearth_config.json` on GCS.

## What I've done

## What I haven't done

## How I tested

I ran the workflow by dispatching the event and confirmed that it's working: [log](https://github.com/reearth/reearth-cms/actions/runs/11427310222/job/31791290711)

## Screenshot

## Which point I want you to review particularly

## Memo

* See: https://github.com/reearth/reearth-cms/pull/1253


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a scheduled workflow to update the Cloud Run service on the 2nd day of every month at midnight.
	- Added new environment variables for improved configuration management.
- **Bug Fixes**
	- Streamlined the process for updating the Cesium Ion token by directly updating the Cloud Run service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->