### PR TITLE
fix(web): preview asset in full screen

### DIFF
--- a/web/e2e/project/asset.spec.ts
+++ b/web/e2e/project/asset.spec.ts
@@ -1,84 +1,128 @@
+import { Page } from "@playwright/test";
+
 import { closeNotification } from "@reearth-cms/e2e/common/notification";
 import { expect, test } from "@reearth-cms/e2e/utils";
 
 import { crudComment } from "./utils/comment";
 import { createProject, deleteProject } from "./utils/project";
 
-const uploadFileUrl =
-  "https://assets.cms.plateau.reearth.io/assets/11/6d05db-ed47-4f88-b565-9eb385b1ebb0/13100_tokyo23-ku_2022_3dtiles%20_1_1_op_bldg_13101_chiyoda-ku_lod1/tileset.json";
-const uploadFileName = "tileset.json";
+const jsonName = "tileset.json";
+const jsonUrl = `https://assets.cms.plateau.reearth.io/assets/11/6d05db-ed47-4f88-b565-9eb385b1ebb0/13100_tokyo23-ku_2022_3dtiles%20_1_1_op_bldg_13101_chiyoda-ku_lod1/${jsonName}`;
+
+const pngName = "road_plan2.png";
+const pngUrl = `https://assets.cms.plateau.reearth.io/assets/33/e999c4-7859-446b-ab3c-86625b3c760e/${pngName}`;
+
+const upload = async (page: Page, url: string) => {
+  await page.getByRole("button", { name: "upload Upload Asset" }).click();
+  await page.getByRole("tab", { name: "URL" }).click();
+  await page.getByPlaceholder("Please input a valid URL").click();
+  await page.getByPlaceholder("Please input a valid URL").fill(url);
+  await page.getByRole("button", { name: "Upload", exact: true }).click();
+  await closeNotification(page);
+};
 
 test.beforeEach(async ({ reearth, page }) => {
   await reearth.goto("/", { waitUntil: "domcontentloaded" });
   await createProject(page);
-
   await page.getByText("Asset").click();
-  await page.getByRole("button", { name: "upload Upload Asset" }).click();
-  await page.getByRole("tab", { name: "URL" }).click();
-  await page.getByPlaceholder("Please input a valid URL").click();
-  await page.getByPlaceholder("Please input a valid URL").fill(uploadFileUrl);
-  await page.getByRole("button", { name: "Upload", exact: true }).click();
-  await closeNotification(page);
-  await expect(page.getByText(uploadFileName)).toBeVisible();
 });
 
 test.afterEach(async ({ page }) => {
   await deleteProject(page);
 });
 
-test("Asset CRUD and Searching has succeeded", async ({ page }) => {
-  await page.getByPlaceholder("input search text").click();
-  await page.getByPlaceholder("input search text").fill("no asset");
-  await page.getByRole("button", { name: "search" }).click();
-  await expect(page.getByText(uploadFileName)).toBeHidden();
-  await page.getByPlaceholder("input search text").click();
-  await page.getByPlaceholder("input search text").fill("");
-  await page.getByRole("button", { name: "search" }).click();
-  await expect(page.getByText(uploadFileName)).toBeVisible();
+test.describe.parallel("Json file tests", () => {
+  test.beforeEach(async ({ page }) => {
+    await upload(page, jsonUrl);
+  });
+
+  test("Asset CRUD and Searching has succeeded", async ({ page }) => {
+    await expect(page.getByText(jsonName)).toBeVisible();
+    await page.getByPlaceholder("input search text").click();
+    await page.getByPlaceholder("input search text").fill("no asset");
+    await page.getByRole("button", { name: "search" }).click();
+    await expect(page.getByText(jsonName)).toBeHidden();
+    await page.getByPlaceholder("input search text").click();
+    await page.getByPlaceholder("input search text").fill("");
+    await page.getByRole("button", { name: "search" }).click();
+    await expect(page.getByText(jsonName)).toBeVisible();
+    await page.getByLabel("edit").locator("svg").click();
+    await expect(page.getByText(`Asset / ${jsonName}`)).toBeVisible();
+    await page.getByLabel("Back").click();
+    await page.getByLabel("", { exact: true }).check();
+    await page.getByText("Delete").click();
+    await expect(page.getByText(jsonName)).toBeHidden();
+    await closeNotification(page);
+  });
+
+  test("Previewing json file by full screen has succeeded", async ({ page }) => {
+    await page.getByLabel("edit").locator("svg").click();
+    await page
+      .locator("div")
+      .filter({ hasText: /^Unknown Type$/ })
+      .nth(1)
+      .click();
+    await page.getByText("GEOJSON/KML/CZML").click();
+    await page.getByRole("button", { name: "Save" }).click();
+    await closeNotification(page);
+    const viewportSizeGet = () => {
+      const viewportSize = page.viewportSize();
+      expect(viewportSize).toBeTruthy();
+      return {
+        width: (viewportSize as { width: number; height: number }).width.toString(),
+        height: (viewportSize as { width: number; height: number }).height.toString(),
+      };
+    };
+    const { width, height } = viewportSizeGet();
+    const canvas = page.locator("canvas");
+    await expect(canvas).not.toHaveAttribute("width", width);
+    await expect(canvas).not.toHaveAttribute("height", height);
+    await page.getByRole("button", { name: "fullscreen" }).click();
+    await expect(canvas).toHaveAttribute("width", width);
+    await expect(canvas).toHaveAttribute("height", height);
+    await page.goBack();
+  });
+
+  test("Donwloading asset has succeeded", async ({ page }) => {
+    await page.getByLabel("", { exact: true }).check();
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "download Download" }).click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toEqual(jsonName);
+
+    await page.getByLabel("edit").locator("svg").click();
+    const download1Promise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "download Download" }).click();
+    const download1 = await download1Promise;
+    expect(download1.suggestedFilename()).toEqual(jsonName);
+
+    await page.getByLabel("Back").click();
+    await page.getByLabel("", { exact: true }).check();
+    await page.getByText("Delete").click();
+    await closeNotification(page);
+  });
+
+  test("Comment CRUD on edit page has succeeded", async ({ page }) => {
+    await page.getByRole("cell", { name: "edit" }).locator("svg").click();
+    await page.getByLabel("comment").click();
+    await expect(page.getByText("Comments0 / 1000Comment")).toBeVisible();
+    await crudComment(page);
+  });
+
+  test("Comment CRUD on Asset page has succeeded", async ({ page }) => {
+    await page.getByRole("button", { name: "0" }).click();
+    await expect(page.getByText("CommentsNo comments.0 / 1000Comment")).toBeVisible();
+    await crudComment(page);
+  });
+});
+
+test("Previewing png file on modal has succeeded", async ({ page }) => {
+  await upload(page, pngUrl);
   await page.getByLabel("edit").locator("svg").click();
-  await page
-    .locator("div")
-    .filter({ hasText: /^Unknown Type$/ })
-    .nth(1)
-    .click();
-  await page.getByText("GEOJSON/KML/CZML").click();
-  await page.getByRole("button", { name: "Save" }).click();
-  await closeNotification(page);
-  await page.getByLabel("Back").click();
-  await page.getByLabel("", { exact: true }).check();
-  await page.getByText("Delete").click();
-  await expect(page.getByText(uploadFileName)).toBeHidden();
-  await closeNotification(page);
-});
-
-test("Donwloading asset has succeeded", async ({ page }) => {
-  await page.getByLabel("", { exact: true }).check();
-  const downloadPromise = page.waitForEvent("download");
-  await page.getByRole("button", { name: "download Download" }).click();
-  const download = await downloadPromise;
-  expect(download.suggestedFilename()).toEqual(uploadFileName);
-
-  await page.getByLabel("edit").locator("svg").click();
-  const download1Promise = page.waitForEvent("download");
-  await page.getByRole("button", { name: "download Download" }).click();
-  const download1 = await download1Promise;
-  expect(download1.suggestedFilename()).toEqual(uploadFileName);
-
-  await page.getByLabel("Back").click();
-  await page.getByLabel("", { exact: true }).check();
-  await page.getByText("Delete").click();
-  await closeNotification(page);
-});
-
-test("Comment CRUD on edit page has succeeded", async ({ page }) => {
-  await page.getByRole("cell", { name: "edit" }).locator("svg").click();
-  await page.getByLabel("comment").click();
-  await expect(page.getByText("Comments0 / 1000Comment")).toBeVisible();
-  await crudComment(page);
-});
-
-test("Comment CRUD on Asset page has succeeded", async ({ page }) => {
-  await page.getByRole("button", { name: "0" }).click();
-  await expect(page.getByText("CommentsNo comments.0 / 1000Comment")).toBeVisible();
-  await crudComment(page);
+  await expect(page.getByText("Asset TypePNG/JPEG/TIFF/GIF")).toBeVisible();
+  await page.getByRole("button", { name: "fullscreen" }).click();
+  await expect(page.getByRole("img", { name: "asset-preview" })).toBeVisible();
+  // eslint-disable-next-line playwright/no-wait-for-timeout
+  await page.waitForTimeout(150);
+  await page.getByLabel("Close", { exact: true }).click();
 });

--- a/web/e2e/project/asset.spec.ts
+++ b/web/e2e/project/asset.spec.ts
@@ -83,7 +83,7 @@ test.describe.parallel("Json file tests", () => {
     await page.goBack();
   });
 
-  test("Donwloading asset has succeeded", async ({ page }) => {
+  test("Downloading asset has succeeded", async ({ page }) => {
     await page.getByLabel("", { exact: true }).check();
     const downloadPromise = page.waitForEvent("download");
     await page.getByRole("button", { name: "download Download" }).click();

--- a/web/src/components/atoms/ResiumViewer/index.tsx
+++ b/web/src/components/atoms/ResiumViewer/index.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { Cesium3DTileFeature, Viewer as CesiumViewer, JulianDate, Entity } from "cesium";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CesiumComponentRef, CesiumMovementEvent, RootEventTarget, Viewer } from "resium";
+import { CesiumMovementEvent, RootEventTarget, Viewer } from "resium";
 
 import InfoBox from "@reearth-cms/components/molecules/Asset/InfoBox";
 import { Property } from "@reearth-cms/components/molecules/Asset/Viewers/MvtViewer/Imagery";
@@ -27,7 +27,6 @@ const ResiumViewer: React.FC<Props> = ({
   onSelect,
   workspaceSettings,
 }) => {
-  const viewer = useRef<CesiumComponentRef<CesiumViewer>>(null);
   const [properties, setProperties] = useState<Property>();
   const [infoBoxVisibility, setInfoBoxVisibility] = useState(false);
   const [title, setTitle] = useState("");
@@ -81,12 +80,6 @@ const ResiumViewer: React.FC<Props> = ({
   }, []);
 
   useEffect(() => {
-    if (viewer.current) {
-      onGetViewer(viewer.current?.cesiumElement);
-    }
-  }, [onGetViewer]);
-
-  useEffect(() => {
     if (passedProps) {
       setSortedProperties(passedProps);
       setInfoBoxVisibility(true);
@@ -124,7 +117,7 @@ const ResiumViewer: React.FC<Props> = ({
         shouldAnimate={true}
         onClick={handleClick}
         infoBox={false}
-        ref={viewer}>
+        ref={node => onGetViewer(node?.cesiumElement)}>
         {children}
       </StyledViewer>
       <InfoBox

--- a/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
@@ -48,10 +48,9 @@ type Props = {
   onModalCancel: () => void;
   onTypeChange: (value: PreviewType) => void;
   onChangeToFullScreen: () => void;
+  onGetViewer: (viewer?: CesiumViewer) => void;
   workspaceSettings: WorkspaceSettings;
 };
-
-export let viewerRef: CesiumViewer | undefined;
 
 const AssetMolecule: React.FC<Props> = ({
   asset,
@@ -67,6 +66,7 @@ const AssetMolecule: React.FC<Props> = ({
   onTypeChange,
   onModalCancel,
   onChangeToFullScreen,
+  onGetViewer,
   workspaceSettings,
 }) => {
   const t = useT();
@@ -75,10 +75,6 @@ const AssetMolecule: React.FC<Props> = ({
   const assetBaseUrl = asset.url.slice(0, asset.url.lastIndexOf("/"));
   const formattedCreatedAt = dateTimeFormat(asset.createdAt);
 
-  const getViewer = (viewer?: CesiumViewer) => {
-    viewerRef = viewer;
-  };
-
   const renderPreview = useCallback(() => {
     switch (viewerType) {
       case "geo":
@@ -86,7 +82,7 @@ const AssetMolecule: React.FC<Props> = ({
           <GeoViewer
             url={assetUrl}
             assetFileExt={assetFileExt}
-            onGetViewer={getViewer}
+            onGetViewer={onGetViewer}
             workspaceSettings={workspaceSettings}
           />
         );
@@ -95,13 +91,17 @@ const AssetMolecule: React.FC<Props> = ({
           <Geo3dViewer
             url={assetUrl}
             setAssetUrl={setAssetUrl}
-            onGetViewer={getViewer}
+            onGetViewer={onGetViewer}
             workspaceSettings={workspaceSettings}
           />
         );
       case "geo_mvt":
         return (
-          <MvtViewer url={assetUrl} onGetViewer={getViewer} workspaceSettings={workspaceSettings} />
+          <MvtViewer
+            url={assetUrl}
+            onGetViewer={onGetViewer}
+            workspaceSettings={workspaceSettings}
+          />
         );
       case "image":
         return <ImageViewer url={assetUrl} />;
@@ -111,19 +111,23 @@ const AssetMolecule: React.FC<Props> = ({
         return (
           <GltfViewer
             url={assetUrl}
-            onGetViewer={getViewer}
+            onGetViewer={onGetViewer}
             workspaceSettings={workspaceSettings}
           />
         );
       case "csv":
         return (
-          <CsvViewer url={assetUrl} onGetViewer={getViewer} workspaceSettings={workspaceSettings} />
+          <CsvViewer
+            url={assetUrl}
+            onGetViewer={onGetViewer}
+            workspaceSettings={workspaceSettings}
+          />
         );
       case "unknown":
       default:
         return <ViewerNotSupported />;
     }
-  }, [assetFileExt, assetUrl, svgRender, viewerType, workspaceSettings]);
+  }, [assetFileExt, assetUrl, onGetViewer, svgRender, viewerType, workspaceSettings]);
 
   return (
     <BodyContainer>

--- a/web/src/components/molecules/Asset/Asset/AssetBody/index.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/index.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { Viewer as CesiumViewer } from "cesium";
 
 import Button from "@reearth-cms/components/atoms/Button";
 import ComplexInnerContents from "@reearth-cms/components/atoms/InnerContents/complex";
@@ -29,6 +30,7 @@ type Props = {
   onChangeToFullScreen: () => void;
   onBack: () => void;
   onSave: () => void;
+  onGetViewer: (viewer?: CesiumViewer) => void;
   workspaceSettings: WorkspaceSettings;
 };
 
@@ -51,6 +53,7 @@ const AssetWrapper: React.FC<Props> = ({
   onChangeToFullScreen,
   onBack,
   onSave,
+  onGetViewer,
   workspaceSettings,
 }) => {
   const t = useT();
@@ -82,6 +85,7 @@ const AssetWrapper: React.FC<Props> = ({
             onTypeChange={onTypeChange}
             onModalCancel={onModalCancel}
             onChangeToFullScreen={onChangeToFullScreen}
+            onGetViewer={onGetViewer}
             workspaceSettings={workspaceSettings}
           />
         </Wrapper>

--- a/web/src/components/organisms/Project/Asset/Asset/hooks.ts
+++ b/web/src/components/organisms/Project/Asset/Asset/hooks.ts
@@ -1,9 +1,8 @@
-import { Ion } from "cesium";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Ion, Viewer as CesiumViewer } from "cesium";
+import { useCallback, useEffect, useMemo, useState, useRef } from "react";
 import { useNavigate, useParams, useLocation } from "react-router-dom";
 
 import Notification from "@reearth-cms/components/atoms/Notification";
-import { viewerRef } from "@reearth-cms/components/molecules/Asset/Asset/AssetBody/Asset";
 import {
   Asset,
   AssetItem,
@@ -183,6 +182,12 @@ export default (assetId?: string) => {
     [assetFileExt],
   );
 
+  const viewerRef = useRef<CesiumViewer>();
+
+  const handleGetViewer = (viewer?: CesiumViewer) => {
+    viewerRef.current = viewer;
+  };
+
   const handleFullScreen = useCallback(() => {
     if (
       viewerType === "geo" ||
@@ -190,7 +195,7 @@ export default (assetId?: string) => {
       viewerType === "model_3d" ||
       viewerType === "geo_mvt"
     ) {
-      viewerRef?.canvas.requestFullscreen();
+      viewerRef.current?.canvas.requestFullscreen();
     } else if (viewerType === "image" || viewerType === "image_svg") {
       setIsModalVisible(true);
     }
@@ -256,5 +261,6 @@ export default (assetId?: string) => {
     handleFullScreen,
     handleSave,
     handleBack,
+    handleGetViewer,
   };
 };

--- a/web/src/components/organisms/Project/Asset/Asset/index.tsx
+++ b/web/src/components/organisms/Project/Asset/Asset/index.tsx
@@ -30,6 +30,7 @@ const Asset: React.FC = () => {
     handleFullScreen,
     handleBack,
     handleSave,
+    handleGetViewer,
   } = useHooks(assetId);
 
   const { workspaceSettings } = useSettingsHooks();
@@ -64,6 +65,7 @@ const Asset: React.FC = () => {
       onChangeToFullScreen={handleFullScreen}
       onBack={handleBack}
       onSave={handleSave}
+      onGetViewer={handleGetViewer}
       workspaceSettings={workspaceSettings}
     />
   );


### PR DESCRIPTION
# Overview
This PR fixes the bug that the full screen button on Asset edit page doesn’t work when the asset is not an image file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced asset upload handling with improved test coverage for JSON and PNG files.
  - Introduced a callback mechanism for managing viewer instances in the Asset components.
  
- **Bug Fixes**
  - Streamlined fullscreen functionality for the Cesium viewer to ensure proper operation.

- **Refactor**
  - Reorganized test structure for better maintainability and readability.
  - Removed global viewer references in favor of a callback approach.

- **Documentation**
  - Updated prop types to reflect new viewer management capabilities across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->