### PR TITLE
feat(web,server): update role-based permissions for project, schema and model

### DIFF
--- a/server/internal/usecase/interactor/model.go
+++ b/server/internal/usecase/interactor/model.go
@@ -73,7 +73,7 @@ func (i Model) FindByIDOrKey(ctx context.Context, p id.ProjectID, q model.IDOrKe
 func (i Model) Create(ctx context.Context, param interfaces.CreateModelParam, operator *usecase.Operator) (*model.Model, error) {
 	return Run1(ctx, operator, i.repos, Usecase().Transaction(),
 		func(ctx context.Context) (_ *model.Model, err error) {
-			if !operator.IsMaintainingProject(param.ProjectId) {
+			if !operator.IsWritableProject(param.ProjectId) {
 				return nil, interfaces.ErrOperationDenied
 			}
 			return i.create(ctx, param)
@@ -147,7 +147,7 @@ func (i Model) Update(ctx context.Context, param interfaces.UpdateModelParam, op
 				return nil, err
 			}
 
-			if !operator.IsMaintainingProject(m.Project()) {
+			if !operator.IsWritableProject(m.Project()) {
 				return nil, interfaces.ErrOperationDenied
 			}
 
@@ -193,7 +193,7 @@ func (i Model) Delete(ctx context.Context, modelID id.ModelID, operator *usecase
 			if err != nil {
 				return err
 			}
-			if !operator.IsMaintainingProject(m.Project()) {
+			if !operator.IsWritableProject(m.Project()) {
 				return interfaces.ErrOperationDenied
 			}
 
@@ -233,7 +233,7 @@ func (i Model) FindOrCreateSchema(ctx context.Context, param interfaces.FindOrCr
 						if err != nil {
 							return nil, err
 						}
-						if !operator.IsMaintainingProject(p.ID()) {
+						if !operator.IsWritableProject(p.ID()) {
 							return nil, interfaces.ErrOperationDenied
 						}
 
@@ -285,7 +285,7 @@ func (i Model) UpdateOrder(ctx context.Context, ids id.ModelIDList, operator *us
 				return nil, rerror.ErrNotFound
 			}
 
-			if !operator.IsMaintainingProject(models.Projects()...) {
+			if !operator.IsWritableProject(models.Projects()...) {
 				return nil, interfaces.ErrOperationDenied
 			}
 			ordered := models.OrderByIDs(ids)
@@ -304,7 +304,7 @@ func (i Model) Copy(ctx context.Context, params interfaces.CopyModelParam, opera
 			if err != nil {
 				return nil, err
 			}
-			if !operator.IsMaintainingProject(oldModel.Project()) {
+			if !operator.IsWritableProject(oldModel.Project()) {
 				return nil, interfaces.ErrOperationDenied
 			}
 

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -76,7 +76,7 @@ func (i *Project) Create(ctx context.Context, param interfaces.CreateProjectPara
 		}
 	}
 
-	return Run1(ctx, op, i.repos, Usecase().WithMaintainableWorkspaces(param.WorkspaceID).Transaction(),
+	return Run1(ctx, op, i.repos, Usecase().WithWritableWorkspaces(param.WorkspaceID).Transaction(),
 		func(ctx context.Context) (_ *project.Project, err error) {
 			pb := project.New().
 				NewID().
@@ -163,7 +163,7 @@ func (i *Project) Update(ctx context.Context, param interfaces.UpdateProjectPara
 		}
 	}
 
-	return Run1(ctx, op, i.repos, Usecase().WithMaintainableWorkspaces(p.Workspace()).Transaction(),
+	return Run1(ctx, op, i.repos, Usecase().WithWritableWorkspaces(p.Workspace()).Transaction(),
 		func(ctx context.Context) (_ *project.Project, err error) {
 			if param.Name != nil {
 				p.UpdateName(*param.Name)
@@ -192,6 +192,9 @@ func (i *Project) Update(ctx context.Context, param interfaces.UpdateProjectPara
 			}
 
 			if param.Accessibility != nil {
+				if !op.IsMaintainingWorkspace(p.Workspace()) {
+					return nil, interfaces.ErrOperationDenied
+				}
 				accessibility := p.Accessibility()
 				if accessibility == nil {
 					accessibility = project.NewPublicAccessibility()
@@ -237,7 +240,7 @@ func (i *Project) Delete(ctx context.Context, projectID id.ProjectID, op *usecas
 	if err != nil {
 		return err
 	}
-	return Run0(ctx, op, i.repos, Usecase().WithMaintainableWorkspaces(proj.Workspace()).Transaction(),
+	return Run0(ctx, op, i.repos, Usecase().WithWritableWorkspaces(proj.Workspace()).Transaction(),
 		func(ctx context.Context) error {
 			if !op.IsOwningWorkspace(proj.Workspace()) {
 				return interfaces.ErrOperationDenied

--- a/server/internal/usecase/interactor/schema.go
+++ b/server/internal/usecase/interactor/schema.go
@@ -108,7 +108,7 @@ func (i Schema) CreateField(ctx context.Context, param interfaces.CreateFieldPar
 			return nil, err
 		}
 
-		if !op.IsMaintainingProject(s.Project()) {
+		if !op.IsWritableProject(s.Project()) {
 			return nil, interfaces.ErrOperationDenied
 		}
 
@@ -205,7 +205,7 @@ func (i Schema) UpdateField(ctx context.Context, param interfaces.UpdateFieldPar
 			return nil, err
 		}
 
-		if !op.IsMaintainingProject(s.Project()) {
+		if !op.IsWritableProject(s.Project()) {
 			return nil, interfaces.ErrOperationDenied
 		}
 
@@ -328,7 +328,7 @@ func (i Schema) DeleteField(ctx context.Context, schemaId id.SchemaID, fieldID i
 				return err
 			}
 
-			if !operator.IsMaintainingProject(s.Project()) {
+			if !operator.IsWritableProject(s.Project()) {
 				return interfaces.ErrOperationDenied
 			}
 
@@ -377,7 +377,7 @@ func (i Schema) UpdateFields(ctx context.Context, sid id.SchemaID, params []inte
 		if err != nil {
 			return nil, err
 		}
-		if !operator.IsMaintainingProject(s.Project()) {
+		if !operator.IsWritableProject(s.Project()) {
 			return nil, interfaces.ErrOperationDenied
 		}
 
@@ -488,7 +488,7 @@ func (i Schema) CreateFields(ctx context.Context, sId id.SchemaID, createFieldsP
 			if err != nil {
 				return nil, err
 			}
-			if !op.IsMaintainingProject(s.Project()) {
+			if !op.IsWritableProject(s.Project()) {
 				return nil, interfaces.ErrOperationDenied
 			}
 


### PR DESCRIPTION
# Overview
This PR updates the role-based permission matrix for Project, Schema, and Model management in accordance with the new RBAC design.

## Changes
Project Permissions
Writer can now:

Create and delete projects

Schema & Model Permissions
Writer can now:

Create and delete models

Add, remove, and modify fields

Change field types and validation rules

Publish models and content items


## Memo
