### PR TITLE
fix(worker): resolve copier dockerfile entry point

### DIFF
--- a/worker/copier.Dockerfile
+++ b/worker/copier.Dockerfile
@@ -2,21 +2,21 @@ FROM golang:1.23.3 AS build
 
 WORKDIR /app
 
-COPY go.work go.work.sum /app/
-COPY server/go.mod server/go.sum server/main.go /app/server/
-COPY worker/go.mod worker/go.sum worker/main.go /app/worker/
+COPY go.work go.work.sum ./
+COPY server/go.mod server/go.sum server/main.go ./server/
+COPY worker/go.mod worker/go.sum worker/main.go ./worker/
 
 RUN go mod download
 
-COPY server/pkg/ /app/server/pkg/
-COPY worker/cmd/ /app/worker/cmd/
-COPY worker/internal/ /app/worker/internal/
-COPY worker/pkg/ /app/worker/pkg/
+COPY server/pkg/ ./server/pkg/
+COPY worker/cmd/ ./worker/cmd/
+COPY worker/internal/ ./worker/internal/
+COPY worker/pkg/ ./worker/pkg/
 
-RUN CGO_ENABLED=0 go build -trimpath ./worker/cmd/copier
+RUN CGO_ENABLED=0 go build -trimpath -o copier ./worker/cmd/copier
 
 FROM scratch
 
-COPY --from=build /app/copier /app/copier
+COPY --from=build /app/copier /copier
 
-ENTRYPOINT ["/app/copier"]
+ENTRYPOINT ["/copier"]

--- a/worker/copier.Dockerfile
+++ b/worker/copier.Dockerfile
@@ -19,6 +19,4 @@ FROM scratch
 
 COPY --from=build /app/copier /app/copier
 
-WORKDIR /app
-
-CMD ["./copier"]
+ENTRYPOINT ["/app/copier"]


### PR DESCRIPTION
# Overview
This PR resolves copier's dockerfile entry point

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Dockerfile for the worker service
	- Refined file path handling for Docker image build
	- Modified binary build and execution configuration
	- Switched from `CMD` to `ENTRYPOINT` for container startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->