### PR TITLE
fix(server): add missing mime types

### DIFF
--- a/server/internal/usecase/gateway/file.go
+++ b/server/internal/usecase/gateway/file.go
@@ -11,6 +11,7 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/file"
 	"github.com/reearth/reearthx/i18n"
 	"github.com/reearth/reearthx/rerror"
+	"github.com/samber/lo"
 )
 
 var (
@@ -41,6 +42,12 @@ type IssueUploadAssetParam struct {
 	ExpiresAt     time.Time
 
 	Cursor string
+}
+
+func init() {
+	// mime package depends on the OS, so adding the requited mime types to make sure about the results in different OS
+	lo.Must0(mime.AddExtensionType(".zip", "application/zip"))
+	lo.Must0(mime.AddExtensionType(".7z", "application/x-7z-compressed"))
 }
 
 func (p IssueUploadAssetParam) ContentType() string {

--- a/server/internal/usecase/gateway/file.go
+++ b/server/internal/usecase/gateway/file.go
@@ -48,6 +48,10 @@ func init() {
 	// mime package depends on the OS, so adding the requited mime types to make sure about the results in different OS
 	lo.Must0(mime.AddExtensionType(".zip", "application/zip"))
 	lo.Must0(mime.AddExtensionType(".7z", "application/x-7z-compressed"))
+	lo.Must0(mime.AddExtensionType(".gz", "application/gzip"))
+	lo.Must0(mime.AddExtensionType(".bz2", "application/x-bzip2"))
+	lo.Must0(mime.AddExtensionType(".tar", "application/x-tar"))
+	lo.Must0(mime.AddExtensionType(".rar", "application/vnd.rar"))
 }
 
 func (p IssueUploadAssetParam) ContentType() string {

--- a/server/internal/usecase/gateway/file_test.go
+++ b/server/internal/usecase/gateway/file_test.go
@@ -1,0 +1,45 @@
+package gateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIssueUploadAssetParam_ContentType(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields IssueUploadAssetParam
+		want   string
+	}{
+		{
+			name: "zip file",
+			fields: IssueUploadAssetParam{
+				UUID:          uuid.New().String(),
+				Filename:      "filename.zip",
+				ContentLength: 1,
+				ExpiresAt:     time.Now(),
+				Cursor:        "",
+			},
+			want: "application/zip",
+		},
+		{
+			name: "7zip file",
+			fields: IssueUploadAssetParam{
+				UUID:          uuid.New().String(),
+				Filename:      "filename.7z",
+				ContentLength: 1,
+				ExpiresAt:     time.Now(),
+				Cursor:        "",
+			},
+			want: "application/x-7z-compressed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.fields.ContentType())
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Introduced a new test function to validate the content type handling for uploaded assets, covering various file scenarios.
- **New Features**
	- Added MIME type associations for `.zip` and `.7z` file extensions to ensure correct file type recognition across different operating systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->