### PR TITLE
fix(server): add asset public field in GQL schema

### DIFF
--- a/server/internal/adapter/gql/generated.go
+++ b/server/internal/adapter/gql/generated.go
@@ -88,6 +88,7 @@ type ComplexityRoot struct {
 		PreviewType             func(childComplexity int) int
 		Project                 func(childComplexity int) int
 		ProjectID               func(childComplexity int) int
+		Public                  func(childComplexity int) int
 		Size                    func(childComplexity int) int
 		Thread                  func(childComplexity int) int
 		ThreadID                func(childComplexity int) int
@@ -1197,6 +1198,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Asset.ProjectID(childComplexity), true
+
+	case "Asset.public":
+		if e.complexity.Asset.Public == nil {
+			break
+		}
+
+		return e.complexity.Asset.Public(childComplexity), true
 
 	case "Asset.size":
 		if e.complexity.Asset.Size == nil {
@@ -5194,6 +5202,7 @@ schema {
   url: String!
   fileName: String!
   archiveExtractionStatus: ArchiveExtractionStatus
+  public: Boolean!
 }
 
 type AssetItem {
@@ -10738,6 +10747,50 @@ func (ec *executionContext) fieldContext_Asset_archiveExtractionStatus(_ context
 	return fc, nil
 }
 
+func (ec *executionContext) _Asset_public(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.Asset) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Asset_public(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Public, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Asset_public(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Asset",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _AssetConnection_edges(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.AssetConnection) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_AssetConnection_edges(ctx, field)
 	if err != nil {
@@ -10861,6 +10914,8 @@ func (ec *executionContext) fieldContext_AssetConnection_nodes(_ context.Context
 				return ec.fieldContext_Asset_fileName(ctx, field)
 			case "archiveExtractionStatus":
 				return ec.fieldContext_Asset_archiveExtractionStatus(ctx, field)
+			case "public":
+				return ec.fieldContext_Asset_public(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Asset", field.Name)
 		},
@@ -11080,6 +11135,8 @@ func (ec *executionContext) fieldContext_AssetEdge_node(_ context.Context, field
 				return ec.fieldContext_Asset_fileName(ctx, field)
 			case "archiveExtractionStatus":
 				return ec.fieldContext_Asset_archiveExtractionStatus(ctx, field)
+			case "public":
+				return ec.fieldContext_Asset_public(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Asset", field.Name)
 		},
@@ -12558,6 +12615,8 @@ func (ec *executionContext) fieldContext_CreateAssetPayload_asset(_ context.Cont
 				return ec.fieldContext_Asset_fileName(ctx, field)
 			case "archiveExtractionStatus":
 				return ec.fieldContext_Asset_archiveExtractionStatus(ctx, field)
+			case "public":
+				return ec.fieldContext_Asset_public(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Asset", field.Name)
 		},
@@ -12947,6 +13006,8 @@ func (ec *executionContext) fieldContext_DecompressAssetPayload_asset(_ context.
 				return ec.fieldContext_Asset_fileName(ctx, field)
 			case "archiveExtractionStatus":
 				return ec.fieldContext_Asset_archiveExtractionStatus(ctx, field)
+			case "public":
+				return ec.fieldContext_Asset_public(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Asset", field.Name)
 		},
@@ -16141,6 +16202,8 @@ func (ec *executionContext) fieldContext_Item_assets(_ context.Context, field gr
 				return ec.fieldContext_Asset_fileName(ctx, field)
 			case "archiveExtractionStatus":
 				return ec.fieldContext_Asset_archiveExtractionStatus(ctx, field)
+			case "public":
+				return ec.fieldContext_Asset_public(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Asset", field.Name)
 		},
@@ -31413,6 +31476,8 @@ func (ec *executionContext) fieldContext_UpdateAssetPayload_asset(_ context.Cont
 				return ec.fieldContext_Asset_fileName(ctx, field)
 			case "archiveExtractionStatus":
 				return ec.fieldContext_Asset_archiveExtractionStatus(ctx, field)
+			case "public":
+				return ec.fieldContext_Asset_public(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Asset", field.Name)
 		},
@@ -42260,6 +42325,11 @@ func (ec *executionContext) _Asset(ctx context.Context, sel ast.SelectionSet, ob
 			}
 		case "archiveExtractionStatus":
 			out.Values[i] = ec._Asset_archiveExtractionStatus(ctx, field, obj)
+		case "public":
+			out.Values[i] = ec._Asset_public(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/server/internal/adapter/gql/gqlmodel/convert_asset.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_asset.go
@@ -40,6 +40,7 @@ func ToAsset(a *asset.Asset, urlResolver func(a *asset.Asset) string) *Asset {
 		ThreadID:                IDFromRef(a.Thread()),
 		ArchiveExtractionStatus: ToArchiveExtractionStatus(a.ArchiveExtractionStatus()),
 		Size:                    int64(a.Size()),
+		Public:                  a.Public(),
 	}
 }
 

--- a/server/internal/adapter/gql/gqlmodel/convert_asset_test.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_asset_test.go
@@ -19,7 +19,7 @@ func TestToAsset(t *testing.T) {
 	var pti = asset.PreviewTypeImage
 	uuid := uuid.New().String()
 	thid := id.NewThreadID()
-	a1 := asset.New().ID(id1).Project(pid1).CreatedByUser(uid1).FileName("aaa.jpg").Size(1000).Type(&pti).UUID(uuid).Thread(thid.Ref()).MustBuild()
+	a1 := asset.New().ID(id1).Project(pid1).CreatedByUser(uid1).FileName("aaa.jpg").Size(1000).Type(&pti).UUID(uuid).Thread(thid.Ref()).Public(true).MustBuild()
 
 	want1 := Asset{
 		ID:            ID(id1.String()),
@@ -33,6 +33,7 @@ func TestToAsset(t *testing.T) {
 		FileName:      "aaa.jpg",
 		ThreadID:      lo.ToPtr(ID(thid.String())),
 		Size:          1000,
+		Public:        true,
 	}
 
 	var a2 *asset.Asset = nil

--- a/server/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/server/internal/adapter/gql/gqlmodel/models_gen.go
@@ -91,6 +91,7 @@ type Asset struct {
 	URL                     string                   `json:"url"`
 	FileName                string                   `json:"fileName"`
 	ArchiveExtractionStatus *ArchiveExtractionStatus `json:"archiveExtractionStatus,omitempty"`
+	Public                  bool                     `json:"public"`
 }
 
 func (Asset) IsNode()        {}

--- a/server/internal/infrastructure/mongo/mongodoc/asset_test.go
+++ b/server/internal/infrastructure/mongo/mongodoc/asset_test.go
@@ -68,7 +68,7 @@ func TestNewAsset(t *testing.T) {
 	}{
 		{
 			name: "new",
-			a:    asset.New().ID(aId).Project(pId).CreatedByUser(uId).CreatedAt(now).Thread(tId.Ref()).UUID(uuId.String()).Size(123).MustBuild(),
+			a:    asset.New().ID(aId).Project(pId).CreatedByUser(uId).CreatedAt(now).Thread(tId.Ref()).UUID(uuId.String()).Size(123).Public(true).MustBuild(),
 			want: &AssetDocument{
 				ID:                      aId.String(),
 				Project:                 pId.String(),
@@ -81,6 +81,7 @@ func TestNewAsset(t *testing.T) {
 				UUID:                    uuId.String(),
 				Thread:                  tId.StringRef(),
 				ArchiveExtractionStatus: "",
+				Public: true,
 			},
 			aDocId: aId.String(),
 		},

--- a/server/pkg/asset/asset.go
+++ b/server/pkg/asset/asset.go
@@ -128,5 +128,6 @@ func (a *Asset) Clone() *Asset {
 		thread:                  a.thread.CloneRef(),
 		archiveExtractionStatus: a.archiveExtractionStatus,
 		flatFiles:               a.flatFiles,
+		public:                  a.public,
 	}
 }

--- a/server/pkg/asset/builder_test.go
+++ b/server/pkg/asset/builder_test.go
@@ -29,6 +29,7 @@ type Input struct {
 	thread                  *ThreadID
 	archiveExtractionStatus *ArchiveExtractionStatus
 	flatFiles               bool
+	public                  bool
 }
 
 func TestBuilder_Build(t *testing.T) {
@@ -55,6 +56,7 @@ func TestBuilder_Build(t *testing.T) {
 				thread:                  thid.Ref(),
 				archiveExtractionStatus: lo.ToPtr(ArchiveExtractionStatusPending),
 				flatFiles:               false,
+				public:                  true,
 			},
 			want: &Asset{
 				id:                      aid,
@@ -68,6 +70,7 @@ func TestBuilder_Build(t *testing.T) {
 				thread:                  thid.Ref(),
 				archiveExtractionStatus: lo.ToPtr(ArchiveExtractionStatusPending),
 				flatFiles:               false,
+				public:                  true,
 			},
 		},
 		{
@@ -81,6 +84,7 @@ func TestBuilder_Build(t *testing.T) {
 				uuid:                    "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				thread:                  thid.Ref(),
 				archiveExtractionStatus: lo.ToPtr(ArchiveExtractionStatusPending),
+				public:                  true,
 			},
 			err: ErrNoProjectID,
 		},
@@ -95,6 +99,7 @@ func TestBuilder_Build(t *testing.T) {
 				uuid:                    "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				thread:                  thid.Ref(),
 				archiveExtractionStatus: lo.ToPtr(ArchiveExtractionStatusPending),
+				public:                  true,
 			},
 			err: ErrInvalidID,
 		},
@@ -109,6 +114,7 @@ func TestBuilder_Build(t *testing.T) {
 				uuid:                    "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				thread:                  thid.Ref(),
 				archiveExtractionStatus: lo.ToPtr(ArchiveExtractionStatusPending),
+				public:                  true,
 			},
 			err: ErrNoUser,
 		},
@@ -124,6 +130,7 @@ func TestBuilder_Build(t *testing.T) {
 				uuid:                    "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				thread:                  thid.Ref(),
 				archiveExtractionStatus: lo.ToPtr(ArchiveExtractionStatusPending),
+				public:                  true,
 			},
 			err: ErrZeroSize,
 		},
@@ -137,6 +144,7 @@ func TestBuilder_Build(t *testing.T) {
 				size:          size,
 				previewType:   PreviewTypeFromRef(lo.ToPtr(PreviewTypeImage.String())),
 				thread:        thid.Ref(),
+				public:                  true,
 			},
 			err: ErrNoUUID,
 		},
@@ -152,6 +160,7 @@ func TestBuilder_Build(t *testing.T) {
 				uuid:                    "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				thread:                  thid.Ref(),
 				archiveExtractionStatus: lo.ToPtr(ArchiveExtractionStatusPending),
+				public:                  true,
 			},
 			want: &Asset{
 				id:                      aid,
@@ -164,6 +173,7 @@ func TestBuilder_Build(t *testing.T) {
 				uuid:                    "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				thread:                  thid.Ref(),
 				archiveExtractionStatus: lo.ToPtr(ArchiveExtractionStatusPending),
+				public:                  true,
 			},
 		},
 		{
@@ -178,6 +188,7 @@ func TestBuilder_Build(t *testing.T) {
 				uuid:                    "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				thread:                  thid.Ref(),
 				archiveExtractionStatus: lo.ToPtr(ArchiveExtractionStatusPending),
+				public:                  true,
 			},
 			want: &Asset{
 				id:                      aid,
@@ -190,6 +201,7 @@ func TestBuilder_Build(t *testing.T) {
 				uuid:                    "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				thread:                  thid.Ref(),
 				archiveExtractionStatus: lo.ToPtr(ArchiveExtractionStatusPending),
+				public:                  true,
 			},
 		},
 	}
@@ -206,7 +218,8 @@ func TestBuilder_Build(t *testing.T) {
 				UUID(tt.input.uuid).
 				Thread(tt.input.thread.Ref()).
 				ArchiveExtractionStatus(tt.input.archiveExtractionStatus).
-				FlatFiles(tt.input.flatFiles)
+				FlatFiles(tt.input.flatFiles).
+			Public(tt.input.public)
 			if !tt.input.createdByUser.IsNil() {
 				ab.CreatedByUser(tt.input.createdByUser)
 			}
@@ -245,6 +258,7 @@ func TestBuilder_MustBuild(t *testing.T) {
 				previewType:   PreviewTypeFromRef(lo.ToPtr("image")),
 				uuid:          "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				thread:        thid.Ref(),
+				public:                  true,
 			},
 			want: &Asset{
 				id:          aid,
@@ -256,6 +270,7 @@ func TestBuilder_MustBuild(t *testing.T) {
 				previewType: PreviewTypeFromRef(lo.ToPtr("image")),
 				uuid:        "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				thread:      thid.Ref(),
+				public:                  true,
 			},
 		},
 		{
@@ -270,6 +285,7 @@ func TestBuilder_MustBuild(t *testing.T) {
 				previewType:   PreviewTypeFromRef(lo.ToPtr("image")),
 				uuid:          "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				thread:        thid.Ref(),
+				public:                  true,
 			},
 			err: ErrInvalidID,
 		},
@@ -291,6 +307,7 @@ func TestBuilder_MustBuild(t *testing.T) {
 					Size(tt.input.size).
 					UUID(tt.input.uuid).
 					Thread(tt.input.thread).
+					Public(tt.input.public).
 					MustBuild()
 			}
 			if tt.err != nil {

--- a/server/schemas/asset.graphql
+++ b/server/schemas/asset.graphql
@@ -16,6 +16,7 @@ type Asset implements Node {
   url: String!
   fileName: String!
   archiveExtractionStatus: ArchiveExtractionStatus
+  public: Boolean!
 }
 
 type AssetItem {


### PR DESCRIPTION
# Overview
This PR adds public to asset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new non-nullable Boolean field, `public`, to the Asset type in the GraphQL API, allowing users to see whether an asset is public.
- **Bug Fixes**
  - Ensured the `public` field is correctly handled in asset cloning and conversion.
- **Tests**
  - Updated and expanded test coverage to verify correct handling and representation of the `public` field for assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->