### PR TITLE
fix(server): missing /api in public_api_ep

### DIFF
--- a/server/internal/adapter/internalapi/server.go
+++ b/server/internal/adapter/internalapi/server.go
@@ -34,7 +34,7 @@ type server struct {
 func NewServer(webHost, serverHost string) pb.ReEarthCMSServer {
 	return &server{
 		webBaseUrl:  lo.Must(url.Parse(webHost)),
-		pApiBaseUrl: lo.Must(url.Parse(serverHost)).JoinPath("p"),
+		pApiBaseUrl: lo.Must(url.Parse(serverHost)).JoinPath("api", "p"),
 	}
 }
 


### PR DESCRIPTION
# Overview
fix missing /api in public_api_ep
before: http://api.cms.dev.reearth.io/p/test-project-cms-1/test
after: http://api.cms.dev.reearth.io/api/p/test-project-cms-1/test
## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
