### PR TITLE
fix(server): use custom service account for decompressor tasks

### DIFF
--- a/server/internal/infrastructure/gcp/taskrunner.go
+++ b/server/internal/infrastructure/gcp/taskrunner.go
@@ -103,6 +103,7 @@ func decompressAsset(ctx context.Context, p task.Payload, conf *TaskConfig) erro
 	}
 
 	project := conf.GCPProject
+	account := conf.BuildServiceAccount
 	region := conf.GCPRegion
 
 	machineType := ""
@@ -131,9 +132,11 @@ func decompressAsset(ctx context.Context, p task.Payload, conf *TaskConfig) erro
 				},
 			},
 		},
+		ServiceAccount: fmt.Sprintf("projects/%s/serviceAccounts/%s", project, account),
 		Options: &cloudbuild.BuildOptions{
 			MachineType: machineType,
 			DiskSizeGb:  diskSizeGb,
+			Logging:     "CLOUD_LOGGING_ONLY",
 		},
 	}
 


### PR DESCRIPTION
# Overview


From a security point of view, we shouldn't use the Compute Engine service account, which will be assigned when no service accounts are specified in the build configuration.

Like we already do for `copier` and `importItems` tasks, this task `decompressor` should also use the custom service account.

https://github.com/reearth/reearth-cms/blob/ef04229a7f12a61fe3d64a5b2890e5ba2a633c53/server/internal/infrastructure/gcp/taskrunner.go#L184

https://github.com/reearth/reearth-cms/blob/ef04229a7f12a61fe3d64a5b2890e5ba2a633c53/server/internal/infrastructure/gcp/taskrunner.go#L260

Also, do not log in to GCS, I have also specified `CLOUD_LOGGING_ONLY` in the options field.

## What I've done

I added the `serviceAccount` field for CloudBuild builds.

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Build processes now dynamically select the correct service account based on your configuration for more seamless operations.
	- Logging for build operations has been enhanced to utilize a focused cloud-logging mode, providing clearer operational insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->