### PR TITLE
fix(server): make Accounts API optional with fallback to local auth

### DIFF
--- a/server/internal/adapter/gql/resolver_user.go
+++ b/server/internal/adapter/gql/resolver_user.go
@@ -77,7 +77,6 @@ func (r *mutationResolver) DeleteMe(ctx context.Context, input gqlmodel.DeleteMe
 // Me is the resolver for the me field.
 func (r *queryResolver) Me(ctx context.Context) (*gqlmodel.Me, error) {
 	g := gateways(ctx)
-
 	if g != nil && g.Accounts != nil {
 		usr, err := g.Accounts.FindMe(ctx)
 		if err != nil {


### PR DESCRIPTION
# Overview

Fixes login failure when Accounts API is not configured by adding fallback to local authentication.