### PR TITLE
feat(web): auto-detect and parse JSON string attributes in asset preview

### DIFF
--- a/web/src/components/atoms/ResiumViewer/sortProperty.test.ts
+++ b/web/src/components/atoms/ResiumViewer/sortProperty.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe } from "vitest";
 
-import { sortProperties } from "./sortProperty";
+import { sortProperties, tryParseJson } from "./sortProperty";
 
 describe("sort Properties", () => {
   test("sort depth1: simple", () => {
@@ -60,5 +60,60 @@ describe("sort Properties", () => {
       c: ["1", "2", "3"],
     };
     expect(sortProperties(obj)).toStrictEqual(expected);
+  });
+
+  test("parse JSON string properties", () => {
+    const obj = {
+      name: "test",
+      attributes: '{"key": "value", "nested": {"a": 1}}',
+      normalString: "hello",
+    };
+    const result = sortProperties(obj);
+    expect(result).toEqual({
+      attributes: { key: "value", nested: { a: 1 } },
+      name: "test",
+      normalString: "hello",
+    });
+  });
+
+  test("parse JSON array string properties", () => {
+    const obj = {
+      items: '[1, 2, 3]',
+      name: "test",
+    };
+    const result = sortProperties(obj);
+    expect(result).toEqual({
+      items: [1, 2, 3],
+      name: "test",
+    });
+  });
+});
+
+describe("tryParseJson", () => {
+  test("parse valid JSON object", () => {
+    expect(tryParseJson('{"a": 1}')).toEqual({ a: 1 });
+    expect(tryParseJson('  {"a": 1}  ')).toEqual({ a: 1 });
+  });
+
+  test("parse valid JSON array", () => {
+    expect(tryParseJson("[1, 2, 3]")).toEqual([1, 2, 3]);
+    expect(tryParseJson('["a", "b"]')).toEqual(["a", "b"]);
+  });
+
+  test("return null for non-JSON strings", () => {
+    expect(tryParseJson("hello")).toBeNull();
+    expect(tryParseJson("123")).toBeNull();
+    expect(tryParseJson("")).toBeNull();
+  });
+
+  test("return null for invalid JSON", () => {
+    expect(tryParseJson("{invalid}")).toBeNull();
+    expect(tryParseJson("{a: 1}")).toBeNull();
+    expect(tryParseJson("[1, 2,]")).toBeNull();
+  });
+
+  test("return null for primitive JSON values", () => {
+    expect(tryParseJson("null")).toBeNull();
+    expect(tryParseJson("true")).toBeNull();
   });
 });

--- a/web/src/components/atoms/ResiumViewer/sortProperty.ts
+++ b/web/src/components/atoms/ResiumViewer/sortProperty.ts
@@ -5,6 +5,9 @@ export const sortProperties = <T extends Record<string, any>>(properties: T) => 
   const sortedProperties = sortedKeys.reduce(
     (obj, k) => {
       let val = properties[k];
+      if (typeof val === "string") {
+        val = tryParseJson(val) ?? val;
+      }
       if (val !== null && typeof val === "object" && !Array.isArray(val)) {
         val = sortProperties(val);
       }
@@ -16,3 +19,19 @@ export const sortProperties = <T extends Record<string, any>>(properties: T) => 
   );
   return sortedProperties;
 };
+
+export function tryParseJson(value: string): object | null {
+  const trimmed = value.trim();
+  if (
+    !(trimmed.startsWith("{") && trimmed.endsWith("}")) &&
+    !(trimmed.startsWith("[") && trimmed.endsWith("]"))
+  ) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(trimmed);
+    return typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}

--- a/web/src/components/molecules/Asset/Viewers/MvtViewer/index.tsx
+++ b/web/src/components/molecules/Asset/Viewers/MvtViewer/index.tsx
@@ -18,18 +18,7 @@ const MvtViewer: React.FC<Props> = ({ isAssetPublic, viewerRef, url, workspaceSe
   const [properties, setProperties] = useState<Property>();
 
   const handleProperties = useCallback((prop: Property) => {
-    if (!prop || typeof prop !== "object") {
-      setProperties(undefined);
-      return;
-    }
-
-    try {
-      const attributes =
-        typeof prop.attributes === "string" ? JSON.parse(prop.attributes) : prop.attributes;
-      setProperties({ ...prop, attributes });
-    } catch {
-      setProperties(prop);
-    }
+    setProperties(prop && typeof prop === "object" ? prop : undefined);
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- Automatically detect and parse JSON-like strings in all property values for MVT and 3D Tiles preview
- Remove hardcoded `attributes` field parsing in MVTViewer and apply JSON detection universally

## Changes
- `sortProperty.ts`: Add `tryParseJson` function and integrate JSON detection in `sortProperties`
- `MvtViewer/index.tsx`: Remove hardcoded `attributes` parsing (now handled by generic processing)
- Add comprehensive tests for `tryParseJson` and JSON string parsing

## Related
- https://github.com/eukarya-inc/PLATEAU-VIEW/pull/495

## Test plan
- [ ] Verify JSON string attributes (like `attributes`) are expanded in MVT preview
- [ ] Verify JSON string attributes are also expanded in 3D Tiles preview
- [ ] Verify normal strings are displayed as-is
- [ ] Verify invalid JSON strings are displayed as-is without parsing