### PR TITLE
fix(web): introduce startup delay to Asset page before loading content

### DIFF
--- a/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { Viewer as CesiumViewer } from "cesium";
-import { MutableRefObject, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 import Button from "@reearth-cms/components/atoms/Button";
 import CopyButton from "@reearth-cms/components/atoms/CopyButton";
@@ -37,7 +37,6 @@ type Props = {
   assetFileExt?: string;
   selectedPreviewType: PreviewType;
   isModalVisible: boolean;
-  viewerRef: MutableRefObject<CesiumViewer | undefined>;
   viewerType: ViewerType;
   displayUnzipFileList: boolean;
   decompressing: boolean;
@@ -57,7 +56,6 @@ const AssetMolecule: React.FC<Props> = ({
   assetFileExt,
   selectedPreviewType,
   isModalVisible,
-  viewerRef,
   viewerType,
   displayUnzipFileList,
   decompressing,
@@ -91,7 +89,6 @@ const AssetMolecule: React.FC<Props> = ({
         return (
           <Geo3dViewer
             url={assetUrl}
-            viewerRef={viewerRef}
             setAssetUrl={setAssetUrl}
             workspaceSettings={workspaceSettings}
             onGetViewer={onGetViewer}
@@ -101,7 +98,6 @@ const AssetMolecule: React.FC<Props> = ({
         return (
           <MvtViewer
             url={assetUrl}
-            viewerRef={viewerRef}
             workspaceSettings={workspaceSettings}
             onGetViewer={onGetViewer}
           />
@@ -130,7 +126,7 @@ const AssetMolecule: React.FC<Props> = ({
       default:
         return <ViewerNotSupported />;
     }
-  }, [assetFileExt, assetUrl, onGetViewer, svgRender, viewerRef, viewerType, workspaceSettings]);
+  }, [assetFileExt, assetUrl, onGetViewer, svgRender, viewerType, workspaceSettings]);
 
   return (
     <BodyContainer>

--- a/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
@@ -91,9 +91,10 @@ const AssetMolecule: React.FC<Props> = ({
         return (
           <Geo3dViewer
             url={assetUrl}
+            viewerRef={viewerRef}
             setAssetUrl={setAssetUrl}
-            onGetViewer={onGetViewer}
             workspaceSettings={workspaceSettings}
+            onGetViewer={onGetViewer}
           />
         );
       case "geo_mvt":

--- a/web/src/components/molecules/Asset/Asset/AssetBody/index.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/index.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 import { Viewer as CesiumViewer } from "cesium";
-import { MutableRefObject } from "react";
 
 import Button from "@reearth-cms/components/atoms/Button";
 import ComplexInnerContents from "@reearth-cms/components/atoms/InnerContents/complex";
@@ -17,7 +16,6 @@ type Props = {
   assetFileExt?: string;
   selectedPreviewType: PreviewType;
   isModalVisible: boolean;
-  viewerRef: MutableRefObject<CesiumViewer | undefined>;
   viewerType: ViewerType;
   displayUnzipFileList: boolean;
   decompressing: boolean;
@@ -41,7 +39,6 @@ const AssetWrapper: React.FC<Props> = ({
   assetFileExt,
   selectedPreviewType,
   isModalVisible,
-  viewerRef,
   viewerType,
   displayUnzipFileList,
   decompressing,
@@ -80,7 +77,6 @@ const AssetWrapper: React.FC<Props> = ({
             assetFileExt={assetFileExt}
             selectedPreviewType={selectedPreviewType}
             isModalVisible={isModalVisible}
-            viewerRef={viewerRef}
             viewerType={viewerType}
             displayUnzipFileList={displayUnzipFileList}
             decompressing={decompressing}

--- a/web/src/components/molecules/Asset/Asset/AssetBody/waitForViewer.ts
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/waitForViewer.ts
@@ -1,8 +1,7 @@
 import { Viewer as CesiumViewer } from "cesium";
-import { MutableRefObject } from "react";
 
 export function waitForViewer(
-  viewerRef: MutableRefObject<CesiumViewer | undefined>,
+  viewer?: CesiumViewer,
   timeout = 10000,
   interval = 100,
 ): Promise<CesiumViewer> {
@@ -10,7 +9,6 @@ export function waitForViewer(
     const start = Date.now();
 
     const check = () => {
-      const viewer = viewerRef.current;
       if (viewer) {
         resolve(viewer);
       } else if (Date.now() - start >= timeout) {

--- a/web/src/components/molecules/Asset/Viewers/Geo3dViewer/Cesium3dTileSetComponent.tsx
+++ b/web/src/components/molecules/Asset/Viewers/Geo3dViewer/Cesium3dTileSetComponent.tsx
@@ -1,28 +1,28 @@
-import { Cesium3DTileset, Viewer as CesiumViewer } from "cesium";
-import { ComponentProps, MutableRefObject, useCallback } from "react";
-import { Cesium3DTileset as Resium3DTileset } from "resium";
+import { Cesium3DTileset } from "cesium";
+import { ComponentProps, useCallback } from "react";
+import { Cesium3DTileset as Resium3DTileset, useCesium } from "resium";
 
 import { waitForViewer } from "@reearth-cms/components/molecules/Asset/Asset/AssetBody/waitForViewer";
 
-type Props = ComponentProps<typeof Resium3DTileset> & {
-  viewerRef: MutableRefObject<CesiumViewer | undefined>;
-};
+type Props = ComponentProps<typeof Resium3DTileset>;
 
-const Cesium3dTileSetComponent: React.FC<Props> = ({ viewerRef, ...props }) => {
+const Cesium3dTileSetComponent: React.FC<Props> = ({ ...props }) => {
+  const { viewer } = useCesium();
+
   const handleReady = useCallback(
     async (tileset: Cesium3DTileset) => {
       try {
         // Wait for the next frame to ensure everything is properly initialized
         await new Promise(resolve => requestAnimationFrame(resolve));
         if (tileset.isDestroyed()) return;
-        const viewer = await waitForViewer(viewerRef);
-        await viewer.zoomTo(tileset);
+        const resolvedViewer = await waitForViewer(viewer);
+        await resolvedViewer.zoomTo(tileset);
         tileset.show = true;
       } catch (err) {
         console.error(err);
       }
     },
-    [viewerRef],
+    [viewer],
   );
 
   return <Resium3DTileset {...props} onReady={handleReady} />;

--- a/web/src/components/molecules/Asset/Viewers/Geo3dViewer/Cesium3dTileSetComponent.tsx
+++ b/web/src/components/molecules/Asset/Viewers/Geo3dViewer/Cesium3dTileSetComponent.tsx
@@ -1,26 +1,28 @@
-import { Cesium3DTileset } from "cesium";
-import { ComponentProps, useCallback } from "react";
-import { Cesium3DTileset as Resium3DTileset, useCesium } from "resium";
+import { Cesium3DTileset, Viewer as CesiumViewer } from "cesium";
+import { ComponentProps, MutableRefObject, useCallback } from "react";
+import { Cesium3DTileset as Resium3DTileset } from "resium";
 
-type Props = ComponentProps<typeof Resium3DTileset>;
+import { waitForViewer } from "@reearth-cms/components/molecules/Asset/Asset/AssetBody/waitForViewer";
 
-const Cesium3dTileSetComponent: React.FC<Props> = ({ ...props }) => {
-  const { viewer } = useCesium();
+type Props = ComponentProps<typeof Resium3DTileset> & {
+  viewerRef: MutableRefObject<CesiumViewer | undefined>;
+};
 
+const Cesium3dTileSetComponent: React.FC<Props> = ({ viewerRef, ...props }) => {
   const handleReady = useCallback(
     async (tileset: Cesium3DTileset) => {
-      if (!viewer) return;
       try {
         // Wait for the next frame to ensure everything is properly initialized
         await new Promise(resolve => requestAnimationFrame(resolve));
         if (tileset.isDestroyed()) return;
-        await viewer?.zoomTo(tileset);
+        const viewer = await waitForViewer(viewerRef);
+        await viewer.zoomTo(tileset);
         tileset.show = true;
       } catch (err) {
         console.error(err);
       }
     },
-    [viewer],
+    [viewerRef],
   );
 
   return <Resium3DTileset {...props} onReady={handleReady} />;

--- a/web/src/components/molecules/Asset/Viewers/Geo3dViewer/index.tsx
+++ b/web/src/components/molecules/Asset/Viewers/Geo3dViewer/index.tsx
@@ -1,5 +1,5 @@
 import { Viewer as CesiumViewer } from "cesium";
-import { MutableRefObject, useEffect } from "react";
+import { useEffect } from "react";
 
 import ResiumViewer from "@reearth-cms/components/atoms/ResiumViewer";
 import { compressedFileFormats } from "@reearth-cms/components/molecules/Common/Asset";
@@ -11,18 +11,11 @@ import Cesium3dTileSetComponent from "./Cesium3dTileSetComponent";
 type Props = {
   url: string;
   setAssetUrl: (url: string) => void;
-  viewerRef: MutableRefObject<CesiumViewer | undefined>;
   workspaceSettings: WorkspaceSettings;
   onGetViewer: (viewer?: CesiumViewer) => void;
 };
 
-const Geo3dViewer: React.FC<Props> = ({
-  url,
-  setAssetUrl,
-  viewerRef,
-  workspaceSettings,
-  onGetViewer,
-}) => {
+const Geo3dViewer: React.FC<Props> = ({ url, setAssetUrl, workspaceSettings, onGetViewer }) => {
   useEffect(() => {
     const assetExtension = getExtension(url);
     if (compressedFileFormats.includes(assetExtension)) {
@@ -33,7 +26,7 @@ const Geo3dViewer: React.FC<Props> = ({
 
   return (
     <ResiumViewer onGetViewer={onGetViewer} workspaceSettings={workspaceSettings}>
-      <Cesium3dTileSetComponent url={url} viewerRef={viewerRef} />
+      <Cesium3dTileSetComponent url={url} />
     </ResiumViewer>
   );
 };

--- a/web/src/components/molecules/Asset/Viewers/Geo3dViewer/index.tsx
+++ b/web/src/components/molecules/Asset/Viewers/Geo3dViewer/index.tsx
@@ -1,5 +1,5 @@
 import { Viewer as CesiumViewer } from "cesium";
-import { useEffect } from "react";
+import { MutableRefObject, useEffect } from "react";
 
 import ResiumViewer from "@reearth-cms/components/atoms/ResiumViewer";
 import { compressedFileFormats } from "@reearth-cms/components/molecules/Common/Asset";
@@ -10,12 +10,19 @@ import Cesium3dTileSetComponent from "./Cesium3dTileSetComponent";
 
 type Props = {
   url: string;
-  onGetViewer: (viewer?: CesiumViewer) => void;
   setAssetUrl: (url: string) => void;
+  viewerRef: MutableRefObject<CesiumViewer | undefined>;
   workspaceSettings: WorkspaceSettings;
+  onGetViewer: (viewer?: CesiumViewer) => void;
 };
 
-const Geo3dViewer: React.FC<Props> = ({ url, setAssetUrl, onGetViewer, workspaceSettings }) => {
+const Geo3dViewer: React.FC<Props> = ({
+  url,
+  setAssetUrl,
+  viewerRef,
+  workspaceSettings,
+  onGetViewer,
+}) => {
   useEffect(() => {
     const assetExtension = getExtension(url);
     if (compressedFileFormats.includes(assetExtension)) {
@@ -26,7 +33,7 @@ const Geo3dViewer: React.FC<Props> = ({ url, setAssetUrl, onGetViewer, workspace
 
   return (
     <ResiumViewer onGetViewer={onGetViewer} workspaceSettings={workspaceSettings}>
-      <Cesium3dTileSetComponent url={url} />
+      <Cesium3dTileSetComponent url={url} viewerRef={viewerRef} />
     </ResiumViewer>
   );
 };

--- a/web/src/components/molecules/Asset/Viewers/MvtViewer/Imagery.tsx
+++ b/web/src/components/molecules/Asset/Viewers/MvtViewer/Imagery.tsx
@@ -7,11 +7,11 @@ import {
   HeadingPitchRange,
   ImageryLayerCollection,
   ImageryLayer,
-  Viewer as CesiumViewer,
 } from "cesium";
 import { CesiumMVTImageryProvider } from "cesium-mvt-imagery-provider";
 import { md5 } from "js-md5";
-import { MutableRefObject, useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCesium } from "resium";
 
 import AutoComplete from "@reearth-cms/components/atoms/AutoComplete";
 import { waitForViewer } from "@reearth-cms/components/molecules/Asset/Asset/AssetBody/waitForViewer";
@@ -22,7 +22,6 @@ const normalOffset = new HeadingPitchRange(0, Math.toRadians(-90.0), 200000);
 
 type Props = {
   url: string;
-  viewerRef: MutableRefObject<CesiumViewer | undefined>;
   handleProperties: (prop: Property) => void;
 };
 
@@ -42,7 +41,8 @@ type Metadata = {
   maximumLevel?: number;
 };
 
-export const Imagery: React.FC<Props> = ({ url, viewerRef, handleProperties }) => {
+export const Imagery: React.FC<Props> = ({ url, handleProperties }) => {
+  const { viewer } = useCesium();
   const [selectedFeature, setSelectedFeature] = useState<string>();
   const [urlTemplate, setUrlTemplate] = useState<URLTemplate>(url as URLTemplate);
   const [currentLayer, setCurrentLayer] = useState("");
@@ -51,8 +51,8 @@ export const Imagery: React.FC<Props> = ({ url, viewerRef, handleProperties }) =
 
   const zoomTo = useCallback(
     async ([lng, lat, height]: [number, number, number], useDefaultRange?: boolean) => {
-      const viewer = await waitForViewer(viewerRef);
-      viewer.camera.flyToBoundingSphere(
+      const resolvedViewer = await waitForViewer(viewer);
+      resolvedViewer.camera.flyToBoundingSphere(
         new BoundingSphere(Cartesian3.fromDegrees(lng, lat, height)),
         {
           duration: 0,
@@ -60,7 +60,7 @@ export const Imagery: React.FC<Props> = ({ url, viewerRef, handleProperties }) =
         },
       );
     },
-    [viewerRef],
+    [viewer],
   );
 
   const loadData = useCallback(
@@ -110,8 +110,8 @@ export const Imagery: React.FC<Props> = ({ url, viewerRef, handleProperties }) =
     let imageryLayer: ImageryLayer;
 
     const addLayer = async () => {
-      const viewer = await waitForViewer(viewerRef);
-      layers = viewer.scene.imageryLayers;
+      const resolvedViewer = await waitForViewer(viewer);
+      layers = resolvedViewer.scene.imageryLayers;
       const imageryProvider = new CesiumMVTImageryProvider({
         urlTemplate,
         layerName: currentLayer,
@@ -129,7 +129,7 @@ export const Imagery: React.FC<Props> = ({ url, viewerRef, handleProperties }) =
         layers.remove(imageryLayer);
       }
     };
-  }, [currentLayer, maximumLevel, onSelectFeature, style, urlTemplate, viewerRef]);
+  }, [currentLayer, maximumLevel, onSelectFeature, style, urlTemplate, viewer]);
 
   const handleChange = useCallback((value: unknown) => {
     if (typeof value === "string") {

--- a/web/src/components/molecules/Asset/Viewers/MvtViewer/Imagery.tsx
+++ b/web/src/components/molecules/Asset/Viewers/MvtViewer/Imagery.tsx
@@ -63,23 +63,6 @@ export const Imagery: React.FC<Props> = ({ url, handleProperties }) => {
     [viewer],
   );
 
-  const loadData = useCallback(
-    async (url: string) => {
-      try {
-        const data = await fetchLayers(url);
-        if (!data) return;
-        setUrlTemplate(`${data.base}/{z}/{x}/{y}.mvt` as URLTemplate);
-        setLayers(data.layers ?? []);
-        setCurrentLayer(data.layers?.[0] || "");
-        setMaximumLevel(data.maximumLevel);
-        await zoomTo(data.center || defaultCameraPosition, !data.center);
-      } catch (err) {
-        console.error(err);
-      }
-    },
-    [zoomTo],
-  );
-
   const style = useCallback(
     (f: VectorTileFeature, tile: TileCoordinates) => {
       const fid = idFromGeometry(f.loadGeometry(), tile);
@@ -102,8 +85,21 @@ export const Imagery: React.FC<Props> = ({ url, handleProperties }) => {
   );
 
   useEffect(() => {
+    const loadData = async (url: string) => {
+      try {
+        const data = await fetchLayers(url);
+        if (!data) return;
+        setUrlTemplate(`${data.base}/{z}/{x}/{y}.mvt` as URLTemplate);
+        setLayers(data.layers ?? []);
+        setCurrentLayer(data.layers?.[0] || "");
+        setMaximumLevel(data.maximumLevel);
+        await zoomTo(data.center || defaultCameraPosition, !data.center);
+      } catch (err) {
+        console.error(err);
+      }
+    };
     loadData(url);
-  }, [loadData, url]);
+  }, [url, zoomTo]);
 
   useEffect(() => {
     let layers: ImageryLayerCollection;

--- a/web/src/components/molecules/Asset/Viewers/MvtViewer/index.tsx
+++ b/web/src/components/molecules/Asset/Viewers/MvtViewer/index.tsx
@@ -8,12 +8,11 @@ import { Imagery, Property } from "./Imagery";
 
 type Props = {
   url: string;
-  viewerRef: React.MutableRefObject<CesiumViewer | undefined>;
   workspaceSettings: WorkspaceSettings;
   onGetViewer: (viewer?: CesiumViewer) => void;
 };
 
-const MvtViewer: React.FC<Props> = ({ url, viewerRef, workspaceSettings, onGetViewer }) => {
+const MvtViewer: React.FC<Props> = ({ url, workspaceSettings, onGetViewer }) => {
   const [properties, setProperties] = useState<Property>();
 
   const handleProperties = useCallback((prop: Property) => {
@@ -36,7 +35,7 @@ const MvtViewer: React.FC<Props> = ({ url, viewerRef, workspaceSettings, onGetVi
       onGetViewer={onGetViewer}
       properties={properties}
       workspaceSettings={workspaceSettings}>
-      <Imagery url={url} viewerRef={viewerRef} handleProperties={handleProperties} />
+      <Imagery url={url} handleProperties={handleProperties} />
     </ResiumViewer>
   );
 };

--- a/web/src/components/organisms/Project/Asset/Asset/hooks.ts
+++ b/web/src/components/organisms/Project/Asset/Asset/hooks.ts
@@ -274,7 +274,6 @@ export default (assetId?: string) => {
     selectedPreviewType,
     isModalVisible,
     collapsed,
-    viewerRef,
     viewerType,
     displayUnzipFileList,
     decompressing,

--- a/web/src/components/organisms/Project/Asset/Asset/index.tsx
+++ b/web/src/components/organisms/Project/Asset/Asset/index.tsx
@@ -18,7 +18,6 @@ const Asset: React.FC = () => {
     selectedPreviewType,
     isModalVisible,
     collapsed,
-    viewerRef,
     viewerType,
     displayUnzipFileList,
     decompressing,
@@ -43,7 +42,7 @@ const Asset: React.FC = () => {
   useEffect(() => {
     const timeout = setTimeout(() => {
       setDelayed(true);
-    }, 1000);
+    }, 1500);
     return () => clearTimeout(timeout);
   }, []);
 
@@ -72,7 +71,6 @@ const Asset: React.FC = () => {
       assetFileExt={assetFileExt}
       selectedPreviewType={selectedPreviewType}
       isModalVisible={isModalVisible}
-      viewerRef={viewerRef}
       viewerType={viewerType}
       displayUnzipFileList={displayUnzipFileList}
       decompressing={decompressing}

--- a/web/src/components/organisms/Project/Asset/Asset/index.tsx
+++ b/web/src/components/organisms/Project/Asset/Asset/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import Loading from "@reearth-cms/components/atoms/Loading";
@@ -38,9 +39,23 @@ const Asset: React.FC = () => {
 
   const { workspaceSettings } = useSettingsHooks();
 
-  return isLoading ? (
-    <Loading spinnerSize="large" minHeight="100vh" />
-  ) : asset ? (
+  const [delayed, setDelayed] = useState(false);
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setDelayed(true);
+    }, 1000);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  if (!delayed || isLoading) {
+    return <Loading spinnerSize="large" minHeight="100vh" />;
+  }
+
+  if (!asset) {
+    return <NotFound />;
+  }
+
+  return (
     <AssetWrapper
       commentsPanel={
         <CommentsPanel
@@ -75,8 +90,6 @@ const Asset: React.FC = () => {
       onGetViewer={handleGetViewer}
       workspaceSettings={workspaceSettings}
     />
-  ) : (
-    <NotFound />
   );
 };
 


### PR DESCRIPTION
# Overview
This PR introduces startup delay to Asset page before loading content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the use of the viewer reference prop (`viewerRef`) from multiple asset and viewer components, streamlining how the Cesium viewer instance is accessed and managed internally.
  - Updated viewer management to use context hooks instead of passing refs between components.
  - Improved loading behavior in the asset view with a delay and clearer loading states.
- **Bug Fixes**
  - Ensured viewer-dependent operations wait for the viewer to be fully initialized before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->