### PR TITLE
fix(server): disable health check on init by default

### DIFF
--- a/server/internal/app/config.go
+++ b/server/internal/app/config.go
@@ -85,7 +85,7 @@ type Config struct {
 type HealthCheckConfig struct {
 	Username  string `pp:",omitempty"`
 	Password  string `pp:",omitempty"`
-	RunOnInit bool   `default:"true" pp:",omitempty"`
+	RunOnInit bool   `default:"false" pp:",omitempty"`
 }
 
 type AccountAPIConfig struct {


### PR DESCRIPTION
# Overview

This is a **temporary fix** to quickly resolve Cloud Run deployment failures. A proper fix is being prepared in a separate PR.
