### PR TITLE
chore(server): implement mongo git save many

### DIFF
--- a/server/internal/infrastructure/mongo/item.go
+++ b/server/internal/infrastructure/mongo/item.go
@@ -240,7 +240,7 @@ func (r *Item) SaveAll(ctx context.Context, items item.List) error {
 		}
 	}
 	docs, ids := mongodoc.NewItems(items)
-	return r.client.SaveAll(ctx, ids, lo.ToAnySlice(docs), nil)
+	return r.client.SaveMany(ctx, ids, lo.ToAnySlice(docs))
 }
 
 func (r *Item) UpdateRef(ctx context.Context, item id.ItemID, ref version.Ref, vr *version.VersionOrRef) error {

--- a/server/internal/infrastructure/mongo/mongogit/collection.go
+++ b/server/internal/infrastructure/mongo/mongogit/collection.go
@@ -218,13 +218,18 @@ func (c *Collection) IsArchived(ctx context.Context, filter any) (bool, error) {
 		metaKey: true,
 	})
 
-	if err := c.client.FindOne(ctx, q, &cons); err != nil {
+	if err := c.client.Find(ctx, q, &cons); err != nil {
 		if errors.Is(err, rerror.ErrNotFound) || err == io.EOF {
 			return false, nil
 		}
 		return false, err
 	}
-	return cons.Result[0].Archived, nil
+	for _, m := range cons.Result {
+		if m.Archived {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (c *Collection) ArchiveOne(ctx context.Context, filter bson.M, archived bool) error {

--- a/server/internal/infrastructure/mongo/mongogit/collection_test.go
+++ b/server/internal/infrastructure/mongo/mongogit/collection_test.go
@@ -606,7 +606,7 @@ func TestCollection_DeleteRef(t *testing.T) {
 	assert.NoError(t, col.DeleteRef(ctx, []string{"x", "y"}, "a"))
 	got := c.FindOne(ctx, bson.M{"id": "x", versionKey: v1})
 	assert.NoError(t, got.Decode(&meta))
-	assert.Equal(t, Meta{ObjectID: meta.ObjectID, Version: v1, Refs: []version.Ref{"a", "b"}}, meta)
+	assert.Equal(t, Meta{ObjectID: meta.ObjectID, Version: v1, Refs: []version.Ref{"b"}}, meta)
 
 	got = c.FindOne(ctx, bson.M{"id": "x", versionKey: v2})
 	assert.NoError(t, got.Decode(&meta))

--- a/server/internal/infrastructure/mongo/mongogit/collection_test.go
+++ b/server/internal/infrastructure/mongo/mongogit/collection_test.go
@@ -530,6 +530,94 @@ func TestCollection_SaveOne(t *testing.T) {
 	assert.Same(t, rerror.ErrNotFound, col.SaveOne(ctx, "x", Data{}, version.New().OrRef().Ref()))
 }
 
+func TestCollection_SaveAll(t *testing.T) {
+	ctx := context.Background()
+	col := initCollection(t)
+	c := col.Client().Client()
+
+	type Data struct {
+		ID string
+		A  string
+	}
+	var data Data
+
+	// first
+	assert.NoError(t, col.SaveMany(ctx, []string{"x"}, []any{Data{ID: "x", A: "aaa"}}))
+
+	cur := c.FindOne(ctx, bson.M{"id": "x"})
+	meta1 := Meta{}
+	assert.NoError(t, cur.Decode(&meta1))
+	assert.Equal(t, Meta{
+		ObjectID: meta1.ObjectID,
+		Version:  meta1.Version,
+		Refs:     []version.Ref{version.Latest},
+	}, meta1)
+	assert.NoError(t, cur.Decode(&data))
+	assert.Equal(t, Data{ID: "x", A: "aaa"}, data)
+
+	// next version
+	assert.NoError(t, col.SaveMany(ctx, []string{"x"}, []any{Data{ID: "x", A: "bbb"}}))
+
+	cur = c.FindOne(ctx, bson.M{"id": "x", refsKey: bson.M{"$in": []string{"latest"}}})
+	meta2 := Meta{}
+	assert.NoError(t, cur.Decode(&meta2))
+	assert.Equal(t, Meta{
+		ObjectID: meta2.ObjectID,
+		Version:  meta2.Version,
+		Parents:  []version.Version{meta1.Version},
+		Refs:     []version.Ref{version.Latest},
+	}, meta2)
+	data2 := Data{}
+	assert.NoError(t, cur.Decode(&data2))
+	assert.Equal(t, Data{ID: "x", A: "bbb"}, data2)
+
+	cur = c.FindOne(ctx, bson.M{"id": "x", versionKey: meta1.Version})
+	meta3 := Meta{}
+	assert.NoError(t, cur.Decode(&meta3))
+	assert.Equal(t, Meta{
+		ObjectID: meta3.ObjectID,
+		Version:  meta1.Version,
+		Refs:     []version.Ref{}, // latest ref should be deleted
+	}, meta3)
+	data3 := Data{}
+	assert.NoError(t, cur.Decode(&data3))
+	assert.Equal(t, Data{ID: "x", A: "aaa"}, data3)
+
+	// should fail when there is an archived doc
+	assert.NoError(t, col.ArchiveOne(ctx, bson.M{"id": "x"}, true))
+	assert.ErrorIs(t, col.SaveMany(ctx, []string{"x"}, []any{Data{ID: "x", A: "ccc"}}), version.ErrArchived)
+}
+
+func TestCollection_DeleteRef(t *testing.T) {
+	ctx := context.Background()
+	col := initCollection(t)
+	c := col.Client().Client()
+
+	v1, v2, v3 := version.New(), version.New(), version.New()
+	_, _ = c.InsertMany(ctx, []any{
+		bson.M{"id": "x", versionKey: v1, refsKey: []string{"a", "b"}},
+		bson.M{"id": "x", versionKey: v2, refsKey: []string{"a", "b", "c"}},
+		bson.M{"id": "y", versionKey: v3, refsKey: []string{"a", "d"}},
+	})
+
+	var meta Meta
+
+	// delete a ref
+	assert.NoError(t, col.DeleteRef(ctx, []string{"x", "y"}, "a"))
+	got := c.FindOne(ctx, bson.M{"id": "x", versionKey: v1})
+	assert.NoError(t, got.Decode(&meta))
+	assert.Equal(t, Meta{ObjectID: meta.ObjectID, Version: v1, Refs: []version.Ref{"a", "b"}}, meta)
+
+	got = c.FindOne(ctx, bson.M{"id": "x", versionKey: v2})
+	assert.NoError(t, got.Decode(&meta))
+	assert.Equal(t, Meta{ObjectID: meta.ObjectID, Version: v2, Refs: []version.Ref{"b", "c"}}, meta)
+
+	got = c.FindOne(ctx, bson.M{"id": "y", versionKey: v3})
+	assert.NoError(t, got.Decode(&meta))
+	assert.Equal(t, Meta{ObjectID: meta.ObjectID, Version: v3, Refs: []version.Ref{"d"}}, meta)
+
+}
+
 func TestCollection_UpdateRef(t *testing.T) {
 	ctx := context.Background()
 	col := initCollection(t)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for saving multiple documents at once, enhancing bulk operations.
	- Added functionality to manage document references more efficiently, including the ability to delete references for multiple IDs.
- **Bug Fixes**
	- Improved error handling when saving archived documents.
- **Tests**
	- Added tests to validate the new saving functionality and reference deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->