### PR TITLE
fix(ci): explicitly pass E2E secrets to smoke tests in deploy workflow

### DIFF
--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -112,6 +112,8 @@ jobs:
             --quiet
 
   e2e_web:
+    needs: [deploy_server, deploy_web]
+    if: needs.deploy_server.result == 'success' && needs.deploy_web.result == 'success'
     uses: ./.github/workflows/e2e_web.yml
     with:
       api_url: ${{ vars.REEARTH_CMS_API }}


### PR DESCRIPTION
# Overview

Explicitly pass E2E credentials to the smoke test workflow instead of inheriting all secrets.
