### PR TITLE
fix(server): add timeout and propagate context in Auth0 HTTP client

### DIFF
--- a/server/internal/infrastructure/auth0/authenticator.go
+++ b/server/internal/infrastructure/auth0/authenticator.go
@@ -67,16 +67,19 @@ func (u response) Error() string {
 	return u.Message
 }
 
+const defaultTimeout = 30 * time.Second
+
 func New(domain, clientID, clientSecret string) *Auth0 {
 	return &Auth0{
 		domain:       urlFromDomain(domain),
 		clientID:     clientID,
 		clientSecret: clientSecret,
+		client:       &http.Client{Timeout: defaultTimeout},
 	}
 }
 
 func (a *Auth0) UpdateUser(ctx context.Context, p accountgateway.AuthenticatorUpdateUserParam) (data accountgateway.AuthenticatorUser, err error) {
-	err = a.updateToken()
+	err = a.updateToken(ctx)
 	if err != nil {
 		return
 	}
@@ -97,7 +100,7 @@ func (a *Auth0) UpdateUser(ctx context.Context, p accountgateway.AuthenticatorUp
 	}
 
 	var r response
-	r, err = a.exec(http.MethodPatch, "api/v2/users/"+p.ID, a.token, payload)
+	r, err = a.exec(ctx, http.MethodPatch, "api/v2/users/"+p.ID, a.token, payload)
 	if err != nil {
 		if !a.disableLogging {
 			log.Errorf("auth0: update user: %+v", err)
@@ -120,7 +123,7 @@ func (a *Auth0) needsFetchToken() bool {
 	return a.expireAt.IsZero() || a.expireAt.Sub(a.current()) <= time.Hour
 }
 
-func (a *Auth0) updateToken() error {
+func (a *Auth0) updateToken(ctx context.Context) error {
 	if a == nil || !a.needsFetchToken() {
 		return nil
 	}
@@ -136,7 +139,7 @@ func (a *Auth0) updateToken() error {
 		return nil
 	}
 
-	r, err := a.exec(http.MethodPost, "oauth/token", "", map[string]string{
+	r, err := a.exec(ctx, http.MethodPost, "oauth/token", "", map[string]string{
 		"client_id":     a.clientID,
 		"client_secret": a.clientSecret,
 		"audience":      urlFromDomain(a.domain) + "api/v2/",
@@ -166,13 +169,13 @@ func (a *Auth0) updateToken() error {
 	return nil
 }
 
-func (a *Auth0) exec(method, path, token string, b interface{}) (r response, err error) {
+func (a *Auth0) exec(ctx context.Context, method, path, token string, b interface{}) (r response, err error) {
 	if a == nil || a.domain == "" {
 		err = rerror.NewE(i18n.T("auth0: domain is not set"))
 		return
 	}
 	if a.client == nil {
-		a.client = http.DefaultClient
+		a.client = &http.Client{Timeout: defaultTimeout}
 	}
 
 	var body io.Reader = nil
@@ -190,7 +193,7 @@ func (a *Auth0) exec(method, path, token string, b interface{}) (r response, err
 	}
 
 	var req *http.Request
-	req, err = http.NewRequest(method, urlFromDomain(a.domain)+path, body)
+	req, err = http.NewRequestWithContext(ctx, method, urlFromDomain(a.domain)+path, body)
 	if err != nil {
 		return
 	}

--- a/server/internal/infrastructure/auth0/authenticator_test.go
+++ b/server/internal/infrastructure/auth0/authenticator_test.go
@@ -43,7 +43,7 @@ func TestAuth0(t *testing.T) {
 	a.disableLogging = true
 
 	assert.True(t, a.needsFetchToken())
-	assert.NoError(t, a.updateToken())
+	assert.NoError(t, a.updateToken(context.Background()))
 	assert.Equal(t, token, a.token)
 	assert.Equal(t, current.Add(time.Second*expiresIn), a.expireAt)
 	assert.False(t, a.needsFetchToken())

--- a/server/internal/infrastructure/auth0/authenticator_test.go
+++ b/server/internal/infrastructure/auth0/authenticator_test.go
@@ -36,6 +36,29 @@ func TestURLFromDomain(t *testing.T) {
 	assert.Equal(t, "https://a/", urlFromDomain("a/"))
 }
 
+func TestNew_ClientTimeout(t *testing.T) {
+	t.Parallel()
+	a := New(domain, clientID, clientSecret)
+	assert.NotNil(t, a.client)
+	assert.Equal(t, defaultTimeout, a.client.Timeout)
+}
+
+func TestExec_NilClientFallback(t *testing.T) {
+	t.Parallel()
+	a := &Auth0{
+		domain:         domain,
+		disableLogging: true,
+	}
+	assert.Nil(t, a.client)
+
+	// exec with a nil body so it reaches the http.Client.Do call, which
+	// will fail (no real server), but by then a.client must be populated.
+	_, _ = a.exec(context.Background(), http.MethodGet, "api/v2/users/test", "", nil)
+
+	assert.NotNil(t, a.client)
+	assert.Equal(t, defaultTimeout, a.client.Timeout)
+}
+
 func TestAuth0(t *testing.T) {
 	a := New(domain, clientID, clientSecret)
 	a.client = client(t) // inject mock


### PR DESCRIPTION
## Summary

- Initialize `Auth0.client` with a 30-second timeout in `New()` instead of lazily falling back to `http.DefaultClient` (which has no timeout)
- Replace the `http.DefaultClient` fallback in `exec()` with a timeout-bearing client as a safety net
- Add `ctx context.Context` parameter to `exec()` and `updateToken()`, threading it from `UpdateUser()` all the way to the outbound HTTP call via `http.NewRequestWithContext`

## Motivation

The Auth0 client had two related bugs that could cause a full-server outage:

1. **No timeout** — `exec()` was falling back to `http.DefaultClient`, which has a zero (infinite) timeout. A single hung Auth0 call would block its goroutine forever.
2. **Context not propagated** — `exec()` used `http.NewRequest` instead of `http.NewRequestWithContext`, so the caller's deadline (e.g. from an Echo request context) was never wired to the outbound request.

Combined with the Echo server having no `ReadTimeout`/`WriteTimeout`, a slow Auth0 response would accumulate blocked goroutines until the server could no longer accept new connections — a full outage affecting all users, not just Auth0-dependent operations.

The fix follows the existing `HTTPPolicyChecker` pattern (`server/internal/infrastructure/policy/http_checker.go`), which uses a configurable-timeout client and `http.NewRequestWithContext`.

## Test plan

- [x] `cd server && go test ./internal/infrastructure/auth0/... -v -race` — all tests pass
- [x] `cd server && go build ./...` — no compilation errors