### PR TITLE
fix(server): Fix switching current user reviewer filter bug

### DIFF
--- a/server/internal/adapter/gql/resolver_request.go
+++ b/server/internal/adapter/gql/resolver_request.go
@@ -137,7 +137,7 @@ func (r *mutationResolver) DeleteRequest(ctx context.Context, input gqlmodel.Del
 
 // Requests is the resolver for the requests field.
 func (r *queryResolver) Requests(ctx context.Context, projectID gqlmodel.ID, key *string, state []gqlmodel.RequestState, createdBy *gqlmodel.ID, reviewer *gqlmodel.ID, pagination *gqlmodel.Pagination, sort *gqlmodel.Sort) (*gqlmodel.RequestConnection, error) {
-	return loaders(ctx).Request.FindByProject(ctx, projectID, key, state, reviewer, createdBy, pagination, sort)
+	return loaders(ctx).Request.FindByProject(ctx, projectID, key, state, createdBy, reviewer, pagination, sort)
 }
 
 // Thread is the resolver for the thread field.


### PR DESCRIPTION
# Overview
e.g.) If you try to get a request created by yourself, you will get the request for which you are the reviewer.

before filter by current user as reviewer

![Screenshot 2025-01-16 111746](https://github.com/user-attachments/assets/d1ed7fd3-6d83-4010-b2f2-6469bea7e05f)

after filter by current user reviewers

![Screenshot 2025-01-16 111800](https://github.com/user-attachments/assets/2d02f19f-2ba9-4ec0-a4ab-9afb509a37a9)

bug: this should only show requests which jk.eukarya is the reviewers. in this case, test req 4 shouldn’t show. creator-tsuc request should show instead.

## What I've done
switched createdBy and reviewer to the right place in the designated function
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted parameter order in request resolver function for improved internal processing

Note: This change is primarily an internal code adjustment that does not impact end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->