### PR TITLE
fix(web): disable the save button when creating a new item with invalid metadata

### DIFF
--- a/web/e2e/project/item/metadata/text.spec.ts
+++ b/web/e2e/project/item/metadata/text.spec.ts
@@ -131,6 +131,10 @@ test("Text metadata editing has succeeded", async ({ page }) => {
   await expect(page.getByRole("main")).toContainText("new text1 description");
   await expect(page.getByRole("textbox").nth(0)).toHaveValue("text2");
   await expect(page.getByRole("textbox").nth(1)).toHaveValue("text1");
+  await page.getByLabel("new text1(unique)").click();
+  await page.getByLabel("new text1(unique)").fill("text22");
+  await expect(page.getByRole("button", { name: "Save" })).toBeDisabled();
+  await page.getByLabel("new text1(unique)").fill("text2");
 
   await page.getByRole("button", { name: "Save" }).click();
   await closeNotification(page);

--- a/web/src/components/molecules/Content/Form/index.tsx
+++ b/web/src/components/molecules/Content/Form/index.tsx
@@ -440,6 +440,19 @@ const ContentForm: React.FC<Props> = ({
     }
   }, [itemId, item, metaForm, onMetaItemUpdate, model?.metadataSchema?.fields]);
 
+  const handleMetaValuesChange = useCallback(async () => {
+    if (itemId) return;
+    try {
+      await metaForm.validateFields();
+    } catch (e) {
+      if ((e as ValidateErrorEntity).errorFields.length > 0) {
+        setIsDisabled(true);
+        return;
+      }
+    }
+    setIsDisabled(false);
+  }, [itemId, metaForm]);
+
   const items: MenuProps["items"] = useMemo(() => {
     const menuItems = [
       {
@@ -656,7 +669,11 @@ const ContentForm: React.FC<Props> = ({
         </FormItemsWrapper>
       </StyledForm>
       <SideBarWrapper>
-        <Form form={metaForm} layout="vertical" initialValues={initialMetaFormValues}>
+        <Form
+          form={metaForm}
+          layout="vertical"
+          initialValues={initialMetaFormValues}
+          onValuesChange={handleMetaValuesChange}>
           <ContentSidebarWrapper item={item} onNavigateToRequest={onNavigateToRequest} />
           {model?.metadataSchema?.fields?.map(field => {
             const FieldComponent = FIELD_TYPE_COMPONENT_MAP[field.type];


### PR DESCRIPTION
# Overview
This PR fixes to disable the save button when creating a new item with invalid metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced form handling for text metadata with improved validation and state management.
- **Bug Fixes**
	- Improved assertions and interactions in end-to-end tests for text metadata creation and editing, ensuring correct visibility and values.
- **Refactor**
	- Introduced a new method for managing meta form value changes, improving clarity and separation of concerns in the `ContentForm` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->