### PR TITLE
feat(web): add OpenStreetMap attribution overlay to GeometryItem map

### DIFF
--- a/web/src/components/molecules/Common/Form/GeometryItem/index.tsx
+++ b/web/src/components/molecules/Common/Form/GeometryItem/index.tsx
@@ -284,8 +284,7 @@ const GeometryItem: React.FC<Props> = ({
         preload: Infinity,
         source: new OSM({
           attributions:
-            '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a> • ' +
-            '<a href="https://opendatacommons.org/licenses/odbl/">ODbL</a>',
+            'Map data from <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
         }),
       });
 


### PR DESCRIPTION
# Overview

Added proper OpenStreetMap (OSM) attribution in compliance with ODbL requirements to the GeometryItem component.
