### PR TITLE
fix: add missing permissions to workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,9 @@ jobs:
   deploy-web:
     needs: [build-web, ci-web]
     if: needs.ci-web.result == 'success'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/deploy_test.yml
     with:
       target: web
@@ -184,6 +187,9 @@ jobs:
   deploy-server:
     needs: [build-server, ci-server]
     if: needs.ci-server.result == 'success'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/deploy_test.yml
     with:
       target: server
@@ -192,6 +198,9 @@ jobs:
   deploy-worker:
     needs: [build-worker, ci-worker]
     if: needs.ci-worker.result == 'success'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/deploy_test.yml
     with:
       target: worker

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,11 @@ on:
       - synchronize
       - labeled
       - unlabeled
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   labeler:
     name: labeler


### PR DESCRIPTION
# Overview
Two workflow files were missing permissions required by GitHub's enforced permission inheritance policy:

  ci.yml — The deploy-web, deploy-server, and deploy-worker jobs call deploy_test.yml via workflow_call, which requires OIDC authentication (id-token: write) to deploy to Google Cloud Run. GitHub no longer
  automatically inherits this permission from the caller context, so each job needed an explicit permissions block.

  pr.yml — The labeler job (actions/labeler) requires pull-requests: write to apply labels, and the assign-author job (toshimaru/auto-author-assign) requires both pull-requests: write and issues: write to assign
  authors. Without a top-level permissions block, both actions were failing with "Resource not accessible by integration".

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
