### PR TITLE
ci: grant explicit write permissions to labeler and assign-author jobs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,6 +11,9 @@ jobs:
   labeler:
     name: labeler
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
@@ -54,6 +57,10 @@ jobs:
       - run: echo OK
   assign-author:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0


### PR DESCRIPTION
## Summary

- The org-wide default GitHub Actions token permissions were tightened to read-only, breaking the `labeler` and `assign-author` jobs on all PRs.
- Both jobs need write access to labels/assignees but were relying on the implicit default token permissions, which no longer include write access.
- Adds explicit `permissions` blocks to each job with the minimum required scopes (`pull-requests: write` for labeler, `issues: write` + `pull-requests: write` for assign-author).

## Test plan

- Open or update any PR and verify `labeler` and `assign-author` jobs pass.