### PR TITLE
fix(server-worker): resolve copier's TLS certificate config

### DIFF
--- a/server/internal/infrastructure/gcp/config.go
+++ b/server/internal/infrastructure/gcp/config.go
@@ -12,5 +12,5 @@ type TaskConfig struct {
 	DecompressorMachineType string `default:"E2_HIGHCPU_8"`
 	DecompressorDiskSideGb  int64  `default:"2000"`
 	CopierImage             string `default:"reearth/reearth-cms-copier"`
-	DBSecretName            string `default:"reearth-cms-db"`
+	DBSecretName            string `default:"reearth-cms-worker-db"`
 }

--- a/worker/cmd/copier/main.go
+++ b/worker/cmd/copier/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"os"
 	"time"
 
@@ -56,6 +57,7 @@ func initReposWithCollection(ctx context.Context, dbURI, collection string) (*re
 		ctx,
 		options.Client().
 			ApplyURI(dbURI).
+			SetTLSConfig(&tls.Config{InsecureSkipVerify: true}).
 			SetConnectTimeout(10*time.Second).
 			SetMonitor(otelmongo.NewMonitor()),
 	)

--- a/worker/cmd/copier/main.go
+++ b/worker/cmd/copier/main.go
@@ -28,7 +28,6 @@ func main() {
 	}
 
 	dbURI := mustGetEnv("REEARTH_CMS_WORKER_DB")
-	log.Debugf("config: db uri %s", dbURI)
 	collection := mustGetEnv("REEARTH_CMS_COPIER_COLLECTION")
 	filter := mustGetEnv("REEARTH_CMS_COPIER_FILTER")
 	changes := mustGetEnv("REEARTH_CMS_COPIER_CHANGES")

--- a/worker/cmd/copier/main.go
+++ b/worker/cmd/copier/main.go
@@ -28,6 +28,7 @@ func main() {
 	}
 
 	dbURI := mustGetEnv("REEARTH_CMS_WORKER_DB")
+	log.Debugf("config: db uri %s", dbURI)
 	collection := mustGetEnv("REEARTH_CMS_COPIER_COLLECTION")
 	filter := mustGetEnv("REEARTH_CMS_COPIER_FILTER")
 	changes := mustGetEnv("REEARTH_CMS_COPIER_CHANGES")


### PR DESCRIPTION
# Overview
This PR resolves copier's TLS certificate config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Updated default database secret name for task configuration
- **Security**
	- Added TLS configuration for MongoDB database connection with optional certificate verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->