### PR TITLE
fix(server): Fix inconsistent e2e tests

### DIFF
--- a/server/e2e/integration_item_import_test.go
+++ b/server/e2e/integration_item_import_test.go
@@ -421,26 +421,28 @@ func TestIntegrationModelImportJSONWithJsonInput3(t *testing.T) {
 	i := a.Value(0).Object()
 	i.Value("id").NotNull().IsEqual(iId)
 	i.Value("fields").Array().Length().IsEqual(3)
-	i.Value("fields").Array().IsEqual([]map[string]any{
-		{
-			"id":    f.textFId,
-			"key":   "text",
-			"type":  "text",
-			"value": "test1",
-		},
-		{
+
+	// Check that each expected field is present, regardless of order
+	fields := i.Value("fields").Array()
+
+	// Check for text field
+	fields.ContainsAll(map[string]any{
+		"id":    f.textFId,
+		"key":   "text",
+		"type":  "text",
+		"value": "test1",
+	},
+		map[string]any{
 			"id":    f.boolFId,
 			"key":   "bool",
 			"type":  "bool",
 			"value": true,
-		},
-		{
+		}, map[string]any{
 			"id":    f.numberFId,
 			"key":   "number",
 			"type":  "number",
 			"value": 1.1,
-		},
-	})
+		})
 
 	// endregion
 }

--- a/server/e2e/internal_project_test.go
+++ b/server/e2e/internal_project_test.go
@@ -17,12 +17,14 @@ func TestInternalGetProjectsAPI(t *testing.T) {
 	StartServer(t, &app.Config{
 		InternalApi: app.InternalApiConfig{
 			Active: true,
-			Port:   "0", // Let os assign a random port
+			Port:   "52050",
 			Token:  "TestToken",
 		},
 	}, true, baseSeeder)
 
-	clientConn, err := grpc.NewClient("localhost:52050", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	clientConn, err := grpc.NewClient("localhost:52050",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithMaxCallAttempts(5))
 	assert.NoError(t, err)
 
 	client := pb.NewReEarthCMSClient(clientConn)

--- a/server/e2e/internal_project_test.go
+++ b/server/e2e/internal_project_test.go
@@ -17,7 +17,7 @@ func TestInternalGetProjectsAPI(t *testing.T) {
 	StartServer(t, &app.Config{
 		InternalApi: app.InternalApiConfig{
 			Active: true,
-			Port:   "52050",
+			Port:   "0", // Let os assign a random port
 			Token:  "TestToken",
 		},
 	}, true, baseSeeder)


### PR DESCRIPTION
# Overview
fix TestIntegrationModelImportJSONWithJsonInput3 inconsistency
`Error Trace:	/home/runner/go/pkg/mod/github.com/gavv/httpexpect/v2@v2.17.0/reporter.go:24
        	            				/home/runner/go/pkg/mod/github.com/gavv/httpexpect/v2@v2.17.0/assertion.go:278
        	            				/home/runner/go/pkg/mod/github.com/gavv/httpexpect/v2@v2.17.0/chain.go:406
        	            				/home/runner/go/pkg/mod/github.com/gavv/httpexpect/v2@v2.17.0/array.go:802
        	            				/home/runner/work/reearth-cms/reearth-cms/server/e2e/integration_item_import_test.go:424
        	Error:      	
        	            	expected: arrays are equal
        	            	
        	            	test name: TestIntegrationModelImportJSONWithJsonInput3
        	            	
        	            	request: GET /api/models/01jtqkg85k6x7skz4bz0321bt1/items?page=1&perPage=5 HTTP/1.1
        	            	  Host: [::]:37829
        	            	  X-Reearth-Debug-User: 01jtqke9n9gvm5n1ndnh69na5c
        	            	
        	            	response: HTTP/1.1 200 OK 11.106029ms
        	            	  Content-Length: 606
        	            	  Cache-Control: private, no-store, no-cache, must-revalidate
        	            	  Content-Type: application/json
        	            	  Date: Thu, 08 May 2025 09:26:53 GMT
        	            	  Vary: Origin
        	            	
        	            	assertion:
        	            	  Request("GET").Expect().JSON().Object().Value("items").
        	            	    Array().Value(0).Object().Value("fields").Array().
        	            	      IsEqual()
        	            	
        	            	expected value:
        	            	  [
        	            	    {
        	            	      "id": "01jtqkg85tmbm171jgz3y1k3e0",
        	            	      "key": "text",
        	            	      "type": "text",
        	            	      "value": "test1"
        	            	    },
        	            	    {
        	            	      "id": "01jtqkg86jtsw22ppdq5wp8cre",
        	            	      "key": "bool",
        	            	      "type": "bool",
        	            	      "value": true
        	            	    },
        	            	    {
        	            	      "id": "01jtqkg8744h5j4ma6c1ecqa9f",
        	            	      "key": "number",
        	            	      "type": "number",
        	            	      "value": 1.1
        	            	    }
        	            	  ]
        	            	
        	            	actual value:
        	            	  [
        	            	    {
        	            	      "id": "01jtqkg85tmbm171jgz3y1k3e0",
        	            	      "key": "text",
        	            	      "type": "text",
        	            	      "value": "test1"
        	            	    },
        	            	    {
        	            	      "id": "01jtqkg8744h5j4ma6c1ecqa9f",
        	            	      "key": "number",
        	            	      "type": "number",
        	            	      "value": 1.1
        	            	    },
        	            	    {
        	            	      "id": "01jtqkg86jtsw22ppdq5wp8cre",
        	            	      "key": "bool",
        	            	      "type": "bool",
        	            	      "value": true
        	            	    }
        	            	  ]
        	            	
        	            	diff:
        	            	  --- expected
        	            	  +++ actual
        	            	   [
        	            	     0: {
        	            	       "id": "01jtqkg85tmbm171jgz3y1k3e0",
        	            	       "key": "text",
        	            	       "type": "text",
        	            	       "value": "test1"
        	            	     },
        	            	     2: {
        	            	       "id": "01jtqkg8744h5j4ma6c1ecqa9f",
        	            	       "key": "number",
        	            	       "type": "number",
        	            	       "value": 1.1
        	            	     },
        	            	   ]`
and 
```
common_test.go:142: grpc server failed to listen: listen tcp :52050: bind: address already in use
--- FAIL: TestInternalGetProjectsAPI (0.34s)

```
## What I've done
fix TestIntegrationModelImportJSONWithJsonInput3 inconsistency

## What I haven't done

## How I tested
run test in ci 5 times
## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved the flexibility of field verification in item import tests to allow for any order of fields.
  - Added a maximum call attempt limit to gRPC client connections in internal project tests for increased robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->