### PR TITLE
ci(web): update cesium ion token via secret manager

### DIFF
--- a/.github/workflows/cron_ion_token_test.yml
+++ b/.github/workflows/cron_ion_token_test.yml
@@ -36,9 +36,17 @@ jobs:
           " \
           )
           echo "token=${ION_TOKEN}" >> $GITHUB_OUTPUT
+      - name: Update Secret Manager secret
+        run: |
+          echo -n "${{ steps.ion_token.outputs.token }}" | gcloud secrets versions add ${{ secrets.CESIUM_ION_TOKEN_SECRET_NAME }} \
+            --data-file=-
       - name: Update Cloud Run
         run: |
           gcloud run services update $CMS_WEB \
-            --update-env-vars REEARTH_CMS_CESIUM_ION_ACCESS_TOKEN=${{ steps.ion_token.outputs.token }} \
-            --region $REGION \
-            --platform managed
+            --update-secrets REEARTH_CMS_CESIUM_ION_ACCESS_TOKEN=${{ secrets.CESIUM_ION_TOKEN_SECRET_NAME }}:latest \
+            --region $REGION
+      - name: Update Cloud Run traffic
+        run: |
+          gcloud run services update-traffic $CMS_WEB \
+            --to-latest \
+            --region $REGION


### PR DESCRIPTION
# Overview

Cloud Run service for Re:Earth CMS web now uses a secret manager for storing the Cesium Ion token, so I made the CI to update the secret and create a new revision.

## What I've done

## What I haven't done

## How I tested

Manually ran the workflow: [result](https://github.com/reearth/reearth-cms/actions/runs/11730504603/job/32679008938)

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security for managing the Cesium Ion access token by integrating with Google Secret Manager.
	- Improved deployment process for the Cloud Run service, ensuring the latest version is utilized.

- **Bug Fixes**
	- Resolved issues related to direct environment variable updates, promoting a more secure approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->