### PR TITLE
fix(server): fix CORS middleware after Echo v5 upgrade

### DIFF
--- a/server/e2e/integration_test.go
+++ b/server/e2e/integration_test.go
@@ -49,7 +49,7 @@ func TestIntegrationAPI_CORS(t *testing.T) {
 		}
 	})
 
-	t.Run("specific public domain in dev mod", func(t *testing.T) {
+	t.Run("specific integration domain in dev mode", func(t *testing.T) {
 		e, _, _ := StartServerWithRepos(t, &app.Config{
 			AssetBaseURL:        "https://example.com",
 			Integration_Origins: []string{"https://example.com"},

--- a/server/e2e/integration_test.go
+++ b/server/e2e/integration_test.go
@@ -1,0 +1,69 @@
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/reearth/reearth-cms/server/internal/app"
+)
+
+func TestIntegrationAPI_CORS(t *testing.T) {
+	endpoints := []string{
+		"/api/openapi.json",
+		fmt.Sprintf("/api/%s/projects", wId0.String()),
+	}
+
+	t.Run("specific domain", func(t *testing.T) {
+		e, _, _ := StartServerWithRepos(t, &app.Config{
+			AssetBaseURL:        "https://example.com",
+			Integration_Origins: []string{"https://example.com"},
+			Dev:                 false,
+		}, true, publicAPISeeder)
+
+		for _, endpoint := range endpoints {
+			res := e.OPTIONS(endpoint).
+				WithHeader("Origin", "https://example.com").
+				WithHeader("Access-Control-Request-Method", "GET").
+				Expect().
+				Status(http.StatusNoContent)
+			res.Header("Access-Control-Allow-Origin").IsEqual("https://example.com")
+			res.Header("Access-Control-Allow-Methods").Contains("GET")
+		}
+	})
+
+	t.Run("*", func(t *testing.T) {
+		e, _, _ := StartServerWithRepos(t, &app.Config{
+			AssetBaseURL:        "https://example.com",
+			Integration_Origins: []string{"*"},
+		}, true, publicAPISeeder)
+
+		for _, endpoint := range endpoints {
+		res := e.OPTIONS(endpoint).
+				WithHeader("Origin", "https://example.com").
+				WithHeader("Access-Control-Request-Method", "POST").
+				Expect().
+				Status(http.StatusNoContent)
+			res.Header("Access-Control-Allow-Origin").IsEqual("*")
+			res.Header("Access-Control-Allow-Methods").Contains("POST")
+		}
+	})
+
+	t.Run("specific public domain in dev mod", func(t *testing.T) {
+		e, _, _ := StartServerWithRepos(t, &app.Config{
+			AssetBaseURL:        "https://example.com",
+			Integration_Origins: []string{"https://example.com"},
+			Dev:                 true,
+		}, true, publicAPISeeder)
+
+		for _, endpoint := range endpoints {
+			res := e.OPTIONS(endpoint).
+				WithHeader("Origin", "https://example.com").
+				WithHeader("Access-Control-Request-Method", "POST").
+				Expect().
+				Status(http.StatusNoContent)
+			res.Header("Access-Control-Allow-Origin").IsEqual("*")
+			res.Header("Access-Control-Allow-Methods").Contains("POST")
+		}
+	})
+}

--- a/server/e2e/integration_test.go
+++ b/server/e2e/integration_test.go
@@ -39,7 +39,7 @@ func TestIntegrationAPI_CORS(t *testing.T) {
 		}, true, publicAPISeeder)
 
 		for _, endpoint := range endpoints {
-		res := e.OPTIONS(endpoint).
+			res := e.OPTIONS(endpoint).
 				WithHeader("Origin", "https://example.com").
 				WithHeader("Access-Control-Request-Method", "POST").
 				Expect().

--- a/server/internal/adapter/publicapi/api.go
+++ b/server/internal/adapter/publicapi/api.go
@@ -51,10 +51,6 @@ func Echo(e *echo.Group) {
 	// /:ws/:p/:m.zip
 	// /:ws/:p/:m/:i
 
-	// register dummy OPTIONS route so CORS middleware works fine!
-	noopHandler := func(ctx *echo.Context) error { return nil }
-	e.OPTIONS("/*", noopHandler)
-
 	e.GET("/:workspace/:project/:sub-route", SubRoute())
 	e.GET("/:workspace/:project/:model/:item", ItemOrAsset())
 	e.GET("/:workspace/:project", OpenAPISchema())

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -73,19 +73,19 @@ func initApi(appCtx *ApplicationContext, api *echo.Group, usecaseMiddleware echo
 	api.Use(private)
 	api.GET("/ping", Ping())
 	api.GET("/health", appCtx.HealthChecker.Handler())
-	graphqlHandler := GraphqlAPI(appCtx.Config.GraphQL, appCtx.Config.Dev)
-	graphqlMiddlewares := []echo.MiddlewareFunc{
-		middleware.CORSWithConfig(middleware.CORSConfig{AllowOrigins: allowedOrigins(appCtx)}),
+
+	graphqlMiddlewares := []echo.MiddlewareFunc{}
+	if o := allowedOrigins(appCtx); len(o) > 0 {
+		graphqlMiddlewares = append(graphqlMiddlewares, middleware.CORS(o...))
+	}
+	graphqlMiddlewares = append(graphqlMiddlewares,
 		jwtParseMiddleware(appCtx),
 		authMiddleware(appCtx),
 		usecaseMiddleware,
-	}
-	api.Any("/graphql", graphqlHandler, graphqlMiddlewares...)
-	api.POST(
-		"/notify", NotifyHandler(),
-		M2MAuthMiddleware(appCtx.Config),
-		usecaseMiddleware,
 	)
+	api.Any("/graphql", GraphqlAPI(appCtx.Config.GraphQL, appCtx.Config.Dev), graphqlMiddlewares...)
+
+	api.POST("/notify", NotifyHandler(), M2MAuthMiddleware(appCtx.Config), usecaseMiddleware)
 
 	// M2M API endpoints
 	if appCtx.Config.AuthM2M.Token != "" {
@@ -104,7 +104,11 @@ func initPublicApi(appCtx *ApplicationContext, publicAPIGroup *echo.Group, useca
 	publicOrigins := allowedPublicOrigins(appCtx)
 	if len(publicOrigins) > 0 {
 		publicAPIGroup.Use(middleware.CORS(publicOrigins...))
+
+		// register dummy OPTIONS route so CORS middleware works fine!
+		publicAPIGroup.OPTIONS("/*", func(ctx *echo.Context) error { return nil })
 	}
+
 	publicAPIGroup.Use(publicAPIAuthMiddleware(appCtx), usecaseMiddleware)
 	publicapi.Echo(publicAPIGroup)
 }
@@ -112,7 +116,10 @@ func initPublicApi(appCtx *ApplicationContext, publicAPIGroup *echo.Group, useca
 func initIntegrationApi(appCtx *ApplicationContext, integrationAPIGroup *echo.Group, usecaseMiddleware echo.MiddlewareFunc) {
 	integrationOrigins := allowedIntegrationOrigins(appCtx)
 	if len(integrationOrigins) > 0 {
-		integrationAPIGroup.Use(middleware.CORSWithConfig(middleware.CORSConfig{AllowOrigins: integrationOrigins}))
+		integrationAPIGroup.Use(middleware.CORS(integrationOrigins...))
+
+		// register dummy OPTIONS route so CORS middleware works fine!
+		integrationAPIGroup.OPTIONS("/*", func(ctx *echo.Context) error { return nil })
 	}
 
 	// OpenAPI spec endpoint - no auth required
@@ -127,7 +134,7 @@ func initIntegrationApi(appCtx *ApplicationContext, integrationAPIGroup *echo.Gr
 func initAssetsApi(appCtx *ApplicationContext, fileServeGroup *echo.Group) {
 	origins := allowedOrigins(appCtx)
 	if len(origins) > 0 {
-		fileServeGroup.Use(middleware.CORSWithConfig(middleware.CORSConfig{AllowOrigins: origins}))
+		fileServeGroup.Use(middleware.CORS(origins...))
 	}
 	serveFiles(fileServeGroup, appCtx)
 }
@@ -143,10 +150,10 @@ func allowedOrigins(appCtx *ApplicationContext) []string {
 		return nil
 	}
 	origins := append([]string{}, appCtx.Config.Origins...)
-	if appCtx.Debug {
-		origins = append(origins, "http://localhost:3000", "http://127.0.0.1:3000", "http://localhost:8080")
+	if appCtx.Config.Dev {
+		origins = append(origins, "*")
 	}
-	return origins
+	return lo.Uniq(origins)
 }
 
 func allowedIntegrationOrigins(appCtx *ApplicationContext) []string {
@@ -154,10 +161,10 @@ func allowedIntegrationOrigins(appCtx *ApplicationContext) []string {
 		return nil
 	}
 	origins := append([]string{}, appCtx.Config.Integration_Origins...)
-	if appCtx.Debug {
-		origins = append(origins, "http://localhost:3000", "http://127.0.0.1:3000", "http://localhost:8080")
+	if appCtx.Config.Dev {
+		origins = append(origins, "*")
 	}
-	return origins
+	return lo.Uniq(origins)
 }
 
 func allowedPublicOrigins(appCtx *ApplicationContext) []string {

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -135,6 +135,9 @@ func initAssetsApi(appCtx *ApplicationContext, fileServeGroup *echo.Group) {
 	origins := allowedOrigins(appCtx)
 	if len(origins) > 0 {
 		fileServeGroup.Use(middleware.CORS(origins...))
+
+		// register dummy OPTIONS route so CORS middleware works fine!
+		fileServeGroup.OPTIONS("/*", func(ctx *echo.Context) error { return nil })
 	}
 	serveFiles(fileServeGroup, appCtx)
 }


### PR DESCRIPTION
## Summary

- Replaces `middleware.CORSWithConfig(...)` with `middleware.CORS(origins...)` across all API groups (GraphQL, public, integration, assets) to align with the Echo v5 middleware API
- Moves dummy `OPTIONS /*` routes to be registered conditionally at the group level (only when CORS origins are configured), and removes the one from `publicapi.Echo()` since it belongs at the app initialization layer
- In dev mode, uses `*` as the allowed origin instead of hardcoded localhost addresses, and applies `lo.Uniq` to deduplicate origin lists
- Adds an e2e test (`TestIntegrationAPI_CORS`) covering specific-domain, wildcard, and dev-mode CORS behavior on the integration API endpoints

## Motivation

The Echo v4 → v5 upgrade (#1858) changed the CORS middleware API. This follow-up corrects the configurations so CORS preflight (`OPTIONS`) requests are properly handled.

## Test plan

- [ ] New e2e test `TestIntegrationAPI_CORS` in `server/e2e/integration_test.go` covers specific-domain, wildcard, and dev-mode CORS scenarios
- [ ] Verify `OPTIONS` preflight requests return correct `Access-Control-Allow-Origin` and `Access-Control-Allow-Methods` headers