### PR TITLE
feat: increase maximum import record count to 500,000

### DIFF
--- a/server/e2e/gql_item_import_test.go
+++ b/server/e2e/gql_item_import_test.go
@@ -133,14 +133,14 @@ func TestGQLImportItems(t *testing.T) {
 			errorContains: "too large",
 		},
 		{
-			name: "too many records (exceeds 2000)",
+			name: "too many records (exceeds 500_000)",
 			fields: []createFieldParams{
 				{title: "name", key: "name", fType: "Text", typeProp: map[string]any{"text": map[string]any{}}},
 			},
 			fileName: "many.json",
 			fileContent: func() string {
 				var items []string
-				for i := 0; i < 2001; i++ {
+				for i := 0; i < 500_001; i++ {
 					items = append(items, `{"name": "test"}`)
 				}
 				return "[" + strings.Join(items, ",") + "]"

--- a/server/internal/usecase/interfaces/item.go
+++ b/server/internal/usecase/interfaces/item.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	MaxImportFileSize    = 10 * 1024 * 1024 // 10 MB
-	MaxImportRecordCount = 2000
+	MaxImportRecordCount = 500_000
 )
 
 var (

--- a/web/src/utils/constant.ts
+++ b/web/src/utils/constant.ts
@@ -23,7 +23,7 @@ export abstract class Constant {
   };
 
   public static readonly IMPORT = {
-    MAX_CONTENT_RECORDS: 2_000,
+    MAX_CONTENT_RECORDS: 500_000,
     GET_JOB_DELAY_TIME_IN_MS: 500,
 
     // import ignore field types by file format


### PR DESCRIPTION
## Summary

Increase the maximum number of records allowed for item import from 2,000 to 500,000.

## Changes

- **server/internal/usecase/interfaces/item.go**: Update `MaxImportRecordCount` constant from `2000` to `500_000`
- **web/src/utils/constant.ts**: Update `MAX_CONTENT_RECORDS` constant from `2_000` to `500_000`
- **server/e2e/gql_item_import_test.go**: Update E2E test to reflect the new limit (test name and loop count)