### PR TITLE
feat(server): make database name configurable for migrations

### DIFF
--- a/server/cmd/db-migrations/main.go
+++ b/server/cmd/db-migrations/main.go
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	// get db name
-	dbName := os.Getenv("REEARTH_CMS_DB_NAME")
+	dbName := os.Getenv("REEARTH_CMS_DB_CMS")
 	if dbName == "" {
 		dbName = "reearth_cms"
 	}


### PR DESCRIPTION
# Overview
Makes the database name configurable for migrations via the `REEARTH_CMS_DB_CMS` environment variable, defaulting to `reearth_cms` if not set. This allows developers to use custom database names for local development without affecting the default behavior.
