### PR TITLE
fix(server): correctly determine and return asset URL publicity

### DIFF
--- a/server/e2e/common_test.go
+++ b/server/e2e/common_test.go
@@ -90,14 +90,18 @@ func StartServerWithRepos(t *testing.T, cfg *app.Config, useMongo bool, seeder S
 		accountRepos = accountmemory.New()
 	}
 
-	assetBase := cfg.AssetBaseURL
-	if assetBase == "" {
-		assetBase = "https://example.com"
+	if cfg.AssetBaseURL == "" {
+		cfg.AssetBaseURL = "https://example.com"
+	}
+	if cfg.Host == "" {
+		cfg.Host = "https://example.com"
 	}
 
-	gateway := &gateway.Container{
-		File: lo.Must(fs.NewFile(afero.NewMemMapFs(), assetBase)),
+	f := lo.Must(fs.NewFile(afero.NewMemMapFs(), cfg.AssetBaseURL))
+	if !cfg.Asset_Public {
+		f = lo.Must(fs.NewFileWithACL(afero.NewMemMapFs(), cfg.AssetBaseURL, cfg.Host))
 	}
+	gateway := &gateway.Container{File: f}
 	accountGateways := &accountgateway.Container{
 		Mailer: mailer.New(ctx, &mailer.Config{}),
 	}

--- a/server/e2e/integration_asset_test.go
+++ b/server/e2e/integration_asset_test.go
@@ -82,8 +82,8 @@ func TestIntegrationDeleteAssetAPI(t *testing.T) {
 // Test asset Publish/Unpublish API with private asset bucket
 func TestIntegrationPublishAssetAPI1(t *testing.T) {
 	e := StartServer(t, &app.Config{
-		Host:         "http://localhost:8080",
-		AssetBaseURL: "http://localhost:8080",
+		Host:         "https://api.example.com",
+		AssetBaseURL: "https://assets.example.com",
 		Asset_Public: false,
 	}, true, baseSeeder)
 
@@ -122,12 +122,16 @@ func TestIntegrationPublishAssetAPI1(t *testing.T) {
 		JSON().
 		Object()
 	res.HasValue("public", false)
-	res.Value("url").String().Match("localhost:8080/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
+	res.Value("url").String().Match("https://api.example.com/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
 
-	aUrl := strings.TrimPrefix(res.Value("url").String().Raw(), "http://localhost:8080")
+	aUrl := strings.TrimPrefix(res.Value("url").String().Raw(), "https://api.example.com")
 	e.GET(aUrl).
 		Expect().
 		Status(http.StatusNotFound)
+	e.GET(aUrl).
+		WithHeader("authorization", "Bearer "+secret).
+		Expect().
+		Status(http.StatusOK)
 
 	e.POST("/api/assets/{assetId}/publish", aid1).
 		WithHeader("authorization", "Bearer "+secret).
@@ -146,9 +150,9 @@ func TestIntegrationPublishAssetAPI1(t *testing.T) {
 		Object()
 
 	res.HasValue("public", true)
-	res.Value("url").String().Match("localhost:8080/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
+	res.Value("url").String().Match("https://assets.example.com/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
 
-	aUrl = strings.TrimPrefix(res.Value("url").String().Raw(), "http://localhost:8080")
+	aUrl = strings.TrimPrefix(res.Value("url").String().Raw(), "https://assets.example.com")
 	e.GET(aUrl).
 		Expect().
 		Status(http.StatusOK)
@@ -170,20 +174,24 @@ func TestIntegrationPublishAssetAPI1(t *testing.T) {
 		Object()
 
 	res.HasValue("public", false)
-	res.Value("url").String().Match("localhost:8080/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
+	res.Value("url").String().Match("https://api.example.com/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
 
-	aUrl = strings.TrimPrefix(res.Value("url").String().Raw(), "http://localhost:8080")
+	aUrl = strings.TrimPrefix(res.Value("url").String().Raw(), "https://api.example.com")
 	e.GET(aUrl).
 		Expect().
 		Status(http.StatusNotFound)
+	e.GET(aUrl).
+		WithHeader("authorization", "Bearer "+secret).
+		Expect().
+		Status(http.StatusOK)
 
 }
 
 // Test asset Publish/Unpublish API with public asset bucket
 func TestIntegrationPublishAssetAPI2(t *testing.T) {
 	e := StartServer(t, &app.Config{
-		Host:         "http://localhost:8080",
-		AssetBaseURL: "http://localhost:8080",
+		Host:         "https://api.example.com",
+		AssetBaseURL: "https://assets.example.com",
 		Asset_Public: true,
 	}, true, baseSeeder)
 
@@ -222,9 +230,9 @@ func TestIntegrationPublishAssetAPI2(t *testing.T) {
 		JSON().
 		Object()
 	res.HasValue("public", true)
-	res.Value("url").String().Match("localhost:8080/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
+	res.Value("url").String().Match("https://assets.example.com/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
 
-	aUrl := strings.TrimPrefix(res.Value("url").String().Raw(), "http://localhost:8080")
+	aUrl := strings.TrimPrefix(res.Value("url").String().Raw(), "https://assets.example.com")
 	e.GET(aUrl).
 		Expect().
 		Status(http.StatusOK)
@@ -246,9 +254,9 @@ func TestIntegrationPublishAssetAPI2(t *testing.T) {
 		Object()
 
 	res.HasValue("public", true)
-	res.Value("url").String().Match("localhost:8080/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
+	res.Value("url").String().Match("https://assets.example.com/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
 
-	aUrl = strings.TrimPrefix(res.Value("url").String().Raw(), "http://localhost:8080")
+	aUrl = strings.TrimPrefix(res.Value("url").String().Raw(), "https://assets.example.com")
 	e.GET(aUrl).
 		Expect().
 		Status(http.StatusOK)
@@ -270,9 +278,9 @@ func TestIntegrationPublishAssetAPI2(t *testing.T) {
 		Object()
 
 	res.HasValue("public", true)
-	res.Value("url").String().Match("localhost:8080/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
+	res.Value("url").String().Match("https://assets.example.com/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
 
-	aUrl = strings.TrimPrefix(res.Value("url").String().Raw(), "http://localhost:8080")
+	aUrl = strings.TrimPrefix(res.Value("url").String().Raw(), "https://assets.example.com")
 	e.GET(aUrl).
 		Expect().
 		Status(http.StatusOK)

--- a/server/e2e/integration_asset_test.go
+++ b/server/e2e/integration_asset_test.go
@@ -121,7 +121,7 @@ func TestIntegrationPublishAssetAPI1(t *testing.T) {
 		Status(http.StatusOK).
 		JSON().
 		Object()
-	res.HasValue("public", false)
+	res.HasValue("public", true)
 	res.Value("url").String().Match("localhost:8080/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
 
 	aUrl := strings.TrimPrefix(res.Value("url").String().Raw(), "http://localhost:8080")
@@ -160,7 +160,7 @@ func TestIntegrationPublishAssetAPI1(t *testing.T) {
 		JSON().
 		Object().
 		HasValue("id", aid1.String()).
-		HasValue("public", false)
+		HasValue("public", true)
 
 	res = e.GET("/api/assets/{assetId}", aid1).
 		WithHeader("authorization", "Bearer "+secret).
@@ -169,7 +169,7 @@ func TestIntegrationPublishAssetAPI1(t *testing.T) {
 		JSON().
 		Object()
 
-	res.HasValue("public", false)
+	res.HasValue("public", true)
 	res.Value("url").String().Match("localhost:8080/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
 
 	aUrl = strings.TrimPrefix(res.Value("url").String().Raw(), "http://localhost:8080")
@@ -221,7 +221,7 @@ func TestIntegrationPublishAssetAPI2(t *testing.T) {
 		Status(http.StatusOK).
 		JSON().
 		Object()
-	res.HasValue("public", false)
+	res.HasValue("public", true)
 	res.Value("url").String().Match("localhost:8080/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
 
 	aUrl := strings.TrimPrefix(res.Value("url").String().Raw(), "http://localhost:8080")
@@ -260,7 +260,7 @@ func TestIntegrationPublishAssetAPI2(t *testing.T) {
 		JSON().
 		Object().
 		HasValue("id", aid1.String()).
-		HasValue("public", false)
+		HasValue("public", true)
 
 	res = e.GET("/api/assets/{assetId}", aid1).
 		WithHeader("authorization", "Bearer "+secret).
@@ -269,12 +269,11 @@ func TestIntegrationPublishAssetAPI2(t *testing.T) {
 		JSON().
 		Object()
 
-	res.HasValue("public", false)
+	res.HasValue("public", true)
 	res.Value("url").String().Match("localhost:8080/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
 
 	aUrl = strings.TrimPrefix(res.Value("url").String().Raw(), "http://localhost:8080")
 	e.GET(aUrl).
 		Expect().
 		Status(http.StatusOK)
-
 }

--- a/server/e2e/integration_asset_test.go
+++ b/server/e2e/integration_asset_test.go
@@ -121,7 +121,7 @@ func TestIntegrationPublishAssetAPI1(t *testing.T) {
 		Status(http.StatusOK).
 		JSON().
 		Object()
-	res.HasValue("public", true)
+	res.HasValue("public", false)
 	res.Value("url").String().Match("localhost:8080/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
 
 	aUrl := strings.TrimPrefix(res.Value("url").String().Raw(), "http://localhost:8080")
@@ -160,7 +160,7 @@ func TestIntegrationPublishAssetAPI1(t *testing.T) {
 		JSON().
 		Object().
 		HasValue("id", aid1.String()).
-		HasValue("public", true)
+		HasValue("public", false)
 
 	res = e.GET("/api/assets/{assetId}", aid1).
 		WithHeader("authorization", "Bearer "+secret).
@@ -169,7 +169,7 @@ func TestIntegrationPublishAssetAPI1(t *testing.T) {
 		JSON().
 		Object()
 
-	res.HasValue("public", true)
+	res.HasValue("public", false)
 	res.Value("url").String().Match("localhost:8080/assets/[0-9a-f]{2}/[0-9a-f-]{34}/aaa.jpg")
 
 	aUrl = strings.TrimPrefix(res.Value("url").String().Raw(), "http://localhost:8080")

--- a/server/internal/adapter/gql/gqlmodel/convert_asset.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_asset.go
@@ -6,7 +6,7 @@ import (
 	"github.com/samber/lo"
 )
 
-func ToAsset(a *asset.Asset, urlResolver func(a *asset.Asset) (string, bool)) *Asset {
+func ToAsset(a *asset.Asset, urlResolver asset.URLResolver) *Asset {
 	if a == nil {
 		return nil
 	}

--- a/server/internal/adapter/gql/gqlmodel/convert_asset.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_asset.go
@@ -6,14 +6,15 @@ import (
 	"github.com/samber/lo"
 )
 
-func ToAsset(a *asset.Asset, urlResolver func(a *asset.Asset) string) *Asset {
+func ToAsset(a *asset.Asset, urlResolver func(a *asset.Asset) (string, bool)) *Asset {
 	if a == nil {
 		return nil
 	}
 
 	var url string
+	var isPublic bool
 	if urlResolver != nil {
-		url = urlResolver(a)
+		url, isPublic = urlResolver(a)
 	}
 
 	var createdBy ID
@@ -40,7 +41,7 @@ func ToAsset(a *asset.Asset, urlResolver func(a *asset.Asset) string) *Asset {
 		ThreadID:                IDFromRef(a.Thread()),
 		ArchiveExtractionStatus: ToArchiveExtractionStatus(a.ArchiveExtractionStatus()),
 		Size:                    int64(a.Size()),
-		Public:                  a.Public(),
+		Public:                  isPublic,
 	}
 }
 

--- a/server/internal/adapter/gql/gqlmodel/convert_asset_test.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_asset_test.go
@@ -33,7 +33,7 @@ func TestToAsset(t *testing.T) {
 		FileName:      "aaa.jpg",
 		ThreadID:      lo.ToPtr(ID(thid.String())),
 		Size:          1000,
-		Public:        true,
+		Public:        false,
 	}
 
 	var a2 *asset.Asset = nil
@@ -61,8 +61,8 @@ func TestToAsset(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			resolver := func(_ *asset.Asset) string {
-				return "xxx"
+			resolver := func(_ *asset.Asset) (string, bool) {
+				return "xxx", false
 			}
 			got := ToAsset(tc.arg, resolver)
 			assert.Equal(t, tc.want, got)

--- a/server/internal/adapter/gql/loader_asset.go
+++ b/server/internal/adapter/gql/loader_asset.go
@@ -31,8 +31,6 @@ func (c *AssetLoader) FindByID(ctx context.Context, assetId gqlmodel.ID) (*gqlmo
 		return nil, err
 	}
 
-	
-
 	return gqlmodel.ToAsset(a, c.usecase.GetURL), nil
 }
 

--- a/server/internal/adapter/gql/loader_asset.go
+++ b/server/internal/adapter/gql/loader_asset.go
@@ -31,6 +31,8 @@ func (c *AssetLoader) FindByID(ctx context.Context, assetId gqlmodel.ID) (*gqlmo
 		return nil, err
 	}
 
+	
+
 	return gqlmodel.ToAsset(a, c.usecase.GetURL), nil
 }
 

--- a/server/internal/adapter/integration/asset.go
+++ b/server/internal/adapter/integration/asset.go
@@ -48,8 +48,7 @@ func (s *Server) AssetFilter(ctx context.Context, request AssetFilterRequestObje
 	}
 
 	itemList, err := util.TryMap(assets, func(a *asset.Asset) (integrationapi.Asset, error) {
-		aUrl := uc.Asset.GetURL(a)
-		aa := integrationapi.NewAsset(a, nil, aUrl, true)
+		aa := integrationapi.NewAsset(a, nil, uc.Asset.GetURL, true)
 		return *aa, nil
 	})
 	if err != nil {
@@ -125,8 +124,7 @@ func (s *Server) AssetCreate(ctx context.Context, request AssetCreateRequestObje
 		return AssetCreate400Response{}, err
 	}
 
-	aUrl := uc.Asset.GetURL(a)
-	aa := integrationapi.NewAsset(a, af, aUrl, true)
+	aa := integrationapi.NewAsset(a, af, uc.Asset.GetURL, true)
 	return AssetCreate200JSONResponse(*aa), nil
 }
 
@@ -184,8 +182,7 @@ func (s *Server) AssetGet(ctx context.Context, request AssetGetRequestObject) (A
 		return AssetGet400Response{}, err
 	}
 
-	aUrl := uc.Asset.GetURL(a)
-	aa := integrationapi.NewAsset(a, f, aUrl, true)
+	aa := integrationapi.NewAsset(a, f, uc.Asset.GetURL, true)
 	return AssetGet200JSONResponse(*aa), nil
 }
 
@@ -264,8 +261,7 @@ func (s *Server) AssetPublish(ctx context.Context, request AssetPublishRequestOb
 		return AssetPublish404Response{}, err
 	}
 
-	aUrl := uc.Asset.GetURL(a)
-	aa := integrationapi.NewAsset(a, f, aUrl, true)
+	aa := integrationapi.NewAsset(a, f, uc.Asset.GetURL, true)
 	return AssetPublish200JSONResponse(*aa), nil
 }
 
@@ -286,7 +282,6 @@ func (s *Server) AssetUnpublish(ctx context.Context, request AssetUnpublishReque
 		return AssetUnpublish404Response{}, err
 	}
 
-	aUrl := uc.Asset.GetURL(a)
-	aa := integrationapi.NewAsset(a, f, aUrl, true)
+	aa := integrationapi.NewAsset(a, f, uc.Asset.GetURL, true)
 	return AssetUnpublish200JSONResponse(*aa), nil
 }

--- a/server/internal/adapter/publicapi/types.go
+++ b/server/internal/adapter/publicapi/types.go
@@ -174,7 +174,8 @@ func NewAsset(a *asset.Asset, f *asset.File, urlResolver asset.URLResolver) Asse
 	u := ""
 	var files []string
 	if urlResolver != nil {
-		u = urlResolver(a)
+		// TODO: how to handle public api with asset url management
+		u, _ = urlResolver(a)
 		base, _ := url.Parse(u)
 		base.Path = path.Dir(base.Path)
 
@@ -203,7 +204,8 @@ type ItemAsset struct {
 func NewItemAsset(a *asset.Asset, urlResolver asset.URLResolver) ItemAsset {
 	u := ""
 	if urlResolver != nil {
-		u = urlResolver(a)
+		// TODO: how to handle public api with asset url management
+		u, _ = urlResolver(a)
 	}
 
 	return ItemAsset{

--- a/server/internal/adapter/publicapi/types_test.go
+++ b/server/internal/adapter/publicapi/types_test.go
@@ -83,8 +83,8 @@ func TestNewItem(t *testing.T) {
 			},
 			"ggggg": resGroup,
 		}),
-	}, NewItem(it, schema.NewPackage(s, nil, map[id.GroupID]*schema.Schema{id.NewGroupID(): s2}, nil), asset.List{as}, func(a *asset.Asset) string {
-		return "https://example.com/" + a.ID().String() + af.Path()
+	}, NewItem(it, schema.NewPackage(s, nil, map[id.GroupID]*schema.Schema{id.NewGroupID(): s2}, nil), asset.List{as}, func(a *asset.Asset) (string, bool) {
+		return "https://example.com/" + a.ID().String() + af.Path(), false
 	}, nil))
 
 	// no assets
@@ -138,8 +138,8 @@ func TestNewItem_Multiple(t *testing.T) {
 				URL:  "https://example.com/" + as.ID().String() + af.Path(),
 			}},
 		}),
-	}, NewItem(it, schema.NewPackage(s, nil, nil, nil), asset.List{as}, func(a *asset.Asset) string {
-		return "https://example.com/" + a.ID().String() + af.Path()
+	}, NewItem(it, schema.NewPackage(s, nil, nil, nil), asset.List{as}, func(a *asset.Asset) (string, bool) {
+		return "https://example.com/" + a.ID().String() + af.Path(), false
 	}, nil))
 
 	// no assets

--- a/server/internal/app/repo.go
+++ b/server/internal/app/repo.go
@@ -124,6 +124,7 @@ func InitReposAndGateways(ctx context.Context, conf *Config) (*repo.Container, *
 	if conf.Task.GCPProject != "" {
 		conf.Task.GCSHost = conf.Host
 		conf.Task.GCSBucket = conf.GCS.BucketName
+		conf.Task.GCSPublic = conf.Asset_Public
 		taskRunner, err := gcp.NewTaskRunner(ctx, &conf.Task)
 		if err != nil {
 			log.Fatalf("task runner: gcp init error: %+v", err)

--- a/server/internal/infrastructure/aws/file.go
+++ b/server/internal/infrastructure/aws/file.go
@@ -166,12 +166,13 @@ func (f *fileRepo) UnpublishAsset(ctx context.Context, u string, fn string) erro
 	return f.publish(ctx, getS3ObjectPath(u, fn), false)
 }
 
-func (f *fileRepo) GetURL(a *asset.Asset) string {
-	base := f.publicBase
-	if !f.public && !a.Public() {
-		base = f.privateBase
+func (f *fileRepo) GetURL(a *asset.Asset) (string, bool) {
+	base := f.privateBase
+	publiclyAccessible := f.public || a.Public()
+	if publiclyAccessible {
+		base = f.publicBase
 	}
-	return getURL(base, a.UUID(), a.FileName())
+	return getURL(base, a.UUID(), a.FileName()), publiclyAccessible
 }
 
 func (f *fileRepo) GetBaseURL() string {

--- a/server/internal/infrastructure/aws/file_test.go
+++ b/server/internal/infrastructure/aws/file_test.go
@@ -32,7 +32,8 @@ func TestFile_GetURL(t *testing.T) {
 
 	expected, err := url.JoinPath(host, s3AssetBasePath, u[:2], u[2:], n)
 	assert.NoError(t, err)
-	actual := r.GetURL(a)
+	// TODO: add tests for public and private assets and buckets
+	actual, _ := r.GetURL(a)
 	assert.Equal(t, expected, actual)
 }
 

--- a/server/internal/infrastructure/aws/taskrunner.go
+++ b/server/internal/infrastructure/aws/taskrunner.go
@@ -91,13 +91,15 @@ func (t *TaskRunner) runWebhookReq(ctx context.Context, p task.Payload) error {
 		return nil
 	}
 
+	// TODO: maybe the host is missing here and should be handled based on asset url management
 	u, err := url.Parse(s3AssetBasePath)
 	if err != nil {
 		return err
 	}
 
-	var urlFn = func(a *asset.Asset) string {
-		return getURL(u, a.UUID(), a.FileName())
+	var urlFn = func(a *asset.Asset) (string, bool) {
+		// TODO: handle bucket publicity as well as asset publicity for asset url management
+		return getURL(u, a.UUID(), a.FileName()), a.Public()
 	}
 
 	data, err := marshalWebhookData(p.Webhook, urlFn)

--- a/server/internal/infrastructure/fs/file.go
+++ b/server/internal/infrastructure/fs/file.go
@@ -151,12 +151,13 @@ func (f *fileRepo) UnpublishAsset(_ context.Context, u string, fn string) error 
 	return nil
 }
 
-func (f *fileRepo) GetURL(a *asset.Asset) string {
-	base := f.publicBase
-	if !f.public && !a.Public() {
-		base = f.privateBase
+func (f *fileRepo) GetURL(a *asset.Asset) (string, bool) {
+	base := f.privateBase
+	publiclyAccessible := f.public || a.Public()
+	if publiclyAccessible {
+		base = f.publicBase
 	}
-	return grtURL(base, a.UUID(), url.PathEscape(a.FileName()))
+	return grtURL(base, a.UUID(), url.PathEscape(a.FileName())), publiclyAccessible
 }
 
 func grtURL(host *url.URL, uuid, fName string) string {

--- a/server/internal/infrastructure/fs/file.go
+++ b/server/internal/infrastructure/fs/file.go
@@ -60,7 +60,7 @@ func NewFileWithACL(fs afero.Fs, publicBase, privateBase string) (gateway.File, 
 	fr := f.(*fileRepo)
 	fr.public = false
 	fr.privateBase = u
-	return f, nil
+	return fr, nil
 }
 
 func (f *fileRepo) ReadAsset(ctx context.Context, fileUUID string, fn string, h map[string]string) (io.ReadCloser, map[string]string, error) {

--- a/server/internal/infrastructure/fs/file_test.go
+++ b/server/internal/infrastructure/fs/file_test.go
@@ -196,7 +196,8 @@ func TestFile_GetURL(t *testing.T) {
 
 	expected, err := url.JoinPath(host, assetDir, u[:2], u[2:], url.PathEscape(n))
 	assert.NoError(t, err)
-	actual := r.GetURL(a)
+	// TODO: add tests for public and private assets and buckets
+	actual, _ := r.GetURL(a)
 	assert.Equal(t, expected, actual)
 }
 

--- a/server/internal/infrastructure/gcp/config.go
+++ b/server/internal/infrastructure/gcp/config.go
@@ -6,6 +6,7 @@ type TaskConfig struct {
 	Topic                   string `pp:",omitempty"`
 	GCSHost                 string `pp:",omitempty"`
 	GCSBucket               string `pp:",omitempty"`
+	GCSPublic               bool   `pp:",omitempty"`
 	DecompressorImage       string `default:"reearth/reearth-cms-decompressor"`
 	DecompressorTopic       string `default:"decompress"`
 	DecompressorGzipExt     string `default:"gml"`

--- a/server/internal/infrastructure/gcp/file.go
+++ b/server/internal/infrastructure/gcp/file.go
@@ -194,12 +194,13 @@ func (f *fileRepo) UnpublishAsset(ctx context.Context, u string, fn string) erro
 	return f.publish(ctx, p, false)
 }
 
-func (f *fileRepo) GetURL(a *asset.Asset) string {
-	base := f.publicBase
-	if !f.public && !a.Public() {
-		base = f.privateBase
+func (f *fileRepo) GetURL(a *asset.Asset) (string, bool) {
+	base := f.privateBase
+	publiclyAccessible := f.public || a.Public()
+	if publiclyAccessible {
+		base = f.publicBase
 	}
-	return getURL(base, a.UUID(), a.FileName())
+	return getURL(base, a.UUID(), a.FileName()), publiclyAccessible
 }
 
 func (f *fileRepo) GetBaseURL() string {

--- a/server/internal/infrastructure/gcp/file_test.go
+++ b/server/internal/infrastructure/gcp/file_test.go
@@ -30,7 +30,8 @@ func TestFile_GetURL(t *testing.T) {
 
 	expected, err := url.JoinPath(host, gcsAssetBasePath, u[:2], u[2:], n)
 	assert.NoError(t, err)
-	actual := r.GetURL(a)
+	// TODO: add tests for public and private assets and buckets
+	actual, _ := r.GetURL(a)
 	assert.Equal(t, expected, actual)
 }
 

--- a/server/internal/infrastructure/gcp/taskrunner.go
+++ b/server/internal/infrastructure/gcp/taskrunner.go
@@ -315,13 +315,15 @@ func (t *TaskRunner) runPubSub(ctx context.Context, p task.Payload) error {
 		return nil
 	}
 
+	// TODO: handle base url depending on asset url management
 	u, err := url.Parse(t.conf.GCSHost)
 	if err != nil {
 		return fmt.Errorf("failed to parse GCS host as a URL: %w", err)
 	}
 
-	var urlFn = func(a *asset.Asset) string {
-		return getURL(u, a.UUID(), a.FileName())
+	var urlFn = func(a *asset.Asset) (string, bool) {
+		// u should be based on asset publicity or bucket publicity
+		return getURL(u, a.UUID(), a.FileName()), t.conf.GCSPublic || a.Public()
 	}
 
 	data, err := marshalWebhookData(p.Webhook, urlFn)

--- a/server/internal/usecase/gateway/file.go
+++ b/server/internal/usecase/gateway/file.go
@@ -70,7 +70,7 @@ type File interface {
 	DeleteAssets(context.Context, []string) error
 	PublishAsset(context.Context, string, string) error
 	UnpublishAsset(context.Context, string, string) error
-	GetURL(*asset.Asset) string
+	GetURL(*asset.Asset) (string, bool)
 	GetBaseURL() string
 	IssueUploadAssetLink(context.Context, IssueUploadAssetParam) (*UploadAssetLink, error)
 	UploadedAsset(context.Context, *asset.Upload) (*file.File, error)

--- a/server/internal/usecase/interactor/asset.go
+++ b/server/internal/usecase/interactor/asset.go
@@ -100,7 +100,7 @@ func (i *Asset) DownloadByID(ctx context.Context, aid id.AssetID, headers map[st
 	return f, headers, nil
 }
 
-func (i *Asset) GetURL(a *asset.Asset) string {
+func (i *Asset) GetURL(a *asset.Asset) (string, bool) {
 	return i.gateways.File.GetURL(a)
 }
 

--- a/server/internal/usecase/interactor/asset_test.go
+++ b/server/internal/usecase/interactor/asset_test.go
@@ -1388,23 +1388,30 @@ func TestAsset_Delete(t *testing.T) {
 
 type file2 struct {
 	gateway.File
+	public bool
 }
 
-func (f *file2) GetURL(a *asset.Asset) string {
+func (f *file2) GetURL(a *asset.Asset) (string, bool) {
 	if a == nil {
-		return ""
+		return "", f.public
 	}
-	return "xxx"
+	return "xxx", f.public
 }
 
 func TestAsset_GetURL(t *testing.T) {
 	uc := &Asset{
 		gateways: &gateway.Container{
-			File: &file2{},
+			File: &file2{
+				public: true,
+			},
 		},
 	}
-	assert.Equal(t, "", uc.GetURL(nil))
-	assert.Equal(t, "xxx", uc.GetURL(&asset.Asset{}))
+	res, isPublic := uc.GetURL(nil)
+	assert.Equal(t, "", res)
+	assert.True(t, isPublic)
+	res, isPublic = uc.GetURL(&asset.Asset{})
+	assert.Equal(t, "xxx",res)
+	assert.True(t, isPublic)
 }
 
 func mockFs() afero.Fs {

--- a/server/internal/usecase/interfaces/asset.go
+++ b/server/internal/usecase/interfaces/asset.go
@@ -67,7 +67,7 @@ type Asset interface {
 	FindFileByID(context.Context, id.AssetID, *usecase.Operator) (*asset.File, error)
 	FindFilesByIDs(context.Context, id.AssetIDList, *usecase.Operator) (map[id.AssetID]*asset.File, error)
 	DownloadByID(context.Context, id.AssetID, map[string]string, *usecase.Operator) (io.ReadCloser, map[string]string, error)
-	GetURL(*asset.Asset) string
+	GetURL(*asset.Asset) (string, bool)
 	Create(context.Context, CreateAssetParam, *usecase.Operator) (*asset.Asset, *asset.File, error)
 	Update(context.Context, UpdateAssetParam, *usecase.Operator) (*asset.Asset, error)
 	UpdateFiles(context.Context, id.AssetID, *asset.ArchiveExtractionStatus, *usecase.Operator) (*asset.Asset, error)

--- a/server/pkg/asset/asset.go
+++ b/server/pkg/asset/asset.go
@@ -24,7 +24,7 @@ type Asset struct {
 	public                  bool
 }
 
-type URLResolver = func(*Asset) string
+type URLResolver = func(*Asset) (string, bool)
 
 // getters
 

--- a/server/pkg/integrationapi/asset.go
+++ b/server/pkg/integrationapi/asset.go
@@ -5,7 +5,7 @@ import (
 	"github.com/samber/lo"
 )
 
-func NewAsset(a *asset.Asset, f *asset.File, url string, all bool) *Asset {
+func NewAsset(a *asset.Asset, f *asset.File, urlFn asset.URLResolver, all bool) *Asset {
 	if a == nil {
 		return nil
 	}
@@ -16,6 +16,11 @@ func NewAsset(a *asset.Asset, f *asset.File, url string, all bool) *Asset {
 	}
 	if fn := f.Name(); fn != "" {
 		n = lo.ToPtr(fn)
+	}
+
+	url, isPublic := "", false
+	if urlFn != nil {
+		url, isPublic = urlFn(a)
 	}
 
 	return &Asset{
@@ -29,7 +34,7 @@ func NewAsset(a *asset.Asset, f *asset.File, url string, all bool) *Asset {
 		Url:                     url,
 		File:                    ToAssetFile(f, all),
 		ArchiveExtractionStatus: ToAssetArchiveExtractionStatus(a.ArchiveExtractionStatus()),
-		Public:                  a.Public(),
+		Public:                  isPublic,
 	}
 }
 

--- a/server/pkg/integrationapi/asset_test.go
+++ b/server/pkg/integrationapi/asset_test.go
@@ -64,21 +64,22 @@ func Test_NewAsset(t *testing.T) {
 		CreatedByUser(uid).Thread(id.NewThreadID().Ref()).CreatedAt(timeNow).MustBuild()
 
 	f1 := asset.NewFile().Name(name).Path(path).ContentType("s").Size(10).Build()
+	fn := func(*asset.Asset) (string, bool) { return "www.", false }
 
 	tests := []struct {
-		name string
-		a    *asset.Asset
-		f    *asset.File
-		url  string
-		all  bool
-		want *Asset
+		name  string
+		a     *asset.Asset
+		f     *asset.File
+		urlFn asset.URLResolver
+		all   bool
+		want  *Asset
 	}{
 		{
-			name: "success",
-			a:    a,
-			f:    f1,
-			url:  "www.",
-			all:  true,
+			name:  "success",
+			a:     a,
+			f:     f1,
+			urlFn: fn,
+			all:   true,
 			want: &Asset{
 				Name:      lo.ToPtr("aaa"),
 				Id:        a.ID(),
@@ -97,19 +98,19 @@ func Test_NewAsset(t *testing.T) {
 			},
 		},
 		{
-			name: "asset and file input is nil",
-			a:    nil,
-			f:    nil,
-			url:  "www.",
-			all:  false,
-			want: nil,
+			name:  "asset and file input is nil",
+			a:     nil,
+			f:     nil,
+			urlFn: fn,
+			all:   false,
+			want:  nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := NewAsset(tt.a, tt.f, tt.url, tt.all)
+			result := NewAsset(tt.a, tt.f, tt.urlFn, tt.all)
 
 			assert.Equal(t, result, tt.want)
 		})

--- a/server/pkg/integrationapi/convert.go
+++ b/server/pkg/integrationapi/convert.go
@@ -20,7 +20,7 @@ func New(obj any, v string, urlResolver asset.URLResolver) (res any, err error) 
 	case *event.Event[any]:
 		res, err = NewEvent(o, v, urlResolver)
 	case *asset.Asset:
-		res = NewAsset(o, nil, urlResolver(o), true)
+		res = NewAsset(o, nil, urlResolver, true)
 	case *asset.File:
 		res = ToAssetFile(o, true)
 	case *item.Item:

--- a/server/pkg/integrationapi/event_test.go
+++ b/server/pkg/integrationapi/event_test.go
@@ -80,11 +80,11 @@ func TestNewEventWith(t *testing.T) {
 
 	ev := event.New[any]().ID(eID1).Timestamp(mockTime).Type(event.AssetCreate).Operator(operator.OperatorFromUser(u.ID())).Object(a).Project(&prj).MustBuild()
 	ev1 := event.New[any]().ID(eID1).Timestamp(mockTime).Type(event.Type("test")).Operator(operator.OperatorFromUser(u.ID())).Object("test").Project(&prj).MustBuild()
-	d1, _ := New(ev, "test", func(a *asset.Asset) string {
-		return "test.com"
+	d1, _ := New(ev, "test", func(a *asset.Asset) (string, bool) {
+		return "test.com", false
 	})
-	d2, _ := New(ev.Object(), "test", func(a *asset.Asset) string {
-		return "test.com"
+	d2, _ := New(ev.Object(), "test", func(a *asset.Asset) (string, bool) {
+		return "test.com", false
 	})
 	type args struct {
 		event       *event.Event[any]
@@ -104,8 +104,8 @@ func TestNewEventWith(t *testing.T) {
 				event:    ev,
 				override: ev,
 				v:        "test",
-				urlResolver: func(a *asset.Asset) string {
-					return "test.com"
+				urlResolver: func(a *asset.Asset) (string, bool) {
+					return "test.com", false
 				},
 			},
 			want: Event{
@@ -127,8 +127,8 @@ func TestNewEventWith(t *testing.T) {
 				event:    ev,
 				override: nil,
 				v:        "test",
-				urlResolver: func(a *asset.Asset) string {
-					return "test.com"
+				urlResolver: func(a *asset.Asset) (string, bool) {
+					return "test.com", false
 				},
 			},
 			want: Event{

--- a/server/pkg/integrationapi/value.go
+++ b/server/pkg/integrationapi/value.go
@@ -137,24 +137,18 @@ func ToValue(v *value.Value, sf *schema.Field, assets *AssetContext) any {
 type AssetContext struct {
 	Map     asset.Map
 	Files   map[asset.ID]*asset.File
-	BaseURL func(a *asset.Asset) string
+	BaseURL func(a *asset.Asset) (string, bool)
 	All     bool
 }
 
 func (c *AssetContext) ResolveAsset(id asset.ID) *Asset {
 	if c.Map != nil {
 		if a, ok := c.Map[id]; ok {
-			var aurl string
-			if c.BaseURL != nil {
-				aurl = c.BaseURL(a)
-			}
-
 			var f *asset.File
 			if c.Files != nil {
 				f = c.Files[id]
 			}
-
-			return NewAsset(a, f, aurl, c.All)
+			return NewAsset(a, f, c.BaseURL, c.All)
 		}
 	}
 	return nil


### PR DESCRIPTION
# Overview
This PR updates the GetURL method in the fileRepo to correctly determine whether an asset URL should be publicly accessible based on repository and asset visibility. It now returns both the generated URL and a boolean indicating its publicity.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Asset URLs now include information on whether they are publicly accessible, improving clarity on asset visibility.

- **Bug Fixes**
  - Adjusted tests and logic to ensure correct handling and reporting of asset public/private status throughout the application.
  - Updated asset publishing tests to verify authorized access and consistent public status handling.

- **Refactor**
  - Updated asset URL resolver interfaces and method signatures to consistently return both the URL and its public status.
  - Streamlined passing of asset URL and visibility information between components for improved maintainability.
  - Inverted logic for determining public versus private base URLs across storage adapters.

- **Tests**
  - Updated and expanded test coverage to reflect changes in URL resolver signatures and asset public status handling.

- **Chores**
  - Added configuration support for public GCS buckets.
  - Added TODO comments for future improvements regarding asset URL management and public/private handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->