### PR TITLE
fix(server): return empty asset response when signed upload url is not supported

### DIFF
--- a/server/internal/adapter/gql/resolver_asset.go
+++ b/server/internal/adapter/gql/resolver_asset.go
@@ -6,11 +6,13 @@ package gql
 
 import (
 	"context"
+	"errors"
 
 	"github.com/reearth/reearth-cms/server/internal/adapter/gql/gqlmodel"
 	"github.com/reearth/reearth-cms/server/internal/usecase/interfaces"
 	"github.com/reearth/reearth-cms/server/pkg/file"
 	"github.com/reearth/reearth-cms/server/pkg/id"
+	"github.com/reearth/reearthx/rerror"
 	"github.com/samber/lo"
 )
 
@@ -165,9 +167,13 @@ func (r *mutationResolver) CreateAssetUpload(ctx context.Context, input gqlmodel
 		ContentEncoding: lo.FromPtr(input.ContentEncoding),
 		Cursor:          lo.FromPtr(input.Cursor),
 	}, getOperator(ctx))
+	if err != nil && errors.Is(err, rerror.ErrNotFound) {
+		return &gqlmodel.CreateAssetUploadPayload{}, nil
+	}
 	if err != nil {
 		return nil, err
 	}
+
 	return &gqlmodel.CreateAssetUploadPayload{
 		URL:             au.URL,
 		Token:           au.UUID,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the asset upload process to handle certain error situations more gracefully, ensuring that edge cases return an empty result rather than an error message, leading to a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->