### PR TITLE
fix(web): styling of metadata column width

### DIFF
--- a/web/src/components/molecules/Content/Form/index.tsx
+++ b/web/src/components/molecules/Content/Form/index.tsx
@@ -737,9 +737,10 @@ const FormItemsWrapper = styled.div`
 const SideBarWrapper = styled.div`
   background-color: #fafafa;
   padding: 8px;
-  min-width: 272px;
+  width: 272px;
   max-height: 100%;
   overflow-y: auto;
+  overflow-wrap: break-word;
 `;
 
 const MetaFormItemWrapper = styled.div`


### PR DESCRIPTION
# Overview
This PR fixes the styling of metadata column width.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the sidebar width to a fixed size of 272px for consistency.
	- Enhanced text wrapping behavior in the sidebar to improve layout with long words or URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->