### PR TITLE
fix(server): use cloud logging only option with cloud build

### DIFF
--- a/server/internal/infrastructure/gcp/taskrunner.go
+++ b/server/internal/infrastructure/gcp/taskrunner.go
@@ -183,8 +183,8 @@ func copy(ctx context.Context, p task.Payload, conf *TaskConfig) error {
 		},
 		ServiceAccount: fmt.Sprintf("projects/%s/serviceAccounts/%s", project, account),
 		Options: &cloudbuild.BuildOptions{
-			DiskSizeGb:                defaultDiskSizeGb,
-			DefaultLogsBucketBehavior: "REGIONAL_USER_OWNED_BUCKET",
+			DiskSizeGb: defaultDiskSizeGb,
+			Logging:    "CLOUD_LOGGING_ONLY",
 		},
 		AvailableSecrets: &cloudbuild.Secrets{
 			SecretManager: []*cloudbuild.SecretManagerSecret{
@@ -259,8 +259,8 @@ func importItems(ctx context.Context, p task.Payload, conf *TaskConfig) error {
 		},
 		ServiceAccount: fmt.Sprintf("projects/%s/serviceAccounts/%s", project, account),
 		Options: &cloudbuild.BuildOptions{
-			DiskSizeGb:                defaultDiskSizeGb,
-			DefaultLogsBucketBehavior: "REGIONAL_USER_OWNED_BUCKET",
+			DiskSizeGb: defaultDiskSizeGb,
+			Logging:    "CLOUD_LOGGING_ONLY",
 		},
 		AvailableSecrets: &cloudbuild.Secrets{
 			SecretManager: []*cloudbuild.SecretManagerSecret{


### PR DESCRIPTION
# Overview
This PR uses `CLOUD_LOGGING_ONLY` option instead of using `REGIONAL_USER_OWNED_BUCKET`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Refined the logging configuration for build operations to streamline log management without altering user-facing functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->