### PR TITLE
fix(server): import task should start even when omitting optional fields

### DIFF
--- a/server/internal/infrastructure/gcp/taskrunner.go
+++ b/server/internal/infrastructure/gcp/taskrunner.go
@@ -238,9 +238,11 @@ func importItems(ctx context.Context, p task.Payload, conf *TaskConfig) error {
 		"-modelId=" + p.Import.ModelId,
 		"-assetId=" + p.Import.AssetId,
 		"-format=" + p.Import.Format,
-		"-geometryFieldKey=" + p.Import.GeometryFieldKey,
 		"-strategy=" + p.Import.Strategy,
 		"-mutateSchema=" + fmt.Sprint(p.Import.MutateSchema),
+	}
+	if p.Import.GeometryFieldKey != "" {
+		args = append(args, fmt.Sprintf("-geometryFieldKey=%s", p.Import.GeometryFieldKey))
 	}
 	if p.Import.UserId != "" {
 		args = append(args, "-userId="+p.Import.UserId)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined the import process to include geometry field settings only when a valid value is provided, thereby eliminating unnecessary parameters and streamlining operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->