### PR TITLE
fix(web): avoid redundant queries for unchanged reviewers

### DIFF
--- a/web/e2e/project/request.spec.ts
+++ b/web/e2e/project/request.spec.ts
@@ -45,7 +45,6 @@ test("Request creating, searching, updating reviewer, and approving has succeede
   await page.locator(".ant-select-selection-overflow").click();
   await page.locator(".ant-select-item").click();
   await page.getByRole("heading", { name: "Reviewer" }).click();
-  await closeNotification(page);
   await page.getByRole("button", { name: "Approve" }).click();
   await closeNotification(page);
   await expect(page.locator("tbody").getByText(requestTitle, { exact: true })).toBeHidden();

--- a/web/src/components/molecules/Request/Details/SidebarWrapper.tsx
+++ b/web/src/components/molecules/Request/Details/SidebarWrapper.tsx
@@ -54,7 +54,9 @@ const RequestSidebarWrapper: React.FC<Props> = ({
 
   const handleSubmit: FocusEventHandler<HTMLElement> | undefined = useCallback(async () => {
     const requestId = currentRequest?.id;
-    if (!requestId || selectedReviewers.length === 0) {
+    const isEqual =
+      JSON.stringify([...defaultValue].sort()) === JSON.stringify([...selectedReviewers].sort());
+    if (!requestId || selectedReviewers.length === 0 || isEqual) {
       hideViewReviewers();
       return;
     }
@@ -77,6 +79,7 @@ const RequestSidebarWrapper: React.FC<Props> = ({
     currentRequest?.id,
     currentRequest?.state,
     currentRequest?.title,
+    defaultValue,
     hideViewReviewers,
     onRequestUpdate,
     selectedReviewers,

--- a/web/src/components/organisms/Project/Content/ContentDetails/hooks.ts
+++ b/web/src/components/organisms/Project/Content/ContentDetails/hooks.ts
@@ -10,11 +10,7 @@ import {
   ItemField,
 } from "@reearth-cms/components/molecules/Content/types";
 import { Model } from "@reearth-cms/components/molecules/Model/types";
-import {
-  RequestUpdatePayload,
-  RequestState,
-  RequestItem,
-} from "@reearth-cms/components/molecules/Request/types";
+import { RequestState, RequestItem } from "@reearth-cms/components/molecules/Request/types";
 import { Group, Field } from "@reearth-cms/components/molecules/Schema/types";
 import { UserMember } from "@reearth-cms/components/molecules/Workspace/types";
 import { fromGraphQLItem } from "@reearth-cms/components/organisms/DataConverters/content";
@@ -32,7 +28,6 @@ import {
   useGetModelLazyQuery,
   useGetMeQuery,
   useUpdateItemMutation,
-  useUpdateRequestMutation,
   useSearchItemQuery,
   useGetGroupLazyQuery,
   FieldType as GQLFieldType,
@@ -532,32 +527,6 @@ export default () => {
     [createRequestMutation, currentProject?.id, t],
   );
 
-  const [updateRequestMutation, { loading: updateRequestLoading }] = useUpdateRequestMutation({
-    refetchQueries: ["GetRequests"],
-  });
-
-  const handleRequestUpdate = useCallback(
-    async (data: RequestUpdatePayload) => {
-      if (!data.requestId) return;
-      const request = await updateRequestMutation({
-        variables: {
-          requestId: data.requestId,
-          title: data.title,
-          description: data.description,
-          state: data.state as GQLRequestState,
-          reviewersId: data.reviewersId,
-          items: data.items,
-        },
-      });
-      if (request.errors || !request.data?.updateRequest) {
-        Notification.error({ message: t("Failed to update request.") });
-        return;
-      }
-      Notification.success({ message: t("Successfully updated request!") });
-      setRequestModalShown(false);
-    },
-    [updateRequestMutation, t],
-  );
   const handleModalClose = useCallback(() => setRequestModalShown(false), []);
 
   const handleModalOpen = useCallback(() => setRequestModalShown(true), []);
@@ -649,8 +618,6 @@ export default () => {
     handleNavigateToRequest,
     handleBack,
     handleRequestCreate,
-    updateRequestLoading,
-    handleRequestUpdate,
     handleModalClose,
     handleModalOpen,
     handleAddItemToRequestModalClose,

--- a/web/src/components/organisms/Project/Request/RequestDetails/hooks.ts
+++ b/web/src/components/organisms/Project/Request/RequestDetails/hooks.ts
@@ -98,9 +98,7 @@ export default () => {
     [currentRequest?.createdBy?.id, currentRequest?.state, me?.id, userRights?.request.update],
   );
 
-  const [updateRequestMutation, { loading: updateRequestLoading }] = useUpdateRequestMutation({
-    refetchQueries: ["GetRequest"],
-  });
+  const [updateRequestMutation, { loading: updateRequestLoading }] = useUpdateRequestMutation();
 
   const handleRequestUpdate = useCallback(
     async (data: RequestUpdatePayload) => {

--- a/web/src/components/organisms/Project/Request/RequestDetails/index.tsx
+++ b/web/src/components/organisms/Project/Request/RequestDetails/index.tsx
@@ -16,8 +16,10 @@ const RequestDetails: React.FC = () => {
     isAssignActionEnabled,
     currentRequest,
     loading,
+    updateRequestLoading,
     deleteLoading,
     approveLoading,
+    handleRequestUpdate,
     handleRequestApprove,
     handleRequestDelete,
     handleCommentCreate,
@@ -29,8 +31,7 @@ const RequestDetails: React.FC = () => {
 
   const { handleGetAsset } = useAssetHooks(false);
 
-  const { workspaceUserMembers, updateRequestLoading, handleRequestUpdate, handleGroupGet } =
-    useContentHooks();
+  const { workspaceUserMembers, handleGroupGet } = useContentHooks();
 
   return (
     <RequestDetailsMolecule


### PR DESCRIPTION
# Overview
This PR fixes to not throw a query if the new reviewers are the same as before.

## What I've done
- Refactoring
- Removing unnecessary refetch queries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced functionality to update requests, including error handling and notifications for success and failure.
  
- **Improvements**
  - Enhanced notification handling during request operations to improve test clarity.
  - Streamlined request management by removing unnecessary update capabilities in some components.

- **Bug Fixes**
  - Fixed control flow to prevent submission of unchanged reviewer selections.

- **Documentation**
  - Updated component props to reflect new loading states for request updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->