### PR TITLE
fix(server): include asset URLs in Integration API GeoJSON response

### DIFF
--- a/server/internal/adapter/integration/item.go
+++ b/server/internal/adapter/integration/item.go
@@ -101,9 +101,11 @@ func (s *Server) ItemsAsGeoJSON(ctx context.Context, request ItemsAsGeoJSONReque
 	}
 
 	req := interfaces.ExportItemParams{
-		ModelID:       wp.Model.ID(),
-		Format:        exporters.FormatGeoJSON,
-		Options:       exporters.ExportOptions{},
+		ModelID: wp.Model.ID(),
+		Format:  exporters.FormatGeoJSON,
+		Options: exporters.ExportOptions{
+			IncludeAssets: true,
+		},
 		SchemaPackage: *sp,
 	}
 


### PR DESCRIPTION
# Overview

Fixes missing asset URLs in the Integration API's GeoJSON endpoint response.
