### PR TITLE
ci: add missing `id-token:write` permission for Google Cloud

### DIFF
--- a/.github/workflows/cron_ion_token_test.yml
+++ b/.github/workflows/cron_ion_token_test.yml
@@ -13,6 +13,8 @@ jobs:
       contents: read # To checkout
       id-token: write # To authenticate with Google Cloud using OIDC
     steps:
+      - uses: actions/checkout@v4
+
       - uses: google-github-actions/auth@v2
         with:
           service_account: ${{ secrets.GCP_SA_EMAIL }}

--- a/.github/workflows/cron_ion_token_test.yml
+++ b/.github/workflows/cron_ion_token_test.yml
@@ -9,11 +9,14 @@ env:
 jobs:
   update_ion_token:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # To checkout
+      id-token: write # To authenticate with Google Cloud using OIDC
     steps:
       - uses: google-github-actions/auth@v2
         with:
           service_account: ${{ secrets.GCP_SA_EMAIL }}
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER}}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Download reearth config

--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -34,6 +34,9 @@ jobs:
     name: Deploy web to test env
     if: github.event.repository.full_name == 'reearth/reearth-cms' && github.event.workflow_run.name == 'ci-web' && github.event.workflow_run.conclusion != 'failure' && github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # To checkout
+      id-token: write # To authenticate with Google Cloud using OIDC
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token
@@ -56,7 +59,7 @@ jobs:
       - uses: google-github-actions/auth@v2
         with:
           service_account: ${{ secrets.GCP_SA_EMAIL }}
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER}}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Deploy
@@ -66,13 +69,16 @@ jobs:
     name: Deploy server to test env
     runs-on: ubuntu-latest
     if: github.event.repository.full_name == 'reearth/reearth-cms' && github.event.workflow_run.name == 'server-build' && github.event.workflow_run.conclusion != 'failure' && github.event.workflow_run.head_branch == 'main'
+    permissions:
+      contents: read # To checkout
+      id-token: write # To authenticate with Google Cloud using OIDC
     steps:
       - uses: actions/checkout@v4
 
       - uses: google-github-actions/auth@v2
         with:
           service_account: ${{ secrets.GCP_SA_EMAIL }}
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER}}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
@@ -94,13 +100,16 @@ jobs:
     name: Deploy web to test env
     runs-on: ubuntu-latest
     if: github.event.repository.full_name == 'reearth/reearth-cms' && github.event.workflow_run.name == 'web-build' && github.event.workflow_run.conclusion != 'failure' && github.event.workflow_run.head_branch == 'main'
+    permissions:
+      contents: read # To checkout
+      id-token: write # To authenticate with Google Cloud using OIDC
     steps:
       - uses: actions/checkout@v4
 
       - uses: google-github-actions/auth@v2
         with:
           service_account: ${{ secrets.GCP_SA_EMAIL }}
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER}}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
@@ -122,13 +131,16 @@ jobs:
     name: Deploy worker to test env
     runs-on: ubuntu-latest
     if: github.event.repository.full_name == 'reearth/reearth-cms' && github.event.workflow_run.name == 'worker-build' && github.event.workflow_run.conclusion != 'failure' && github.event.workflow_run.head_branch == 'main'
+    permissions:
+      contents: read # To checkout
+      id-token: write # To authenticate with Google Cloud using OIDC
     steps:
       - uses: actions/checkout@v4
       
       - uses: google-github-actions/auth@v2
         with:
           service_account: ${{ secrets.GCP_SA_EMAIL }}
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER}}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker


### PR DESCRIPTION
# Overview

Add missing permissions to authenticate with Google Cloud with workload federation.

## What I've done

## What I haven't done

## How I tested

Ran the workflow: [log](https://github.com/reearth/reearth-cms/actions/runs/11427276462/job/31791273143). 
Looks good.

## Screenshot

## Which point I want you to review particularly

## Memo
