### PR TITLE
fix(server): disable worker pool for asset decompression

### DIFF
--- a/server/internal/infrastructure/gcp/config.go
+++ b/server/internal/infrastructure/gcp/config.go
@@ -10,7 +10,6 @@ type TaskConfig struct {
 	DecompressorTopic       string `default:"decompress"`
 	DecompressorGzipExt     string `default:"gml"`
 	DecompressorMachineType string `default:"E2_HIGHCPU_8"`
-	DecompressorDiskSideGb  int64  `default:"2000"`
 	CopierImage             string `default:"reearth/reearth-cms-copier"`
 	DBSecretName            string `default:"reearth-cms-db"`
 	AccountDBSecretName     string `default:"reearth-cms-db-users"`

--- a/server/internal/infrastructure/gcp/config.go
+++ b/server/internal/infrastructure/gcp/config.go
@@ -10,6 +10,7 @@ type TaskConfig struct {
 	DecompressorTopic       string `default:"decompress"`
 	DecompressorGzipExt     string `default:"gml"`
 	DecompressorMachineType string `default:"E2_HIGHCPU_8"`
+	DecompressorDiskSideGb  int64  `default:"2000"`
 	CopierImage             string `default:"reearth/reearth-cms-copier"`
 	DBSecretName            string `default:"reearth-cms-db"`
 	AccountDBSecretName     string `default:"reearth-cms-db-users"`

--- a/server/internal/infrastructure/gcp/taskrunner.go
+++ b/server/internal/infrastructure/gcp/taskrunner.go
@@ -15,8 +15,6 @@ import (
 	"google.golang.org/api/cloudbuild/v1"
 )
 
-var defaultDiskSizeGb int64 = 2000 // 2TB
-
 type TaskRunner struct {
 	conf   *TaskConfig
 	pubsub *pubsub.Client
@@ -111,13 +109,6 @@ func decompressAsset(ctx context.Context, p task.Payload, conf *TaskConfig) erro
 		machineType = v
 	}
 
-	var diskSizeGb int64
-	if v := conf.DecompressorDiskSideGb; v > 0 {
-		diskSizeGb = v
-	} else {
-		diskSizeGb = defaultDiskSizeGb
-	}
-
 	build := &cloudbuild.Build{
 		Timeout:  "86400s", // 1 day
 		QueueTtl: "86400s", // 1 day
@@ -135,7 +126,6 @@ func decompressAsset(ctx context.Context, p task.Payload, conf *TaskConfig) erro
 		ServiceAccount: fmt.Sprintf("projects/%s/serviceAccounts/%s", project, account),
 		Options: &cloudbuild.BuildOptions{
 			MachineType: machineType,
-			DiskSizeGb:  diskSizeGb, // TODO: should be deleted if a worker pool is used
 			Logging:     "CLOUD_LOGGING_ONLY",
 			Pool: &cloudbuild.PoolOption{
 				Name: fmt.Sprintf("projects/%s/locations/%s/workerPools/%s", project, region, conf.WorkerPool),


### PR DESCRIPTION
# Overview
This PR disables worker pool for asset decompression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the decompression task configuration by removing manual disk size settings.
  - Build operations now use streamlined default settings for enhanced consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->