### PR TITLE
chore: update golang version to 1.25.6 in Dockerfile

### DIFF
--- a/worker/decompressor.Dockerfile
+++ b/worker/decompressor.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5 AS build
+FROM golang:1.25.6 AS build
 WORKDIR /app
 COPY . .
 RUN CGO_ENABLED=0 go build ./cmd/decompressor


### PR DESCRIPTION
## Summary
- Update Go version from 1.25.5 to 1.25.6 in `worker/decompressor.Dockerfile`

## Motivation
Keep the Go toolchain up to date with the latest patch release for bug fixes and security patches.