### PR TITLE
feat: add migration for project metadata fields in MongoDB

### DIFF
--- a/server/cmd/db-migrations/250926132908_add_project_metadata_fields.go
+++ b/server/cmd/db-migrations/250926132908_add_project_metadata_fields.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type ProjectMetadataDocument struct {
+	ID            string                        `bson:"_id,omitempty"`
+	Name          string                        `bson:"name,omitempty"`
+	Description   string                        `bson:"description,omitempty"`
+	License       string                        `bson:"license,omitempty"`
+	Readme        string                        `bson:"readme,omitempty"`
+	Alias         string                        `bson:"alias,omitempty"`
+	ImageURL      string                        `bson:"imageurl,omitempty"`
+	Workspace     string                        `bson:"workspace,omitempty"`
+	Accessibility *ProjectAccessibilityDocument `bson:"accessibility,omitempty"`
+	RequestRoles  []string                      `bson:"requestroles,omitempty"`
+	Topics        []string                      `bson:"topics,omitempty"`
+	StarCount     int                           `bson:"star_count,omitempty"`
+	StarredBy     []string                      `bson:"starred_by,omitempty"`
+}
+
+func (d ProjectMetadataDocument) GetID() primitive.ObjectID {
+	id, err := primitive.ObjectIDFromHex(d.ID)
+	if err != nil {
+		fmt.Printf("failed to parse project id: %v\n", d.ID)
+		return primitive.NilObjectID
+	}
+	return id
+}
+
+func AddProjectMetadataFields(ctx context.Context, dbURL, dbName string, wetRun bool) error {
+	testID := ""
+
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(dbURL))
+	if err != nil {
+		return fmt.Errorf("db: failed to init client err: %w", err)
+	}
+	defer func() {
+		err := client.Disconnect(ctx)
+		if err != nil {
+			fmt.Printf("failed to disconnect from db: %v\n", err)
+		}
+	}()
+
+	pCol := client.Database(dbName).Collection("project")
+
+	filter := bson.M{}
+
+	if testID != "" {
+		filter = bson.M{
+			"$and": []bson.M{
+				{"_id": testID},
+				filter,
+			},
+		}
+		count, err := pCol.CountDocuments(ctx, filter)
+		if err != nil {
+			return fmt.Errorf("failed to count docs: %w", err)
+		}
+		fmt.Printf("test mode: filter on document id '%s' is applied, %d document selected.\n", testID, count)
+	}
+
+	if !wetRun {
+		fmt.Printf("dry run\n")
+		count, err := pCol.CountDocuments(ctx, filter)
+		if err != nil {
+			return fmt.Errorf("failed to count docs: %w", err)
+		}
+		fmt.Printf("%d docs will be updated\n", count)
+		return nil
+	}
+
+	_, err = BatchUpdateWithCustomOperation(ctx, pCol, filter, 1000, updateProjectMetadata())
+	if err != nil {
+		return fmt.Errorf("failed to apply batches: %w", err)
+	}
+
+	fmt.Printf("done.\n")
+	return nil
+}
+
+func updateProjectMetadata() func(ProjectMetadataDocument) (bson.M, error) {
+	return func(oldP ProjectMetadataDocument) (bson.M, error) {
+		
+		updateOp := bson.M{
+			"$set": bson.M{
+				"topics":     []string{},
+				"star_count": 0,
+				"starred_by": []string{},
+			},
+		}
+
+		return updateOp, nil
+	}
+}
+
+// BatchUpdateWithCustomOperation processes documents and applies custom update operations
+func BatchUpdateWithCustomOperation(ctx context.Context, col *mongo.Collection, filter bson.M, batchSize int, fn func(ProjectMetadataDocument) (bson.M, error)) (int, error) {
+	opts := options.Find().
+		SetBatchSize(int32(batchSize)).
+		SetNoCursorTimeout(true)
+
+	cursor, err := col.Find(ctx, filter, opts)
+	if err != nil {
+		return 0, fmt.Errorf("failed to query collection: %w", err)
+	}
+	defer func() {
+		err := cursor.Close(ctx)
+		if err != nil {
+			fmt.Printf("failed to close cursor: %v\n", err)
+		}
+	}()
+
+	batch := make([]mongo.WriteModel, 0, batchSize)
+	processed := 0
+
+	for cursor.Next(ctx) {
+		if ctx.Err() != nil {
+			return 0, ctx.Err()
+		}
+
+		var item ProjectMetadataDocument
+		if err := cursor.Decode(&item); err != nil {
+			return 0, fmt.Errorf("failed to decode document: %w", err)
+		}
+
+		updateOp, err := fn(item)
+		if err != nil {
+			return 0, fmt.Errorf("failed to process document: %w", err)
+		}
+
+		update := mongo.NewUpdateOneModel().
+			SetFilter(bson.M{"_id": item.GetID()}).
+			SetUpdate(updateOp)
+
+		batch = append(batch, update)
+		processed++
+
+		if len(batch) >= batchSize {
+			if err := executeBatch(ctx, col, batch); err != nil {
+				return 0, err
+			}
+
+			fmt.Printf("Processed %d documents\n", processed)
+			batch = batch[:0]
+		}
+	}
+
+	if len(batch) > 0 {
+		if err := executeBatch(ctx, col, batch); err != nil {
+			return 0, err
+		}
+	}
+
+	if err := cursor.Err(); err != nil {
+		return 0, fmt.Errorf("cursor error: %w", err)
+	}
+
+	fmt.Printf("Completed processing %d documents\n", processed)
+	return processed, nil
+}

--- a/server/cmd/db-migrations/250926132908_add_project_metadata_fields_test.go
+++ b/server/cmd/db-migrations/250926132908_add_project_metadata_fields_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func Test_updateProjectMetadata(t *testing.T) {
+	// Create a fixed timestamp for testing
+	fixedTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	objID := primitive.NewObjectIDFromTimestamp(fixedTime)
+
+	tests := []struct {
+		name       string
+		project    ProjectMetadataDocument
+		wantFields map[string]interface{}
+	}{
+		{
+			name: "basic project",
+			project: ProjectMetadataDocument{
+				ID:          objID.Hex(),
+				Name:        "Test Project",
+				Description: "Test Description",
+				Workspace:   "workspace1",
+			},
+			wantFields: map[string]interface{}{
+				"Topics":    []string{},
+				"StarCount": 0,
+				"StarredBy": []string{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updateOp, err := updateProjectMetadata()(tt.project)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, updateOp)
+			
+			// Check that we have a $set operation
+			setOp, exists := updateOp["$set"]
+			assert.True(t, exists, "Should have $set operation")
+			
+			setMap := setOp.(bson.M)
+			
+			// Check the new fields in the $set operation
+			assert.Equal(t, tt.wantFields["Topics"], setMap["topics"])
+			assert.Equal(t, tt.wantFields["StarCount"], setMap["star_count"])
+			assert.Equal(t, tt.wantFields["StarredBy"], setMap["starred_by"])
+
+			// Check that created_at is set
+			assert.NotNil(t, setMap["created_at"])
+
+			// Check that created_at matches ObjectID timestamp
+			createdAt := setMap["created_at"].(time.Time)
+			assert.Equal(t, fixedTime, createdAt)
+
+			// Should not have $unset operation
+			_, hasUnset := updateOp["$unset"]
+			assert.False(t, hasUnset, "Should not have $unset operation")
+		})
+	}
+}
+
+func Test_updateProjectMetadata_with_existing_created_at(t *testing.T) {
+	existingCreatedAt := time.Date(2022, 6, 15, 10, 30, 0, 0, time.UTC)
+	objID := primitive.NewObjectID()
+
+	project := ProjectMetadataDocument{
+		ID:        objID.Hex(),
+		Name:      "Test Project",
+		Workspace: "workspace1",
+	}
+
+	updateOp, err := updateProjectMetadata()(project)
+
+	assert.NoError(t, err)
+	
+	setOp := updateOp["$set"].(bson.M)
+	createdAt := setOp["created_at"].(time.Time)
+	assert.Equal(t, existingCreatedAt, createdAt, "Should preserve existing created_at")
+}
+

--- a/server/cmd/db-migrations/250926132908_add_project_metadata_fields_test.go
+++ b/server/cmd/db-migrations/250926132908_add_project_metadata_fields_test.go
@@ -53,13 +53,6 @@ func Test_updateProjectMetadata(t *testing.T) {
 			assert.Equal(t, tt.wantFields["StarCount"], setMap["star_count"])
 			assert.Equal(t, tt.wantFields["StarredBy"], setMap["starred_by"])
 
-			// Check that created_at is set
-			assert.NotNil(t, setMap["created_at"])
-
-			// Check that created_at matches ObjectID timestamp
-			createdAt := setMap["created_at"].(time.Time)
-			assert.Equal(t, fixedTime, createdAt)
-
 			// Should not have $unset operation
 			_, hasUnset := updateOp["$unset"]
 			assert.False(t, hasUnset, "Should not have $unset operation")
@@ -67,22 +60,4 @@ func Test_updateProjectMetadata(t *testing.T) {
 	}
 }
 
-func Test_updateProjectMetadata_with_existing_created_at(t *testing.T) {
-	existingCreatedAt := time.Date(2022, 6, 15, 10, 30, 0, 0, time.UTC)
-	objID := primitive.NewObjectID()
-
-	project := ProjectMetadataDocument{
-		ID:        objID.Hex(),
-		Name:      "Test Project",
-		Workspace: "workspace1",
-	}
-
-	updateOp, err := updateProjectMetadata()(project)
-
-	assert.NoError(t, err)
-	
-	setOp := updateOp["$set"].(bson.M)
-	createdAt := setOp["created_at"].(time.Time)
-	assert.Equal(t, existingCreatedAt, createdAt, "Should preserve existing created_at")
-}
 

--- a/server/cmd/db-migrations/main.go
+++ b/server/cmd/db-migrations/main.go
@@ -12,9 +12,10 @@ import (
 type command = func(ctx context.Context, dbURL, dbName string, wetRun bool) error
 
 var commands = map[string]command{
-	"ref-field-schema":   RefFieldSchema,
-	"item-migration":     ItemMigration,
-	"project-visibility": ProjectVisibility,
+	"ref-field-schema":           RefFieldSchema,
+	"item-migration":             ItemMigration,
+	"project-visibility":         ProjectVisibility,
+	"add-project-metadata-fields": AddProjectMetadataFields,
 }
 
 func main() {


### PR DESCRIPTION
- Introduces a database migration to add and initialize new metadata fields to the "project" collection in MongoDB, including topics, star count and starred by, while preserving existing data. These fields are to be used in reearth-dashboard project