### PR TITLE
ci: remove web assets from API Docker image

### DIFF
--- a/.github/workflows/build_server.yml
+++ b/.github/workflows/build_server.yml
@@ -92,19 +92,6 @@ jobs:
           echo "::set-output name=platforms::$PLATFORMS"
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=tags::$TAGS"
-      - name: Fetch reearth-cms-web
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          github_token: ${{secrets.GITHUB_TOKEN}}
-          workflow: ci_web.yml
-          workflow_conclusion: success
-          branch: main
-          name: reearth-cms-web
-          path: server
-          check_artifacts: true
-          search_artifacts: true
-      - name: Extract reearth-cms-web
-        run: tar -xvf server/reearth-cms-web.tar.gz; mv reearth-cms-web server/web; ls
       - name: Build and push docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/ci_web.yml
+++ b/.github/workflows/ci_web.yml
@@ -29,3 +29,13 @@ jobs:
         run: yarn i18n --fail-on-update
       - name: Build
         run: yarn build
+      - name: Pack
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release'
+        run: mv dist reearth-cms-web && tar -zcvf reearth-cms-web.tar.gz reearth-cms-web
+
+      - uses: actions/upload-artifact@v4
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release'
+        with:
+          name: reearth-cms-web
+          path: web/reearth-cms-web.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/ci_web.yml
+++ b/.github/workflows/ci_web.yml
@@ -29,16 +29,3 @@ jobs:
         run: yarn i18n --fail-on-update
       - name: Build
         run: yarn build
-      
-      # TODO: Remove after dockerizing the web.
-      - name: Pack
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release'
-        run: mv dist reearth-cms-web && tar -zcvf reearth-cms-web.tar.gz reearth-cms-web
-
-      # TODO: Remove after dockerizing the web.
-      - uses: actions/upload-artifact@v4
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release'
-        with:
-          name: reearth-cms-web
-          path: web/reearth-cms-web.tar.gz
-          if-no-files-found: error

--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -10,9 +10,6 @@ concurrency:
 env:
   GCP_REGION: us-central1
 
-  # TODO: Remove after dockerizing the web.
-  GCS_DEST: gs://cms.test.reearth.dev
-
   # server
   SERVER_IMAGE: reearth/reearth-cms:nightly
   SERVER_IMAGE_NAME: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/reearth/reearth-cms:nightly
@@ -29,42 +26,6 @@ env:
   WORKER_IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-cms-worker:nightly
 
 jobs:
-  # TODO: Remove after dockerizing the web.
-  deploy_web_gcs:
-    name: Deploy web to test env
-    if: github.event.repository.full_name == 'reearth/reearth-cms' && github.event.workflow_run.name == 'ci-web' && github.event.workflow_run.conclusion != 'failure' && github.event.workflow_run.head_branch == 'main'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # To checkout
-      id-token: write # To authenticate with Google Cloud using OIDC
-    steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
-      - name: get latest web artifact
-        uses: dawidd6/action-download-artifact@v3.1.4
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          workflow: ci_web.yml
-          workflow_conclusion: success
-          branch: main
-          name: reearth-cms-web
-          check_artifacts: true
-          search_artifacts: true
-      - name: Extract
-        run: tar -xvf reearth-cms-web.tar.gz
-      - uses: google-github-actions/auth@v2
-        with:
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - name: Deploy
-        run: gsutil -m -h "Cache-Control:no-store" rsync -x "^reearth_config\\.json$" -dr reearth-cms-web/ $GCS_DEST
-
   deploy_server:
     name: Deploy server to test env
     runs-on: ubuntu-latest

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -21,7 +21,6 @@ FROM scratch
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /etc/mime.types /etc/mime.types
 COPY --from=build /app/reearth-cms /app/reearth-cms
-COPY web* /app/web/
 
 WORKDIR /app
 


### PR DESCRIPTION
# Overview

Because the web has it's own Docker image, there is no need to include it with it in the API's Docker image.
I also remove the CI for the web (GCS).

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Streamlined workflows for building and deploying applications.
  
- **Bug Fixes**
	- Removed unnecessary artifact handling in Docker and CI workflows.

- **Chores**
	- Eliminated steps related to web deployment and artifact management, enhancing workflow efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->