### PR TITLE
fix(server): `pool.name` instead of `workerPool` to specify pool

### DIFF
--- a/server/internal/infrastructure/gcp/taskrunner.go
+++ b/server/internal/infrastructure/gcp/taskrunner.go
@@ -105,7 +105,6 @@ func decompressAsset(ctx context.Context, p task.Payload, conf *TaskConfig) erro
 	project := conf.GCPProject
 	account := conf.BuildServiceAccount
 	region := conf.GCPRegion
-	workerPool := conf.WorkerPool
 
 	machineType := ""
 	if v := conf.DecompressorMachineType; v != "" && v != "default" {
@@ -138,7 +137,9 @@ func decompressAsset(ctx context.Context, p task.Payload, conf *TaskConfig) erro
 			MachineType: machineType,
 			DiskSizeGb:  diskSizeGb,
 			Logging:     "CLOUD_LOGGING_ONLY",
-			WorkerPool:  workerPool,
+			Pool: &cloudbuild.PoolOption{
+				Name: conf.WorkerPool,
+			},
 		},
 	}
 
@@ -169,7 +170,6 @@ func copy(ctx context.Context, p task.Payload, conf *TaskConfig) error {
 	account := conf.BuildServiceAccount
 	region := conf.GCPRegion
 	dbSecretName := conf.DBSecretName
-	workerPool := conf.WorkerPool
 
 	build := &cloudbuild.Build{
 		Timeout:  "86400s", // 1 day
@@ -191,7 +191,9 @@ func copy(ctx context.Context, p task.Payload, conf *TaskConfig) error {
 		Options: &cloudbuild.BuildOptions{
 			DiskSizeGb: defaultDiskSizeGb,
 			Logging:    "CLOUD_LOGGING_ONLY",
-			WorkerPool: workerPool,
+			Pool: &cloudbuild.PoolOption{
+				Name: conf.WorkerPool,
+			},
 		},
 		AvailableSecrets: &cloudbuild.Secrets{
 			SecretManager: []*cloudbuild.SecretManagerSecret{
@@ -230,7 +232,6 @@ func importItems(ctx context.Context, p task.Payload, conf *TaskConfig) error {
 	account := conf.BuildServiceAccount
 	region := conf.GCPRegion
 	singleDb := conf.DBName == conf.AccountDBName
-	workerPool := conf.WorkerPool
 
 	args := []string{
 		"item",
@@ -284,7 +285,9 @@ func importItems(ctx context.Context, p task.Payload, conf *TaskConfig) error {
 		Options: &cloudbuild.BuildOptions{
 			DiskSizeGb: defaultDiskSizeGb,
 			Logging:    "CLOUD_LOGGING_ONLY",
-			WorkerPool: workerPool,
+			Pool: &cloudbuild.PoolOption{
+				Name: conf.WorkerPool,
+			},
 		},
 		AvailableSecrets: &cloudbuild.Secrets{
 			SecretManager: availableSecrets,


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

Submitted a job using:

```yaml
steps:
  - name: "bash"
    id: hello
    args: ["echo", "Hello World!"]
options:
  pool:
    name: projects/<PROJECT_ID>/locations/<REGION>/workerPools/<POOL_NAME>
```




## Screenshot

## Which point I want you to review particularly

## Memo

> // WorkerPool: This field deprecated; please use `pool.name` instead.
>	WorkerPool [string](https://pkg.go.dev/builtin#string) `json:"workerPool,omitempty"`

Ref: [cloudbuild package - google.golang.org/api/cloudbuild/v1 - Go Packages](https://pkg.go.dev/google.golang.org/api/cloudbuild/v1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved internal task processing configuration to enhance system maintainability. The external functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->