### PR TITLE
fix(server): build pool name with region & worker pool variable

### DIFF
--- a/server/internal/infrastructure/gcp/taskrunner.go
+++ b/server/internal/infrastructure/gcp/taskrunner.go
@@ -138,7 +138,7 @@ func decompressAsset(ctx context.Context, p task.Payload, conf *TaskConfig) erro
 			DiskSizeGb:  diskSizeGb,
 			Logging:     "CLOUD_LOGGING_ONLY",
 			Pool: &cloudbuild.PoolOption{
-				Name: conf.WorkerPool,
+				Name: fmt.Sprintf("projects/%s/locations/%s/workerPools/%s", project, region, conf.WorkerPool),
 			},
 		},
 	}
@@ -192,7 +192,7 @@ func copy(ctx context.Context, p task.Payload, conf *TaskConfig) error {
 			DiskSizeGb: defaultDiskSizeGb,
 			Logging:    "CLOUD_LOGGING_ONLY",
 			Pool: &cloudbuild.PoolOption{
-				Name: conf.WorkerPool,
+				Name: fmt.Sprintf("projects/%s/locations/%s/workerPools/%s", project, region, conf.WorkerPool),
 			},
 		},
 		AvailableSecrets: &cloudbuild.Secrets{
@@ -286,7 +286,7 @@ func importItems(ctx context.Context, p task.Payload, conf *TaskConfig) error {
 			DiskSizeGb: defaultDiskSizeGb,
 			Logging:    "CLOUD_LOGGING_ONLY",
 			Pool: &cloudbuild.PoolOption{
-				Name: conf.WorkerPool,
+				Name: fmt.Sprintf("projects/%s/locations/%s/workerPools/%s", project, region, conf.WorkerPool),
 			},
 		},
 		AvailableSecrets: &cloudbuild.Secrets{

--- a/server/internal/infrastructure/gcp/taskrunner.go
+++ b/server/internal/infrastructure/gcp/taskrunner.go
@@ -137,10 +137,9 @@ func decompressAsset(ctx context.Context, p task.Payload, conf *TaskConfig) erro
 			MachineType: machineType,
 			DiskSizeGb:  diskSizeGb,
 			Logging:     "CLOUD_LOGGING_ONLY",
-			// TODO: use worker pool
-			// Pool: &cloudbuild.PoolOption{
-			// 	Name: conf.WorkerPool,
-			// },
+			Pool: &cloudbuild.PoolOption{
+				Name: fmt.Sprintf("projects/%s/locations/%s/workerPools/%s", project, region, conf.WorkerPool),
+			},
 		},
 	}
 


### PR DESCRIPTION
# Overview

The process failed because Cloud Build jobs were sent to a `global` location, even if the worker pool was specified.

In my previous PR, I planned to add an environment variable that receives an ID `projects/{project}/locations/{location}/workerPools/{workerPoolId}`,  but from this change, it expects the worker pool name.

Now, CMS will construct a worker pool ID (`.Options.Pool.Name`) but combining with other environment variables.
This is consistent, as the Cloud Build and worker pool regions (`xxx_TASK_GCPREGION`) must be always aligned.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the naming approach for worker pools in cloud build operations by incorporating project and region details. This enhancement boosts clarity and reduces ambiguity during build tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->