### PR TITLE
fix(web): disable use as title in meta text field

### DIFF
--- a/web/e2e/project/item/fields/geometryObject.spec.ts
+++ b/web/e2e/project/item/fields/geometryObject.spec.ts
@@ -94,6 +94,7 @@ test("GeometryObject field editing has succeeded", async ({ page }) => {
   await page.getByLabel("Description(optional)").click();
   await page.getByLabel("Description(optional)").fill("new geometryObject1 description");
   await page.getByLabel("Support multiple values").check();
+  await expect(page.getByLabel("Use as title")).toBeHidden();
   await page.getByRole("tab", { name: "Validation" }).click();
   await page.getByLabel("Make field required").check();
   await page.getByLabel("Set field as unique").check();

--- a/web/e2e/project/item/fields/group.spec.ts
+++ b/web/e2e/project/item/fields/group.spec.ts
@@ -206,6 +206,7 @@ test("Group field editing has succeeded", async ({ page }) => {
   await page.getByLabel("Description(optional)").click();
   await page.getByLabel("Description(optional)").fill("new group1 description");
   await page.getByLabel("Support multiple values").check();
+  await expect(page.getByLabel("Use as title")).toBeHidden();
   await page.getByRole("button", { name: "OK" }).click();
   await closeNotification(page);
   await page.getByText("Content").click();

--- a/web/e2e/project/item/fields/group.spec.ts
+++ b/web/e2e/project/item/fields/group.spec.ts
@@ -75,6 +75,7 @@ test("Group field creating and updating has succeeded", async ({ page }) => {
   await page.getByRole("button", { name: "Save" }).click();
   await closeNotification(page);
   await page.locator("span").filter({ hasText: "Schema" }).click();
+  await page.getByRole("tab", { name: "Meta Data" }).click();
   await page.getByRole("menuitem", { name: "e2e group name" }).locator("span").click();
   await page.getByRole("img", { name: "ellipsis" }).locator("svg").click();
   await page.getByLabel("Display name").click();

--- a/web/e2e/project/item/fields/reference.spec.ts
+++ b/web/e2e/project/item/fields/reference.spec.ts
@@ -69,6 +69,7 @@ test("One-way reference field creating and updating has succeeded", async ({ pag
   await expect(
     page.locator("label").filter({ hasText: "Support multiple values" }).locator("span").nth(1),
   ).toBeDisabled();
+  await expect(page.getByLabel("Use as title")).toBeHidden();
   await page.getByRole("tab", { name: "Validation" }).click();
   await page.getByLabel("Make field required").check();
   await page.getByLabel("Set field as unique").check();
@@ -187,6 +188,7 @@ test("Two-way reference field editing has succeeded", async ({ page }) => {
   await expect(
     page.locator("label").filter({ hasText: "Support multiple values" }).locator("span").nth(1),
   ).toBeDisabled();
+  await expect(page.getByLabel("Use as title")).toBeHidden();
   await page.getByRole("tab", { name: "Validation" }).click();
   await page.getByLabel("Make field required").check();
   await expect(

--- a/web/e2e/project/item/metadata/boolean.spec.ts
+++ b/web/e2e/project/item/metadata/boolean.spec.ts
@@ -34,6 +34,7 @@ test("Boolean metadata creating and updating has succeeded", async ({ page }) =>
     "boolean1 description",
   );
   await expect(page.getByLabel("Support multiple values")).not.toBeChecked();
+  await expect(page.getByLabel("Use as title")).toBeHidden();
   await page.getByRole("tab", { name: "Validation" }).click();
   await expect(page.getByLabel("Make field required")).toBeDisabled();
   await expect(page.getByLabel("Set field as unique")).toBeDisabled();

--- a/web/e2e/project/item/metadata/checkbox.spec.ts
+++ b/web/e2e/project/item/metadata/checkbox.spec.ts
@@ -34,6 +34,7 @@ test("Checkbox metadata creating and updating has succeeded", async ({ page }) =
     "checkbox1 description",
   );
   await expect(page.getByLabel("Support multiple values")).not.toBeChecked();
+  await expect(page.getByLabel("Use as title")).toBeHidden();
   await page.getByRole("tab", { name: "Validation" }).click();
   await expect(page.getByLabel("Make field required")).toBeDisabled();
   await expect(page.getByLabel("Set field as unique")).toBeDisabled();

--- a/web/e2e/project/item/metadata/date.spec.ts
+++ b/web/e2e/project/item/metadata/date.spec.ts
@@ -34,6 +34,7 @@ test("Date metadata creating and updating has succeeded", async ({ page }) => {
     "date1 description",
   );
   await expect(page.getByLabel("Support multiple values")).not.toBeChecked();
+  await expect(page.getByLabel("Use as title")).toBeHidden();
   await page.getByRole("tab", { name: "Validation" }).click();
   await expect(page.getByLabel("Make field required")).not.toBeChecked();
   await expect(page.getByLabel("Set field as unique")).not.toBeChecked();

--- a/web/e2e/project/item/metadata/tag.spec.ts
+++ b/web/e2e/project/item/metadata/tag.spec.ts
@@ -46,6 +46,7 @@ test("Tag metadata creating and updating has succeeded", async ({ page }) => {
   await expect(page.getByText("Tag1", { exact: true })).toBeVisible();
   await expect(page.getByText("Tag2")).toBeVisible();
   await expect(page.getByLabel("Support multiple values")).not.toBeChecked();
+  await expect(page.getByLabel("Use as title")).toBeHidden();
   await page.getByRole("tab", { name: "Validation" }).click();
   await expect(page.getByLabel("Make field required")).not.toBeChecked();
   await expect(page.getByLabel("Set field as unique")).not.toBeChecked();

--- a/web/e2e/project/item/metadata/text.spec.ts
+++ b/web/e2e/project/item/metadata/text.spec.ts
@@ -35,6 +35,7 @@ test("Text metadata creating and updating has succeeded", async ({ page }) => {
     "text1 description",
   );
   await expect(page.getByLabel("Support multiple values")).not.toBeChecked();
+  await expect(page.getByLabel("Use as title")).toBeHidden();
   await page.getByRole("tab", { name: "Validation" }).click();
   await expect(page.getByLabel("Set maximum length")).toBeEmpty();
   await expect(page.getByLabel("Make field required")).not.toBeChecked();

--- a/web/e2e/project/item/metadata/url.spec.ts
+++ b/web/e2e/project/item/metadata/url.spec.ts
@@ -33,6 +33,7 @@ test("Url metadata creating and updating has succeeded", async ({ page }) => {
   await expect(page.getByLabel("Settings").locator("#key")).toHaveValue("url1");
   await expect(page.getByLabel("Settings").locator("#description")).toHaveValue("url1 description");
   await expect(page.getByLabel("Support multiple values")).not.toBeChecked();
+  await expect(page.getByLabel("Use as title")).toBeHidden();
   await page.getByRole("tab", { name: "Validation" }).click();
   await expect(page.getByLabel("Make field required")).not.toBeChecked();
   await expect(page.getByLabel("Set field as unique")).not.toBeChecked();

--- a/web/src/components/molecules/Schema/FieldModal/hooks.ts
+++ b/web/src/components/molecules/Schema/FieldModal/hooks.ts
@@ -16,11 +16,13 @@ import {
   FormTypes,
   ObjectSupportedType,
   EditorSupportedType,
+  SelectedSchemaType,
 } from "@reearth-cms/components/molecules/Schema/types";
 import { transformDayjsToString } from "@reearth-cms/utils/format";
 import { validateKey } from "@reearth-cms/utils/regex";
 
 export default (
+  selectedSchemaType: SelectedSchemaType,
   selectedType: FieldType,
   isMeta: boolean,
   selectedField: Field | null,
@@ -337,8 +339,9 @@ export default (
 
   const isTitleDisabled = useMemo(
     () =>
+      (selectedSchemaType === "model" && isMeta) ||
       !(selectedType === "Text" || selectedType === "TextArea" || selectedType === "MarkdownText"),
-    [selectedType],
+    [isMeta, selectedSchemaType, selectedType],
   );
 
   const ObjectSupportType = useMemo(

--- a/web/src/components/molecules/Schema/FieldModal/index.tsx
+++ b/web/src/components/molecules/Schema/FieldModal/index.tsx
@@ -25,6 +25,7 @@ import {
   Group,
   FormValues,
   Tag,
+  SelectedSchemaType,
 } from "@reearth-cms/components/molecules/Schema/types";
 import { useT } from "@reearth-cms/i18n";
 import { MAX_KEY_LENGTH } from "@reearth-cms/utils/regex";
@@ -34,6 +35,7 @@ import useHooks from "./hooks";
 type Props = {
   groups?: Group[];
   selectedType: FieldType;
+  selectedSchemaType: SelectedSchemaType;
   isMeta: boolean;
   open: boolean;
   fieldLoading: boolean;
@@ -85,6 +87,7 @@ const FieldModal: React.FC<Props> = ({
   groups,
   open,
   isMeta,
+  selectedSchemaType,
   fieldLoading,
   selectedType,
   selectedField,
@@ -143,7 +146,16 @@ const FieldModal: React.FC<Props> = ({
     emptyValidator,
     duplicatedValidator,
     errorIndexes,
-  } = useHooks(selectedType, isMeta, selectedField, open, onClose, onSubmit, handleFieldKeyUnique);
+  } = useHooks(
+    selectedSchemaType,
+    selectedType,
+    isMeta,
+    selectedField,
+    open,
+    onClose,
+    onSubmit,
+    handleFieldKeyUnique,
+  );
 
   const requiredMark = (label: React.ReactNode, { required }: { required: boolean }) => (
     <>

--- a/web/src/components/organisms/Project/Schema/index.tsx
+++ b/web/src/components/organisms/Project/Schema/index.tsx
@@ -147,6 +147,7 @@ const ProjectSchema: React.FC = () => {
         <FieldModal
           groups={groups}
           selectedType={selectedType}
+          selectedSchemaType={selectedSchemaType}
           isMeta={isMeta}
           open={fieldModalShown}
           fieldLoading={selectedField ? fieldUpdateLoading : fieldCreationLoading}


### PR DESCRIPTION
# Overview
This PR fixes to disable use as title in meta text field.

## What I've done
- Hiding use as title button in meta text field
- Enhancing e2e tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced validation in the UI for various metadata fields, ensuring the "Use as title" label is hidden during creation and editing processes.
	- Added a new parameter, `selectedSchemaType`, to the FieldModal component, allowing for more dynamic behavior based on the selected schema type.

- **Bug Fixes**
	- Improved test coverage for geometry, group, reference, boolean, checkbox, date, tag, text, and URL metadata fields by ensuring the correct visibility of UI elements.

- **Documentation**
	- Updated prop definitions in the FieldModal component to include `selectedSchemaType`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->