### PR TITLE
fix(web): ensure stable viewerType detection after asset data is resolved

### DIFF
--- a/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/Asset.tsx
@@ -35,9 +35,9 @@ import useHooks from "./hooks";
 type Props = {
   asset: Asset;
   assetFileExt?: string;
-  selectedPreviewType: PreviewType;
+  selectedPreviewType?: PreviewType;
   isModalVisible: boolean;
-  viewerType: ViewerType;
+  viewerType?: ViewerType;
   displayUnzipFileList: boolean;
   decompressing: boolean;
   hasUpdateRight: boolean;

--- a/web/src/components/molecules/Asset/Asset/AssetBody/index.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/index.tsx
@@ -14,9 +14,9 @@ type Props = {
   commentsPanel: JSX.Element;
   asset: Asset;
   assetFileExt?: string;
-  selectedPreviewType: PreviewType;
+  selectedPreviewType?: PreviewType;
   isModalVisible: boolean;
-  viewerType: ViewerType;
+  viewerType?: ViewerType;
   displayUnzipFileList: boolean;
   decompressing: boolean;
   isSaveDisabled: boolean;

--- a/web/src/components/molecules/Asset/Asset/AssetBody/previewToolbar.tsx
+++ b/web/src/components/molecules/Asset/Asset/AssetBody/previewToolbar.tsx
@@ -7,7 +7,7 @@ import { useT } from "@reearth-cms/i18n";
 type Props = {
   url: string;
   isModalVisible: boolean;
-  viewerType: ViewerType;
+  viewerType?: ViewerType;
   onCodeSourceClick: () => void;
   onRenderClick: () => void;
   onFullScreen: () => void;

--- a/web/src/components/organisms/Project/Asset/Asset/hooks.ts
+++ b/web/src/components/organisms/Project/Asset/Asset/hooks.ts
@@ -151,31 +151,31 @@ export default (assetId?: string) => {
   const assetFileExt = getExtension(convertedAsset?.fileName);
 
   const viewerType = useMemo((): ViewerType | undefined => {
-    if (!convertedAsset?.previewType || !assetFileExt) return;
+    if (!selectedPreviewType || !assetFileExt) return;
 
     switch (true) {
-      case convertedAsset.previewType === "GEO" &&
+      case selectedPreviewType === "GEO" &&
         (geoFormats.includes(assetFileExt) || compressedFileFormats.includes(assetFileExt)):
         return "geo";
-      case convertedAsset.previewType === "GEO_3D_TILES" &&
+      case selectedPreviewType === "GEO_3D_TILES" &&
         (geo3dFormats.includes(assetFileExt) || compressedFileFormats.includes(assetFileExt)):
         return "geo_3d_tiles";
-      case convertedAsset.previewType === "GEO_MVT" &&
+      case selectedPreviewType === "GEO_MVT" &&
         (geoMvtFormat.includes(assetFileExt) || compressedFileFormats.includes(assetFileExt)):
         return "geo_mvt";
-      case convertedAsset.previewType === "MODEL_3D" &&
+      case selectedPreviewType === "MODEL_3D" &&
         (model3dFormats.includes(assetFileExt) || compressedFileFormats.includes(assetFileExt)):
         return "model_3d";
-      case convertedAsset.previewType === "CSV" && csvFormats.includes(assetFileExt):
+      case selectedPreviewType === "CSV" && csvFormats.includes(assetFileExt):
         return "csv";
-      case convertedAsset.previewType === "IMAGE" && imageFormats.includes(assetFileExt):
+      case selectedPreviewType === "IMAGE" && imageFormats.includes(assetFileExt):
         return "image";
-      case convertedAsset.previewType === "IMAGE_SVG" && imageSVGFormat.includes(assetFileExt):
+      case selectedPreviewType === "IMAGE_SVG" && imageSVGFormat.includes(assetFileExt):
         return "image_svg";
       default:
         return "unknown";
     }
-  }, [convertedAsset?.previewType, assetFileExt]);
+  }, [assetFileExt, selectedPreviewType]);
 
   const displayUnzipFileList = useMemo(
     () => compressedFileFormats.includes(assetFileExt),
@@ -260,10 +260,25 @@ export default (assetId?: string) => {
     }
   };
 
+  const [isDelayed, setIsDelayed] = useState(false);
+
+  useEffect(() => {
+    if (!viewerType) return;
+
+    const delayedTypes = new Set<ViewerType>(["geo", "geo_3d_tiles", "geo_mvt", "model_3d", "csv"]);
+    const delay = delayedTypes.has(viewerType) ? 2000 : 0;
+    const timeout = setTimeout(() => {
+      setIsDelayed(true);
+    }, delay);
+
+    return () => clearTimeout(timeout);
+  }, [viewerType]);
+
   return {
     asset,
     assetFileExt,
     isLoading: networkStatus === NetworkStatus.loading || fileLoading,
+    isDelayed,
     selectedPreviewType,
     isModalVisible,
     collapsed,

--- a/web/src/components/organisms/Project/Asset/Asset/hooks.ts
+++ b/web/src/components/organisms/Project/Asset/Asset/hooks.ts
@@ -44,7 +44,7 @@ export default (assetId?: string) => {
   const navigate = useNavigate();
   const { workspaceId, projectId } = useParams();
   const location = useLocation();
-  const [selectedPreviewType, setSelectedPreviewType] = useState<PreviewType>("IMAGE");
+  const [selectedPreviewType, setSelectedPreviewType] = useState<PreviewType>();
   const [decompressing, setDecompressing] = useState(false);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
   const [collapsed, setCollapsed] = useState(true);
@@ -131,7 +131,7 @@ export default (assetId?: string) => {
           Notification.success({ message: t("Asset is being decompressed!") });
         }
       })(),
-    [t, decompressAssetMutation, setDecompressing],
+    [t, decompressAssetMutation],
   );
 
   useEffect(() => {
@@ -148,41 +148,34 @@ export default (assetId?: string) => {
     [convertedAsset?.previewType],
   );
 
-  const [viewerType, setViewerType] = useState<ViewerType>("unknown");
   const assetFileExt = getExtension(convertedAsset?.fileName);
 
-  useEffect(() => {
+  const viewerType = useMemo((): ViewerType | undefined => {
+    if (!convertedAsset?.previewType || !assetFileExt) return;
+
     switch (true) {
-      case selectedPreviewType === "GEO" &&
+      case convertedAsset.previewType === "GEO" &&
         (geoFormats.includes(assetFileExt) || compressedFileFormats.includes(assetFileExt)):
-        setViewerType("geo");
-        break;
-      case selectedPreviewType === "GEO_3D_TILES" &&
+        return "geo";
+      case convertedAsset.previewType === "GEO_3D_TILES" &&
         (geo3dFormats.includes(assetFileExt) || compressedFileFormats.includes(assetFileExt)):
-        setViewerType("geo_3d_tiles");
-        break;
-      case selectedPreviewType === "GEO_MVT" &&
+        return "geo_3d_tiles";
+      case convertedAsset.previewType === "GEO_MVT" &&
         (geoMvtFormat.includes(assetFileExt) || compressedFileFormats.includes(assetFileExt)):
-        setViewerType("geo_mvt");
-        break;
-      case selectedPreviewType === "MODEL_3D" &&
+        return "geo_mvt";
+      case convertedAsset.previewType === "MODEL_3D" &&
         (model3dFormats.includes(assetFileExt) || compressedFileFormats.includes(assetFileExt)):
-        setViewerType("model_3d");
-        break;
-      case selectedPreviewType === "CSV" && csvFormats.includes(assetFileExt):
-        setViewerType("csv");
-        break;
-      case selectedPreviewType === "IMAGE" && imageFormats.includes(assetFileExt):
-        setViewerType("image");
-        break;
-      case selectedPreviewType === "IMAGE_SVG" && imageSVGFormat.includes(assetFileExt):
-        setViewerType("image_svg");
-        break;
+        return "model_3d";
+      case convertedAsset.previewType === "CSV" && csvFormats.includes(assetFileExt):
+        return "csv";
+      case convertedAsset.previewType === "IMAGE" && imageFormats.includes(assetFileExt):
+        return "image";
+      case convertedAsset.previewType === "IMAGE_SVG" && imageSVGFormat.includes(assetFileExt):
+        return "image_svg";
       default:
-        setViewerType("unknown");
-        break;
+        return "unknown";
     }
-  }, [convertedAsset?.previewType, assetFileExt, selectedPreviewType]);
+  }, [convertedAsset?.previewType, assetFileExt]);
 
   const displayUnzipFileList = useMemo(
     () => compressedFileFormats.includes(assetFileExt),

--- a/web/src/components/organisms/Project/Asset/Asset/index.tsx
+++ b/web/src/components/organisms/Project/Asset/Asset/index.tsx
@@ -40,12 +40,15 @@ const Asset: React.FC = () => {
   const [delayed, setDelayed] = useState(false);
 
   useEffect(() => {
+    if (!viewerType) return;
+    const delay =
+      viewerType === "image" || viewerType === "image_svg" || viewerType === "unknown" ? 0 : 2000;
     const timeout = setTimeout(() => {
       setDelayed(true);
-    }, 2000);
+    }, delay);
 
     return () => clearTimeout(timeout);
-  }, []);
+  }, [viewerType]);
 
   if (!delayed || isLoading) {
     return <Loading spinnerSize="large" minHeight="100vh" />;

--- a/web/src/components/organisms/Project/Asset/Asset/index.tsx
+++ b/web/src/components/organisms/Project/Asset/Asset/index.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import Loading from "@reearth-cms/components/atoms/Loading";
@@ -15,6 +14,7 @@ const Asset: React.FC = () => {
     asset,
     assetFileExt,
     isLoading,
+    isDelayed,
     selectedPreviewType,
     isModalVisible,
     collapsed,
@@ -37,20 +37,8 @@ const Asset: React.FC = () => {
   } = useHooks(assetId);
 
   const { workspaceSettings } = useSettingsHooks();
-  const [delayed, setDelayed] = useState(false);
 
-  useEffect(() => {
-    if (!viewerType) return;
-    const delay =
-      viewerType === "image" || viewerType === "image_svg" || viewerType === "unknown" ? 0 : 2000;
-    const timeout = setTimeout(() => {
-      setDelayed(true);
-    }, delay);
-
-    return () => clearTimeout(timeout);
-  }, [viewerType]);
-
-  if (!delayed || isLoading) {
+  if (!isDelayed || isLoading) {
     return <Loading spinnerSize="large" minHeight="100vh" />;
   }
 


### PR DESCRIPTION
# Overview
This PR ensures stable viewerType detection after asset data is resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Made certain preview and viewer type properties optional in asset-related components, allowing for more flexible usage.
	- Shifted delay handling logic from individual components to a shared hook, streamlining state management and simplifying component structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->