### PR TITLE
chore: update Go to 1.26.2

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.26.1
+go 1.26.2
 
 use (
 	./server

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine AS build
+FROM golang:1.26.2-alpine AS build
 ARG TAG=release
 ARG REV
 ARG VERSION

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/reearth/reearth-cms/server
 
-go 1.26.1
+go 1.26.2
 
 require (
 	cloud.google.com/go/pubsub/v2 v2.5.0

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine AS build
+FROM golang:1.26.2-alpine AS build
 
 ARG TAG=release
 ARG REV

--- a/worker/copier.Dockerfile
+++ b/worker/copier.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine AS build
+FROM golang:1.26.2-alpine AS build
 
 RUN apk add --update --no-cache ca-certificates
 

--- a/worker/decompressor.Dockerfile
+++ b/worker/decompressor.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1 AS build
+FROM golang:1.26.2 AS build
 WORKDIR /app
 COPY . .
 RUN CGO_ENABLED=0 go build ./cmd/decompressor

--- a/worker/go.mod
+++ b/worker/go.mod
@@ -1,6 +1,6 @@
 module github.com/reearth/reearth-cms/worker
 
-go 1.26.1
+go 1.26.2
 
 require (
 	cloud.google.com/go/pubsub/v2 v2.5.0


### PR DESCRIPTION
## Summary
- Bump Go version from 1.26.1 to 1.26.2 in `server/go.mod`, `worker/go.mod`, and `go.work`
- Update base Docker image to `golang:1.26.2-alpine` (or non-alpine) across all Dockerfiles: `server/Dockerfile`, `worker/Dockerfile`, `worker/copier.Dockerfile`, `worker/decompressor.Dockerfile`

## Motivation
Picks up the latest Go patch release (1.26.2) which includes bug fixes and minor improvements.