### PR TITLE
feat(ci): [POC] add base_url and api_url inputs to E2E workflow_dispatch

### DIFF
--- a/.github/workflows/e2e_web.yml
+++ b/.github/workflows/e2e_web.yml
@@ -6,6 +6,14 @@ on:
         description: "Target branch"
         required: false
         default: "main"
+      base_url:
+        description: "Base URL for E2E tests (defaults to vars.REEARTH_CMS_E2E_BASEURL)"
+        required: false
+        default: ""
+      api_url:
+        description: "API URL (defaults to vars.REEARTH_CMS_API)"
+        required: false
+        default: ""
       smoke_only:
         description: "Run smoke tests only"
         type: boolean


### PR DESCRIPTION
# Overview

Allow overriding `base_url` and `api_url` when manually triggering the E2E workflow with PR preview deployments.

## Memo
