### PR TITLE
test(web): change the number of workers on CI from 2 to 4

### DIFF
--- a/.github/workflows/e2e_web.yml
+++ b/.github/workflows/e2e_web.yml
@@ -64,6 +64,8 @@ jobs:
         run: |
           echo "REEARTH_CMS_API is $REEARTH_CMS_API"
           echo "REEARTH_CMS_E2E_BASEURL is $REEARTH_CMS_E2E_BASEURL"
+      - name: Check CI env
+        run: echo "CI = $CI"
       - name: Run Playwright tests
         run: yarn e2e
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e_web.yml
+++ b/.github/workflows/e2e_web.yml
@@ -1,6 +1,13 @@
 name: Web E2E test
 on:
+  push:
+    branches: [test-web/test-4-workers]
   workflow_dispatch:
+    inputs:
+      branch:
+        description: "Target branch"
+        required: false
+        default: "main"
   schedule:
     - cron: "0 3 * * 1-5"
   workflow_call:
@@ -33,9 +40,6 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: reearth/reearth-cms
-          ref: ${{ inputs.branch || 'main' }}
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*

--- a/.github/workflows/e2e_web.yml
+++ b/.github/workflows/e2e_web.yml
@@ -1,7 +1,5 @@
 name: Web E2E test
 on:
-  push:
-    branches: [test-web/test-4-workers]
   workflow_dispatch:
     inputs:
       branch:
@@ -40,6 +38,9 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: reearth/reearth-cms
+          ref: ${{ inputs.branch || 'main' }}
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*

--- a/.github/workflows/e2e_web.yml
+++ b/.github/workflows/e2e_web.yml
@@ -64,8 +64,6 @@ jobs:
         run: |
           echo "REEARTH_CMS_API is $REEARTH_CMS_API"
           echo "REEARTH_CMS_E2E_BASEURL is $REEARTH_CMS_E2E_BASEURL"
-      - name: Check CI env
-        run: echo "CI = $CI"
       - name: Run Playwright tests
         run: yarn e2e
       - uses: actions/upload-artifact@v4

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,7 @@
     "preview": "vite preview",
     "test": "vitest",
     "coverage": "vitest run --coverage",
-    "e2e": "playwright test --workers=4",
+    "e2e": "playwright test",
     "lint": "eslint .",
     "fix": "eslint --fix .",
     "format": "prettier --write .",

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,7 @@
     "preview": "vite preview",
     "test": "vitest",
     "coverage": "vitest run --coverage",
-    "e2e": "playwright test",
+    "e2e": "playwright test --workers=4",
     "lint": "eslint .",
     "fix": "eslint --fix .",
     "format": "prettier --write .",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -13,7 +13,7 @@ export const authFile = path.join(__dirname, "./e2e/utils/.auth/user.json");
 export const baseURL = process.env.REEARTH_CMS_E2E_BASEURL || "http://localhost:3000/";
 
 const config: PlaywrightTestConfig = {
-  workers: 1,
+  workers: process.env.CI ? 2 : undefined,
   retries: 2,
   use: {
     baseURL,

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -13,7 +13,7 @@ export const authFile = path.join(__dirname, "./e2e/utils/.auth/user.json");
 export const baseURL = process.env.REEARTH_CMS_E2E_BASEURL || "http://localhost:3000/";
 
 const config: PlaywrightTestConfig = {
-  workers: process.env.CI ? 4 : undefined,
+  workers: process.env.CI ? 1 : undefined,
   retries: 2,
   use: {
     baseURL,

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -13,7 +13,7 @@ export const authFile = path.join(__dirname, "./e2e/utils/.auth/user.json");
 export const baseURL = process.env.REEARTH_CMS_E2E_BASEURL || "http://localhost:3000/";
 
 const config: PlaywrightTestConfig = {
-  workers: process.env.CI ? 1 : undefined,
+  workers: 1,
   retries: 2,
   use: {
     baseURL,

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -13,7 +13,7 @@ export const authFile = path.join(__dirname, "./e2e/utils/.auth/user.json");
 export const baseURL = process.env.REEARTH_CMS_E2E_BASEURL || "http://localhost:3000/";
 
 const config: PlaywrightTestConfig = {
-  workers: process.env.CI ? 2 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   retries: 2,
   use: {
     baseURL,


### PR DESCRIPTION
# Overview
This PR changes the number of workers on CI from 2 to 4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added an option to manually specify a target branch when triggering Web E2E tests.
  - Increased the number of parallel workers for Playwright tests in CI environments for faster test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->