### PR TITLE
fix(server): allow user to star a project owned by another user

### DIFF
--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -571,7 +571,7 @@ func (i *Project) StarProject(ctx context.Context, idOrAlias project.IDOrAlias, 
 		return nil, rerror.ErrNotFound
 	}
 
-	return Run1(ctx, op, i.repos, Usecase().WithWritableWorkspaces(p.Workspace()).Transaction(),
+	return Run1(ctx, op, i.repos, Usecase().Transaction(),
 		func(ctx context.Context) (_ *project.Project, err error) {
 			if slices.Contains(p.StarredBy(), userID.String()) {
 				p.Unstar(*userID)

--- a/server/internal/usecase/interactor/project_test.go
+++ b/server/internal/usecase/interactor/project_test.go
@@ -1211,6 +1211,9 @@ func TestProject_StarProject(t *testing.T) {
 	u1 := user.New().Name("user1").NewID().Email("user1@test.com").Workspace(wid1).MustBuild()
 	u1ID := u1.ID()
 
+	u2 := user.New().Name("user2").NewID().Email("user2@test.com").Workspace(wid2).MustBuild()
+	u2ID := u2.ID()
+
 	pid1 := id.NewProjectID()
 	p1 := project.New().ID(pid1).Workspace(wid1).Alias("test-project").MustBuild()
 
@@ -1220,6 +1223,14 @@ func TestProject_StarProject(t *testing.T) {
 	validOp := &usecase.Operator{
 		AcOperator: &accountusecase.Operator{
 			User:               lo.ToPtr(u1ID),
+			ReadableWorkspaces: []accountdomain.WorkspaceID{wid1, wid2},
+			WritableWorkspaces: []accountdomain.WorkspaceID{wid1, wid2},
+		},
+	}
+
+	otherUserOp := &usecase.Operator{
+		AcOperator: &accountusecase.Operator{
+			User:               lo.ToPtr(u2ID),
 			ReadableWorkspaces: []accountdomain.WorkspaceID{wid1, wid2},
 			WritableWorkspaces: []accountdomain.WorkspaceID{wid1, wid2},
 		},
@@ -1241,6 +1252,21 @@ func TestProject_StarProject(t *testing.T) {
 		mockProjectErr bool
 		wantErr        error
 	}{
+		{
+			name:  "star project owned by another user",
+			seeds: project.List{p1.Clone()},
+			args: args{
+				idOrAlias: project.IDOrAlias(p1.ID().String()),
+				operator:  otherUserOp,
+			},
+			want: func() *project.Project {
+				p := p1.Clone()
+				p.Star(u2ID)
+				p.SetUpdatedAt(now)
+				return p
+			}(),
+			wantErr: nil,
+		},
 		{
 			name:  "star project by ID",
 			seeds: project.List{p1.Clone()},


### PR DESCRIPTION
- Need to allow a user to star ( or unstar ) a project owned by another user. Implemented this change to facilitate that as well as added a test to check functionality