### PR TITLE
feat(web): validate `reearth_config.json` on container launch

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -47,6 +47,9 @@ ENV REEARTH_CMS_EDITOR_URL=null
 ENV REEARTH_CMS_LOGO_URL=null
 ENV REEARTH_CMS_MULTI_TENANT=null
 
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk add --no-cache jq
+
 COPY --from=builder --chown=nginx:nginx /app/dist /usr/share/nginx/html
 COPY --chown=nginx:nginx docker/nginx.conf.template /etc/nginx/templates/nginx.conf.template
 COPY --chown=nginx:nginx docker/40-envsubst-on-reearth-config.sh /docker-entrypoint.d

--- a/web/docker/40-envsubst-on-reearth-config.sh
+++ b/web/docker/40-envsubst-on-reearth-config.sh
@@ -33,3 +33,7 @@ wrap_reearth_cms_variables() {
 
 wrap_reearth_cms_variables "$@"
 envsubst < "$_REEARTH_CONFIG_TEMPLATE_FILE" > "$_REEARTH_CONFIG_OUTPUT_FILE"
+if ! jq empty "$_REEARTH_CONFIG_OUTPUT_FILE" > /dev/null 2>&1; then
+  echo "Invalid JSON configuration file $_REEARTH_CONFIG_OUTPUT_FILE" >&2
+  exit 1
+fi


### PR DESCRIPTION
# Overview

We gonna validate the configuration file on launch so that if some required environment variables are missing, the container will fail to spin up.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo

Ref: https://github.com/reearth/reearth-visualizer/pull/1390
