### PR TITLE
fix(server): Fix reversed lat long in csv import

### DIFF
--- a/server/e2e/integration_item_test.go
+++ b/server/e2e/integration_item_test.go
@@ -1439,7 +1439,7 @@ func TestIntegrationItemsWithProjectAsGeoJSON(t *testing.T) {
 	f.Value("properties").Object().Value("integer").Number().IsEqual(30)
 	g := f.Value("geometry").Object()
 	g.Value("type").String().IsEqual("LineString")
-	g.Value("coordinates").Array().IsEqual([][]float64{{139.65439725962517, 36.34793305387103}, {139.61688622815393, 35.910803456352724}})
+	g.Value("coordinates").Array().IsEqual([][]float64{{36.34793305387103, 139.65439725962517}, {35.910803456352724, 139.61688622815393}})
 }
 
 // GET /models/{modelId}/items.csv
@@ -1456,7 +1456,7 @@ func TestIntegrationItemsAsCSV(t *testing.T) {
 	})
 
 	res := IntegrationItemsAsCSV(e, mId, 1, 10)
-	expected := fmt.Sprintf("id,location_lat,location_lng,text,textArea,markdown,asset,bool,select,integer,number,url,date,tag,checkbox\n%s,139.28179282584915,36.58570985749664,test1,,,,,,,,,,,\n", i1Id)
+	expected := fmt.Sprintf("id,location_lat,location_lng,text,textArea,markdown,asset,bool,select,integer,number,url,date,tag,checkbox\n%s,36.58570985749664,139.28179282584915,test1,,,,,,,,,,,\n", i1Id)
 	res.IsEqual(expected)
 }
 
@@ -1476,7 +1476,7 @@ func TestIntegrationItemsWithProjectAsCSV(t *testing.T) {
 	})
 
 	res := IntegrationItemsWithProjectAsCSV(e, pId, mId, 1, 10)
-	expected := fmt.Sprintf("id,location_lat,location_lng,text,textArea,markdown,asset,bool,select,integer,number,url,date,tag,checkbox\n%s,139.28179282584915,36.58570985749664,test1,,,,,,30,,,,,\n", i1Id)
+	expected := fmt.Sprintf("id,location_lat,location_lng,text,textArea,markdown,asset,bool,select,integer,number,url,date,tag,checkbox\n%s,36.58570985749664,139.28179282584915,test1,,,,,,30,,,,,\n", i1Id)
 	res.IsEqual(expected)
 }
 

--- a/server/e2e/integration_item_test.go
+++ b/server/e2e/integration_item_test.go
@@ -1439,7 +1439,7 @@ func TestIntegrationItemsWithProjectAsGeoJSON(t *testing.T) {
 	f.Value("properties").Object().Value("integer").Number().IsEqual(30)
 	g := f.Value("geometry").Object()
 	g.Value("type").String().IsEqual("LineString")
-	g.Value("coordinates").Array().IsEqual([][]float64{{36.34793305387103, 139.65439725962517}, {35.910803456352724, 139.61688622815393}})
+	g.Value("coordinates").Array().IsEqual([][]float64{{139.65439725962517, 36.34793305387103}, {139.61688622815393, 35.910803456352724}})
 }
 
 // GET /models/{modelId}/items.csv

--- a/server/e2e/publicapi_test.go
+++ b/server/e2e/publicapi_test.go
@@ -334,7 +334,7 @@ func TestPublicAPI(t *testing.T) {
 		Expect().
 		Status(http.StatusOK).
 		Body().
-		IsEqual(fmt.Sprintf("id,location_lat,location_lng,test-field-1,asset,test-field-2,asset2\n%s,102,0.5,ccc,,aaa,\n", publicAPIItem6ID.String()))
+		IsEqual(fmt.Sprintf("id,location_lat,location_lng,test-field-1,asset,test-field-2,asset2\n%s,0.5,102,ccc,,aaa,\n", publicAPIItem6ID.String()))
 
 	// no geometry field
 	e.GET("/api/p/{project}/{model}.csv", publicAPIProjectAlias, publicAPIModelKey3).

--- a/server/internal/usecase/interactor/item_test.go
+++ b/server/internal/usecase/interactor/item_test.go
@@ -1172,7 +1172,7 @@ func TestItem_ItemsAsCSV(t *testing.T) {
 			seedsItems:  item.List{i1},
 			seedSchemas: s1,
 			seedModels:  m1,
-			want:        []byte("id,location_lat,location_lng\n" + i1IDStr + ",139.28179282584915,36.58570985749664\n"),
+			want:        []byte("id,location_lat,location_lng\n" + i1IDStr + ",36.58570985749664,139.28179282584915\n"),
 			wantError:   nil,
 		},
 		{

--- a/server/pkg/exporters/csv.go
+++ b/server/pkg/exporters/csv.go
@@ -32,7 +32,7 @@ func RowFromItem(itm *item.Item, nonGeoFields []*schema.Field) ([]string, bool) 
 	}
 
 	id := itm.ID().String()
-	lat, lng := float64ToString(geoField[0]), float64ToString(geoField[1])
+	lat, lng := float64ToString(geoField[1]), float64ToString(geoField[0])
 	row := []string{id, lat, lng}
 
 	for _, sf := range nonGeoFields {

--- a/server/pkg/exporters/csv_test.go
+++ b/server/pkg/exporters/csv_test.go
@@ -93,7 +93,7 @@ func TestRowFromItem(t *testing.T) {
 		MustBuild()
 	row3, ok3 := RowFromItem(i3, []*schema.Field{sf3, sf4})
 	assert.True(t, ok3)
-	assert.Equal(t, []string{i1.ID().String(), "139.28179282584915", "36.58570985749664", "30", "true"}, row3)
+	assert.Equal(t, []string{i1.ID().String(), "36.58570985749664", "139.28179282584915", "30", "true"}, row3)
 }
 
 func TestExtractFirstPointField(t *testing.T) {


### PR DESCRIPTION
# Overview
This is a fix of a bug that makes the latitude and longtitude reversed

example bug case:
Actual data:
id,location_lat,location_lng,name
01jrshjdwyas9jd9z5fex9mnsb,139.77104696739806,35.70845705107105,tokyo
Expected data:
id,location_lat,location_lng,name
01jrshjdwyas9jd9z5fex9mnsb,35.70845705107105,139.77104696739806,tokyo

To fix:
assign the lat and long to the right variable. 
## What I've done
1. Development
2. unit testing
3. local testing

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the order of location coordinates in CSV exports so that latitude now appears before longitude, ensuring consistency in the data output.

- **Tests**
  - Updated test validations to reflect the revised coordinate ordering in CSV data exports and integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->