### PR TITLE
fix(server): make the default value of number field clearable

### DIFF
--- a/server/pkg/value/number.go
+++ b/server/pkg/value/number.go
@@ -15,6 +15,9 @@ type propertyNumber struct{}
 type Number = float64
 
 func (p *propertyNumber) ToValue(i any) (any, bool) {
+	if i == "" {
+		return nil, true
+	}
 	switch v := i.(type) {
 	case float64:
 		return Number(v), true

--- a/server/pkg/value/number_test.go
+++ b/server/pkg/value/number_test.go
@@ -90,6 +90,12 @@ func Test_propertyNumber_ToValue(t *testing.T) {
 			want2: true,
 		},
 		{
+			name:  "empty string",
+			args:  []any{""},
+			want1: nil,
+			want2: true,
+		},
+		{
 			name:  "nil",
 			args:  []any{"foo", (*float64)(nil), (*string)(nil), (*int)(nil), (*json.Number)(nil), nil},
 			want1: nil,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of empty string inputs in the conversion process, returning `nil` and `true` for empty strings.
  
- **Tests**
	- Added a new test case to verify the behavior of the conversion method when provided with an empty string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->