### PR TITLE
fix(server): add HTTP client timeout to file.FromURL to prevent slow-loris DoS

### DIFF
--- a/server/pkg/file/file.go
+++ b/server/pkg/file/file.go
@@ -11,10 +11,16 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+	"time"
 
 	"github.com/reearth/reearthx/i18n"
 	"github.com/reearth/reearthx/rerror"
 )
+
+// urlFetchClient enforces a hard timeout on user-supplied URL fetches
+var urlFetchClient = &http.Client{
+	Timeout: 5 * time.Minute,
+}
 
 type File struct {
 	Content         io.ReadCloser
@@ -70,7 +76,7 @@ func FromURL(ctx context.Context, rawURL string) (*File, error) {
 	// TODO: support gzip
 	// req.Header.Set("Accept-Encoding", "gzip")
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := urlFetchClient.Do(req)
 	if err != nil {
 		return nil, rerror.ErrInternalBy(err)
 	}


### PR DESCRIPTION
## Summary

`file.FromURL` was calling `http.DefaultClient.Do(req)` with no timeout configured. An attacker could supply a URL pointing at a slow or slow-loris server; because neither caller (`resolver_asset.go`, `adapter/integration/asset.go`) sets a deadline on the incoming context, the goroutine, connection, and response body would be held indefinitely.

## Changes

- Introduce a package-level `urlFetchClient` (`*http.Client`) with a 5-minute timeout in `server/pkg/file/file.go`.
- Replace `http.DefaultClient.Do(req)` with `urlFetchClient.Do(req)`.

The `Transport` field is left nil so `http.DefaultTransport` is used, which means existing `httpmock`-based tests in `file_test.go` continue to work without modification.

The 5-minute ceiling is generous enough for large binary assets (~500 MB at typical cloud egress speed) while preventing indefinite goroutine pins.

## Test plan

- [x] `cd server && go test ./pkg/file/...` — all subtests pass
- [x] Manually verify asset creation via URL still works end-to-end