### PR TITLE
fix(web): add null check before calling onGetViewer in ResiumViewer

### DIFF
--- a/web/src/components/atoms/ResiumViewer/index.tsx
+++ b/web/src/components/atoms/ResiumViewer/index.tsx
@@ -117,7 +117,7 @@ const ResiumViewer: React.FC<Props> = ({
         shouldAnimate={true}
         onClick={handleClick}
         infoBox={false}
-        ref={node => onGetViewer(node?.cesiumElement)}>
+        ref={node => node && onGetViewer(node?.cesiumElement)}>
         {children}
       </StyledViewer>
       <InfoBox

--- a/web/src/components/atoms/ResiumViewer/index.tsx
+++ b/web/src/components/atoms/ResiumViewer/index.tsx
@@ -117,7 +117,7 @@ const ResiumViewer: React.FC<Props> = ({
         shouldAnimate={true}
         onClick={handleClick}
         infoBox={false}
-        ref={node => node && onGetViewer(node?.cesiumElement)}>
+        ref={node => node && onGetViewer(node.cesiumElement)}>
         {children}
       </StyledViewer>
       <InfoBox

--- a/web/src/components/organisms/Project/Asset/Asset/hooks.ts
+++ b/web/src/components/organisms/Project/Asset/Asset/hooks.ts
@@ -50,6 +50,10 @@ export default (assetId?: string) => {
   const [collapsed, setCollapsed] = useState(true);
   const [isSaveDisabled, setIsSaveDisabled] = useState(true);
 
+  useEffect(() => {
+    Ion.defaultAccessToken = config()?.cesiumIonAccessToken ?? Ion.defaultAccessToken;
+  }, []);
+
   const { data: rawAsset, networkStatus } = useGetAssetItemQuery({
     variables: {
       assetId: assetId ?? "",
@@ -186,10 +190,9 @@ export default (assetId?: string) => {
   );
 
   const viewerRef = useRef<CesiumViewer>();
-
-  const handleGetViewer = (viewer?: CesiumViewer) => {
+  const handleGetViewer = useCallback((viewer?: CesiumViewer) => {
     viewerRef.current = viewer;
-  };
+  }, []);
 
   const handleFullScreen = useCallback(() => {
     if (viewerType === "unknown") {
@@ -220,10 +223,6 @@ export default (assetId?: string) => {
     },
     [setCollapsed],
   );
-
-  useEffect(() => {
-    Ion.defaultAccessToken = config()?.cesiumIonAccessToken ?? Ion.defaultAccessToken;
-  }, []);
 
   const handleSave = useCallback(async () => {
     if (assetId) {


### PR DESCRIPTION
# Overview
This PR adds null check before calling onGetViewer in ResiumViewer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when passing the viewer instance to event handlers, ensuring it is only provided when available.
  - Ensured the Cesium Ion access token is set immediately after component mount for more predictable initialization.

- **Refactor**
  - Optimized event handler performance by stabilizing its reference across renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->