### PR TITLE
chore(server): Increase domain package unit test coverage (integrationapi part 2)

### DIFF
--- a/server/pkg/id/id.go
+++ b/server/pkg/id/id.go
@@ -243,7 +243,7 @@ var RequestIDFromRef = idx.FromRef[Request]
 
 type View struct{}
 
-func (View) Type() string { return "request" }
+func (View) Type() string { return "view" }
 
 type ViewID = idx.ID[View]
 type ViewIDList = idx.List[View]

--- a/server/pkg/id/id_test.go
+++ b/server/pkg/id/id_test.go
@@ -57,7 +57,7 @@ func TestAsset_Type(t *testing.T) {
 	assert.Equal(t, "resource", r.Type())
 
 	v := View{}
-	assert.Equal(t, "request", v.Type())
+	assert.Equal(t, "view", v.Type())
 
 	tag := Tag{}
 	assert.Equal(t, "tag", tag.Type())

--- a/server/pkg/id/id_test.go
+++ b/server/pkg/id/id_test.go
@@ -55,4 +55,16 @@ func TestAsset_Type(t *testing.T) {
 
 	r := Resource{}
 	assert.Equal(t, "resource", r.Type())
+
+	v := View{}
+	assert.Equal(t, "request", v.Type())
+
+	tag := Tag{}
+	assert.Equal(t, "tag", tag.Type())
+
+	g := Group{}
+	assert.Equal(t, "group", g.Type())
+
+	ig := ItemGroup{}
+	assert.Equal(t, "item_group", ig.Type())
 }

--- a/server/pkg/id/key_test.go
+++ b/server/pkg/id/key_test.go
@@ -55,3 +55,14 @@ func TestKey_Clone(t *testing.T) {
 	assert.Equal(t, k, c)
 	assert.NotSame(t, k, c)
 }
+
+func TestKey_NewKeyFromPtr(t *testing.T) {
+
+	str := "test-key"
+	wantKey := Key{
+		key: lo.FromPtr(&str),
+	}
+	result := NewKeyFromPtr(&str)
+	assert.NotNil(t, result, "Result should not be nil")
+	assert.Equal(t, &wantKey, result, "Key value should match the input string")
+}

--- a/server/pkg/integrationapi/event_test.go
+++ b/server/pkg/integrationapi/event_test.go
@@ -61,9 +61,7 @@ func Test_NewOperator(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			result := NewOperator(test.input)
-			if !assert.Equal(t, result, test.want) {
-				t.Errorf("expected %+v but got %+v", test.want, result)
-			}
+			assert.Equal(t, result, test.want)
 		})
 
 	}
@@ -163,12 +161,8 @@ func TestNewEventWith(t *testing.T) {
 			t.Parallel()
 
 			result, err := NewEventWith(test.args.event, test.args.override, test.args.v, test.args.urlResolver)
-			if !assert.Equal(t, result, test.want) {
-				t.Errorf("expected %+v but got %+v", test.want, result)
-			}
-			if !assert.Equal(t, err, test.wantErr) {
-				t.Errorf("expected %+v but got %+v", test.wantErr, err)
-			}
+			assert.Equal(t, result, test.want)
+			assert.Equal(t, err, test.wantErr)
 		})
 	}
 }

--- a/server/pkg/integrationapi/event_test.go
+++ b/server/pkg/integrationapi/event_test.go
@@ -18,7 +18,6 @@ func Test_NewOperator(t *testing.T) {
 
 	uid := accountdomain.NewUserID()
 	integrationID := id.NewIntegrationID()
-	// machineID :=
 	opUser := operator.OperatorFromUser(uid)
 	opIntegration := operator.OperatorFromIntegration(integrationID)
 	opMachine := operator.OperatorFromMachine()
@@ -67,7 +66,7 @@ func Test_NewOperator(t *testing.T) {
 }
 
 func TestNewEventWith(t *testing.T) {
-	now := time.Now()
+	mockTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	u := user.New().NewID().Email("hoge@example.com").Name("John").MustBuild()
 	a := asset.New().NewID().Project(project.NewID()).Size(100).NewUUID().
 		CreatedByUser(u.ID()).Thread(id.NewThreadID()).MustBuild()
@@ -77,7 +76,7 @@ func TestNewEventWith(t *testing.T) {
 		Alias: "testAlias",
 	}
 
-	ev := event.New[any]().ID(eID1).Timestamp(now).Type(event.AssetCreate).Operator(operator.OperatorFromUser(u.ID())).Object(a).Project(&prj).MustBuild()
+	ev := event.New[any]().ID(eID1).Timestamp(mockTime).Type(event.AssetCreate).Operator(operator.OperatorFromUser(u.ID())).Object(a).Project(&prj).MustBuild()
 	d1, _ := New(ev, "test", func(a *asset.Asset) string {
 		return "test.com"
 	})

--- a/server/pkg/integrationapi/event_test.go
+++ b/server/pkg/integrationapi/event_test.go
@@ -58,10 +58,14 @@ func Test_NewOperator(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		result := NewOperator(test.input)
-		if !assert.Equal(t, result, test.want) {
-			t.Errorf("expected %+v but got %+v", test.want, result)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result := NewOperator(test.input)
+			if !assert.Equal(t, result, test.want) {
+				t.Errorf("expected %+v but got %+v", test.want, result)
+			}
+		})
+
 	}
 }
 
@@ -143,12 +147,16 @@ func TestNewEventWith(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		result, err := NewEventWith(test.args.event, test.args.override, test.args.v, test.args.urlResolver)
-		if !assert.Equal(t, result, test.want) {
-			t.Errorf("expected %+v but got %+v", test.want, result)
-		}
-		if !assert.Equal(t, err, test.wantErr) {
-			t.Errorf("expected %+v but got %+v", test.wantErr, err)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := NewEventWith(test.args.event, test.args.override, test.args.v, test.args.urlResolver)
+			if !assert.Equal(t, result, test.want) {
+				t.Errorf("expected %+v but got %+v", test.want, result)
+			}
+			if !assert.Equal(t, err, test.wantErr) {
+				t.Errorf("expected %+v but got %+v", test.wantErr, err)
+			}
+		})
 	}
 }

--- a/server/pkg/integrationapi/event_test.go
+++ b/server/pkg/integrationapi/event_test.go
@@ -81,6 +81,7 @@ func TestNewEventWith(t *testing.T) {
 	}
 
 	ev := event.New[any]().ID(eID1).Timestamp(mockTime).Type(event.AssetCreate).Operator(operator.OperatorFromUser(u.ID())).Object(a).Project(&prj).MustBuild()
+	ev1 := event.New[any]().ID(eID1).Timestamp(mockTime).Type(event.Type("test")).Operator(operator.OperatorFromUser(u.ID())).Object("test").Project(&prj).MustBuild()
 	d1, _ := New(ev, "test", func(a *asset.Asset) string {
 		return "test.com"
 	})
@@ -144,6 +145,17 @@ func TestNewEventWith(t *testing.T) {
 				Operator: NewOperator(ev.Operator()),
 			},
 			wantErr: nil,
+		},
+		{
+			name: "error new returns error",
+			args: args{
+				event:       ev,
+				override:    ev1,
+				v:           "",
+				urlResolver: nil,
+			},
+			want:    Event{},
+			wantErr: ErrUnsupportedEntity,
 		},
 	}
 	for _, test := range tests {

--- a/server/pkg/integrationapi/schema_test.go
+++ b/server/pkg/integrationapi/schema_test.go
@@ -21,7 +21,7 @@ func TestNewModel(t *testing.T) {
 		sp           *schema.Package
 		lastModified time.Time
 	}
-	timeNow := time.Now()
+	mockTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	pID := id.NewProjectID()
 	sf1 := schema.NewField(schema.NewText(nil).TypeProperty()).NewID().RandomKey().MustBuild()
 	sf2 := schema.NewField(lo.Must1(schema.NewInteger(nil, nil)).TypeProperty()).NewID().RandomKey().MustBuild()
@@ -29,8 +29,8 @@ func TestNewModel(t *testing.T) {
 	s2 := schema.New().NewID().Project(pID).Workspace(accountdomain.NewWorkspaceID()).Fields([]*schema.Field{sf1, sf2}).TitleField(sf1.ID().Ref()).MustBuild()
 	schemaPackage1 := schema.NewPackage(s1, nil, nil, nil)
 	schemaPackage2 := schema.NewPackage(s2, nil, nil, nil)
-	model1 := model.New().ID(id.NewModelID()).Metadata(s1.ID().Ref()).Project(pID).Schema(s1.ID()).Key(id.NewKey("mmm123")).UpdatedAt(timeNow).MustBuild()
-	model2 := model.New().ID(id.NewModelID()).Metadata(s2.ID().Ref()).Project(pID).Schema(s2.ID()).Key(id.NewKey("mmm123")).UpdatedAt(timeNow).MustBuild()
+	model1 := model.New().ID(id.NewModelID()).Metadata(s1.ID().Ref()).Project(pID).Schema(s1.ID()).Key(id.NewKey("mmm123")).UpdatedAt(mockTime).MustBuild()
+	model2 := model.New().ID(id.NewModelID()).Metadata(s2.ID().Ref()).Project(pID).Schema(s2.ID()).Key(id.NewKey("mmm123")).UpdatedAt(mockTime).MustBuild()
 
 	tests := []struct {
 		name string
@@ -42,7 +42,7 @@ func TestNewModel(t *testing.T) {
 			args: args{
 				m:            model1,
 				sp:           schemaPackage1,
-				lastModified: timeNow,
+				lastModified: mockTime,
 			},
 			want: Model{
 				Id:               model1.ID().Ref(),
@@ -57,7 +57,7 @@ func TestNewModel(t *testing.T) {
 				MetadataSchema:   util.ToPtrIfNotEmpty(NewSchema(schemaPackage1.MetaSchema())),
 				CreatedAt:        lo.ToPtr(model1.ID().Timestamp()),
 				UpdatedAt:        lo.ToPtr(model1.UpdatedAt()),
-				LastModified:     util.ToPtrIfNotEmpty(timeNow),
+				LastModified:     util.ToPtrIfNotEmpty(mockTime),
 			},
 		},
 		{
@@ -65,7 +65,7 @@ func TestNewModel(t *testing.T) {
 			args: args{
 				m:            model2,
 				sp:           schemaPackage2,
-				lastModified: timeNow,
+				lastModified: mockTime,
 			},
 			want: Model{
 				Id:               model2.ID().Ref(),
@@ -80,7 +80,7 @@ func TestNewModel(t *testing.T) {
 				MetadataSchema:   util.ToPtrIfNotEmpty(NewSchema(schemaPackage2.MetaSchema())),
 				CreatedAt:        lo.ToPtr(model2.ID().Timestamp()),
 				UpdatedAt:        lo.ToPtr(model2.UpdatedAt()),
-				LastModified:     util.ToPtrIfNotEmpty(timeNow),
+				LastModified:     util.ToPtrIfNotEmpty(mockTime),
 			},
 		},
 	}

--- a/server/pkg/integrationapi/schema_test.go
+++ b/server/pkg/integrationapi/schema_test.go
@@ -1,0 +1,112 @@
+package integrationapi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/reearth/reearth-cms/server/pkg/id"
+	"github.com/reearth/reearth-cms/server/pkg/model"
+	"github.com/reearth/reearth-cms/server/pkg/schema"
+	"github.com/reearth/reearthx/account/accountdomain"
+	"github.com/reearth/reearthx/util"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewModel(t *testing.T) {
+	type args struct {
+		m            *model.Model
+		sp           *schema.Package
+		lastModified time.Time
+	}
+	timeNow := time.Now()
+	pID := id.NewProjectID()
+	sf1 := schema.NewField(schema.NewText(nil).TypeProperty()).NewID().RandomKey().MustBuild()
+	sf2 := schema.NewField(lo.Must1(schema.NewInteger(nil, nil)).TypeProperty()).NewID().RandomKey().MustBuild()
+	s1 := schema.New().NewID().Project(pID).Workspace(accountdomain.NewWorkspaceID()).Fields([]*schema.Field{sf1, sf2}).MustBuild()
+	s2 := schema.New().NewID().Project(pID).Workspace(accountdomain.NewWorkspaceID()).Fields([]*schema.Field{sf1, sf2}).TitleField(sf1.ID().Ref()).MustBuild()
+	schemaPackage1 := schema.NewPackage(s1, nil, nil, nil)
+	schemaPackage2 := schema.NewPackage(s2, nil, nil, nil)
+	model1 := model.New().ID(id.NewModelID()).Metadata(s1.ID().Ref()).Project(pID).Schema(s1.ID()).Key(id.NewKey("mmm123")).UpdatedAt(timeNow).MustBuild()
+	model2 := model.New().ID(id.NewModelID()).Metadata(s2.ID().Ref()).Project(pID).Schema(s2.ID()).Key(id.NewKey("mmm123")).UpdatedAt(timeNow).MustBuild()
+
+	tests := []struct {
+		name string
+		args args
+		want Model
+	}{
+		{
+			name: "success",
+			args: args{
+				m:            model1,
+				sp:           schemaPackage1,
+				lastModified: timeNow,
+			},
+			want: Model{
+				Id:               model1.ID().Ref(),
+				Key:              util.ToPtrIfNotEmpty(model1.Key().String()),
+				Name:             util.ToPtrIfNotEmpty(model1.Name()),
+				Description:      util.ToPtrIfNotEmpty(model1.Description()),
+				Public:           util.ToPtrIfNotEmpty(model1.Public()),
+				ProjectId:        model1.Project().Ref(),
+				SchemaId:         model1.Schema().Ref(),
+				Schema:           util.ToPtrIfNotEmpty(NewSchema(schemaPackage1.Schema())),
+				MetadataSchemaId: model1.Metadata().Ref(),
+				MetadataSchema:   util.ToPtrIfNotEmpty(NewSchema(schemaPackage1.MetaSchema())),
+				CreatedAt:        lo.ToPtr(model1.ID().Timestamp()),
+				UpdatedAt:        lo.ToPtr(model1.UpdatedAt()),
+				LastModified:     util.ToPtrIfNotEmpty(timeNow),
+			},
+		},
+		{
+			name: "success with item field in schema",
+			args: args{
+				m:            model2,
+				sp:           schemaPackage2,
+				lastModified: timeNow,
+			},
+			want: Model{
+				Id:               model2.ID().Ref(),
+				Key:              util.ToPtrIfNotEmpty(model2.Key().String()),
+				Name:             util.ToPtrIfNotEmpty(model2.Name()),
+				Description:      util.ToPtrIfNotEmpty(model2.Description()),
+				Public:           util.ToPtrIfNotEmpty(model2.Public()),
+				ProjectId:        model2.Project().Ref(),
+				SchemaId:         model2.Schema().Ref(),
+				Schema:           util.ToPtrIfNotEmpty(NewSchema(schemaPackage2.Schema())),
+				MetadataSchemaId: model2.Metadata().Ref(),
+				MetadataSchema:   util.ToPtrIfNotEmpty(NewSchema(schemaPackage2.MetaSchema())),
+				CreatedAt:        lo.ToPtr(model2.ID().Timestamp()),
+				UpdatedAt:        lo.ToPtr(model2.UpdatedAt()),
+				LastModified:     util.ToPtrIfNotEmpty(timeNow),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewModel(tt.args.m, tt.args.sp, tt.args.lastModified)
+			if result != tt.want {
+				assert.Equal(t, result, tt.want)
+			}
+		})
+	}
+}
+
+// func TestNewItemFieldChanges(t *testing.T) {
+// 	type args struct {
+// 		change item.FieldChange
+// 	}
+
+// 	tests := []struct{
+// 		name string
+// 		args args
+// 		want  []FieldChange
+// 	}{
+// 		{
+// 			name: "success",
+// 			args: args{
+// 				change:  item.FieldChanges{},
+// 			},
+// 		},
+// 	}
+// }

--- a/server/pkg/integrationapi/schema_test.go
+++ b/server/pkg/integrationapi/schema_test.go
@@ -86,6 +86,7 @@ func TestNewModel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := NewModel(tt.args.m, tt.args.sp, tt.args.lastModified)
 			assert.Equal(t, tt.want, result)
 		})

--- a/server/pkg/item/builder_test.go
+++ b/server/pkg/item/builder_test.go
@@ -219,3 +219,21 @@ func TestBuilder_IsMetadata(t *testing.T) {
 	b := New().IsMetadata(true)
 	assert.Equal(t, true, b.i.isMetadata)
 }
+
+func TestBuilder_UpdatedByUser(t *testing.T) {
+	uId := accountdomain.NewUserID()
+	uuid := New().UpdatedByUser(&uId)
+	assert.Equal(t, &uId, uuid.i.updatedByUser)
+}
+
+func TestBuilder_UpdatedByIntegration(t *testing.T) {
+	iid := id.NewIntegrationID()
+	uuid := New().UpdatedByIntegration(&iid)
+	assert.Equal(t, &iid, uuid.i.updatedByIntegration)
+}
+
+func TestBuilder_OriginalItem(t *testing.T) {
+	iId := id.NewItemID().Ref()
+	b := New().OriginalItem(iId)
+	assert.Equal(t, iId, b.i.originalItem)
+}


### PR DESCRIPTION
# Overview
Increase unit testing coverage in integrationapi and more (tbd) in pkg
## What I've done
added more ut to cover codes in integrationapi packages
## What I haven't done

## How I tested
run UT coverage testing
## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Introduced unit tests for the `integrationapi` package, covering functionality related to operators and events.
	- Added tests for creating models and handling item field changes to ensure accurate processing and structure.
	- Enhanced test coverage for the `Type()` method across multiple entities.
	- Introduced tests for the `NewKeyFromPtr` method to validate key creation from string pointers.
	- Expanded test coverage for the `Builder` struct with new tests for various builder methods.
- **Bug Fixes**
	- Updated the `Type` method of the `View` struct to correctly return "view" instead of "request," ensuring accurate entity categorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->