### PR TITLE
chore(server): enable to set db name from env file

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -2,14 +2,15 @@
 PORT=8080
 REEARTH_CMS_DB=mongodb://localhost
 REEARTH_CMS_HOST=https://localhost:8080
-REEARTH_CMS_SERVERHOST=https://localhost:8080
+REEARTH_CMS_SERVERHOST=localhost
 REEARTH_CMS_HOST_WEB=https://localhost:3000
 REEARTH_CMS_ASSETBASEURL=https://localhost:8080/assets
 REEARTH_CMS_DEV=false
 REEARTH_CMS_SIGNUPSECRET=
 REEARTH_CMS_ORIGINS=www.example.com,localhost:3000
 
-REEARTH_CMS_DB_ACCOUNT=mongodb://localhost
+REEARTH_CMS_DB_ACCOUNT=reearth_account
+REEARTH_CMS_DB_CMS=reearth_cms
 REEARTH_CMS_DB_USERS=Test1=mongodb://localhost,Test2=mongodb://localhost
 
 #GraphQL

--- a/server/internal/app/config.go
+++ b/server/internal/app/config.go
@@ -57,8 +57,8 @@ type Config struct {
 	// auth for m2m
 	AuthM2M AuthM2MConfig `pp:",omitempty"`
 
-	DB_Account string          `pp:",omitempty"`
-	DB_CMS     string          `pp:",omitempty"`
+	DB_Account string          `default:"reearth_account" pp:",omitempty"`
+	DB_CMS     string          `default:"reearth_cms" pp:",omitempty"`
 	DB_Users   []appx.NamedURI `pp:",omitempty"`
 }
 

--- a/server/internal/app/config.go
+++ b/server/internal/app/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	AuthM2M AuthM2MConfig `pp:",omitempty"`
 
 	DB_Account string          `pp:",omitempty"`
+	DB_CMS     string          `pp:",omitempty"`
 	DB_Users   []appx.NamedURI `pp:",omitempty"`
 }
 

--- a/server/internal/app/repo.go
+++ b/server/internal/app/repo.go
@@ -23,15 +23,8 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo"
 )
 
-const defaultCMSDatabase = "reearth_cms"
-const defaultAccountDatabase = "reearth_account"
-
 func initAccountDB(client *mongo.Client, txAvailable bool, ctx context.Context, conf *Config) *accountrepo.Container {
 	accountDatabase := conf.DB_Account
-	if accountDatabase == "" {
-		accountDatabase = defaultAccountDatabase
-	}
-
 	log.Infof("account database: %s", accountDatabase)
 
 	accountUsers := make([]accountrepo.User, 0, len(conf.DB_Users))
@@ -53,10 +46,6 @@ func initAccountDB(client *mongo.Client, txAvailable bool, ctx context.Context, 
 
 func initCMSDB(client *mongo.Client, txAvailable bool, acRepos *accountrepo.Container, ctx context.Context, conf *Config) *repo.Container {
 	cmsDatabase := conf.DB_CMS
-	if cmsDatabase == "" {
-		cmsDatabase = defaultCMSDatabase
-	}
-
 	log.Infof("cms database: %s", cmsDatabase)
 
 	repos, err := mongorepo.New(ctx, client, cmsDatabase, txAvailable, acRepos)


### PR DESCRIPTION
# Overview
We can't set database name from env file.

## What I've done
- add new env value `DB_CMS`
- read `DB_CMS` value from .env file

## What I haven't done

## How I tested
- print log on my console which database use

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration Updates**
	- Modified environment variables for server and database settings
	- Updated server host configuration
	- Added new database connection parameters

- **Database Initialization**
	- Improved database connection logic
	- Separated account and CMS database initialization
	- Enhanced modularity of database configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->