### PR TITLE
ci: fix branch retrieval in build workflow for web and worker

### DIFF
--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -26,7 +26,7 @@ jobs:
         id: info
         # The tag name should be retrieved lazily, as tagging may be delayed.
         env:
-          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
           if [[ "$BRANCH" = "release" ]]; then

--- a/.github/workflows/build_worker.yml
+++ b/.github/workflows/build_worker.yml
@@ -26,7 +26,7 @@ jobs:
         id: info
         # The tag name should be retrieved lazily, as tagging may be delayed.
         env:
-          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
           if [[ "$BRANCH" = "release" ]]; then


### PR DESCRIPTION
# Overview

The `${{ github.event.workflow_run.head_branch }}` is empty on workflow run.

The server (API) is working but it is because it's only fixed:

https://github.com/reearth/reearth-cms/blob/9c2d46df481b2ff135db45b22697a776418d5982/.github/workflows/build_server.yml#L29


## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
