### PR TITLE
fix(server): temporary revert asset base url redirect

### DIFF
--- a/server/internal/infrastructure/gcp/file.go
+++ b/server/internal/infrastructure/gcp/file.go
@@ -22,7 +22,6 @@ import (
 	"github.com/reearth/reearthx/log"
 	"github.com/reearth/reearthx/rerror"
 	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
 )
 
 const (
@@ -39,7 +38,6 @@ type fileRepo struct {
 	cacheControl     string
 	public           bool
 	replaceUploadURL bool
-	customEndpoint   string // Custom GCS endpoint for proxy setups
 }
 
 func NewFile(bucketName, publicBase, cacheControl string, replaceUploadURL bool) (gateway.File, error) {
@@ -57,20 +55,11 @@ func NewFile(bucketName, publicBase, cacheControl string, replaceUploadURL bool)
 		return nil, rerror.NewE(i18n.T("invalid base URL"))
 	}
 
-	var customEndpoint string
-	// Use custom endpoint if AssetBaseURL (publicBase) is configured with a custom domain
-	// This allows GCS client to redirect to the custom asset proxy endpoint
-	// Treat as custom endpoint if host is not a standard GCS endpoint
-	if !strings.HasSuffix(u.Host, ".googleapis.com") && u.Host != "" {
-		customEndpoint = u.Scheme + "://" + u.Host
-	}
-
 	return &fileRepo{
 		bucketName:       bucketName,
 		publicBase:       u,
 		privateBase:      nil,
 		cacheControl:     cacheControl,
-		customEndpoint:   customEndpoint,
 		public:           true,
 		replaceUploadURL: replaceUploadURL,
 	}, nil
@@ -245,8 +234,7 @@ func (f *fileRepo) IssueUploadAssetLink(ctx context.Context, param gateway.Issue
 		return nil, gateway.ErrInvalidFile
 	}
 
-	// Use signing-capable bucket to ensure signed URLs work with storage.googleapis.com
-	bucket, err := f.bucketWithOptions(ctx, true)
+	bucket, err := f.bucket(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -621,21 +609,7 @@ func getGCSObjectPathFolder(uuid string) string {
 }
 
 func (f *fileRepo) bucket(ctx context.Context) (*storage.BucketHandle, error) {
-	return f.bucketWithOptions(ctx, false)
-}
-
-func (f *fileRepo) bucketWithOptions(ctx context.Context, forSigning bool) (*storage.BucketHandle, error) {
-	var client *storage.Client
-	var err error
-
-	// For signed URLs, always use standard GCS client to ensure signatures work
-	// with storage.googleapis.com, regardless of custom endpoint configuration
-	if forSigning || f.customEndpoint == "" {
-		client, err = storage.NewClient(ctx)
-	} else {
-		client, err = storage.NewClient(ctx, option.WithEndpoint(f.customEndpoint))
-	}
-
+	client, err := storage.NewClient(ctx)
 	if err != nil {
 		log.Errorf("gcs: failed to initialize client: %v", err)
 		return nil, err


### PR DESCRIPTION
# Overview
temporary revert asset base url redirect to the previous implementation due to other team testing in test env
## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
