### PR TITLE
ci(web): disable node’s TS strip-only in E2E workflow to fix Playwright on Node LTS

### DIFF
--- a/.github/workflows/e2e_web.yml
+++ b/.github/workflows/e2e_web.yml
@@ -72,6 +72,8 @@ jobs:
           echo "REEARTH_CMS_E2E_USERNAME is $REEARTH_CMS_E2E_USERNAME"
       - name: Run Playwright tests
         run: yarn e2e
+        env:
+          NODE_OPTIONS: --no-experimental-strip-types
       - uses: actions/upload-artifact@v4
         if: failure()
         with:


### PR DESCRIPTION
# Overview

Add NODE_OPTIONS=--no-experimental-strip-types to the Run Playwright tests step in Web E2E test workflow.

Rationale: Node 22.x enables TypeScript strip-only by default, which can’t handle TS features like enum/parameter properties and breaks Playwright test discovery. Disabling strip-only lets Playwright’s esbuild transpile TS as before.

Scope: CI-only, E2E job; no app/runtime impact.

Notes: This flag is required for Node 22.x+. If we later pin to Node 20.x, remove the env or update the Node version in the workflow accordingly.