### PR TITLE
refactor(web): optimize Playwright test configuration

### DIFF
--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -14,8 +14,10 @@ export const baseURL = process.env.REEARTH_CMS_E2E_BASEURL || "http://localhost:
 
 const config: PlaywrightTestConfig = {
   globalSetup: path.resolve(__dirname, "./e2e/global-setup.ts"),
-  workers: process.env.CI ? 4 : undefined,
-  retries: 2,
+  workers: process.env.CI ? 5 : undefined,
+  retries: 1,
+  maxFailures: process.env.CI ? undefined : 10,
+  forbidOnly: !!process.env.CI,
   use: {
     baseURL,
     screenshot: "only-on-failure",
@@ -26,7 +28,7 @@ const config: PlaywrightTestConfig = {
   testDir: "./e2e/tests",
   testMatch: "**/*.spec.ts",
   testIgnore: ["**/node_modules/**", "**/dist/**", "**/build/**"],
-  reporter: process.env.CI ? "github" : "list",
+  reporter: process.env.CI ? "github" : [["list"], ["html", { open: "never" }]],
   fullyParallel: true,
   projects: [
     {
@@ -36,7 +38,7 @@ const config: PlaywrightTestConfig = {
       },
     },
   ],
-  timeout: 120 * 1000,
+  timeout: 90 * 1000,
 };
 
 export default config;


### PR DESCRIPTION
# Overview
Optimize Playwright test configuration with environment-specific settings to improve developer experience locally while maintaining reliability in CI.

## Changes

### Worker Configuration
- **CI**: Fixed at 5 workers for predictable resource usage
- **Local**: Auto-detect based on CPU cores (undefined = 50% of cores)

### Retry Strategy
- 1 retry for faster feedback

### New Configuration Options
- **maxFailures**: Stop after 10 failures locally to save time (unlimited in CI)
- **forbidOnly**: Prevent `.only()` tests from being committed to CI

### Reporter Enhancement
- **CI**: GitHub Actions reporter for integration
- **Local**: List output + HTML report (saved to `playwright-report/`) for better debugging

### Timeout Optimization
- Reduced from 120s to 90s for faster test execution while still allowing for slower tests
