### PR TITLE
fix(server): remove SetNoCursorTimeout for MongoDB Atlas compatibility in db-migrations

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -4301,6 +4301,7 @@ golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17/go.mod h1:lgLbSvA5ygNOMpwM/9
 golang.org/x/exp v0.0.0-20220706164943-b4a6d9510983/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/exp v0.0.0-20240119083558-1b970713d09a/go.mod h1:idGWGoKP1toJGkd5/ig9ZLuPcZBC3ewk7SzmH0uou08=
+golang.org/x/exp v0.0.0-20250531010427-b6e5de432a8b/go.mod h1:U6Lno4MTRCDY+Ba7aCcauB9T60gsv5s4ralQzP72ZoQ=
 golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/exp/typeparams v0.0.0-20230203172020-98cc5a0785f9/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/exp/typeparams v0.0.0-20250210185358-939b2ce775ac h1:TSSpLIG4v+p0rPv1pNOQtl1I8knsO4S9trOxNMOLVP4=

--- a/server/cmd/db-migrations/common.go
+++ b/server/cmd/db-migrations/common.go
@@ -19,8 +19,7 @@ type Entity interface {
 // BatchUpdate processes documents from a MongoDB collection in batches and applies the given update function to each document
 func BatchUpdate[T Entity](ctx context.Context, col *mongo.Collection, filter bson.M, batchSize int, fn func(item T) (T, error)) (int, error) {
 	opts := options.Find().
-		SetBatchSize(int32(batchSize)).
-		SetNoCursorTimeout(true)
+		SetBatchSize(int32(batchSize))
 
 	cursor, err := col.Find(ctx, filter, opts)
 	if err != nil {


### PR DESCRIPTION
# Overview
  - Remove `SetNoCursorTimeout(true)` from BatchUpdate function to fix MongoDB Atlas
  compatibility issues
  - Resolves "noTimeout cursors are disallowed in this atlas tier" error when running
  item-migration