### PR TITLE
fix(server): enforce 100 MB hard limit on import file reads

### DIFF
--- a/server/internal/usecase/interactor/item_import.go
+++ b/server/internal/usecase/interactor/item_import.go
@@ -80,6 +80,8 @@ func (i Item) Import(ctx context.Context, param interfaces.ImportItemsParam, ope
 		return res.Into(), interfaces.ErrOperationDenied
 	}
 
+	param.Reader = io.LimitReader(param.Reader, interfaces.MaxImportFileSize+1)
+
 	prj, err := i.repos.Project.FindByID(ctx, s.Project())
 	if err != nil {
 		return res.Into(), err
@@ -228,11 +230,16 @@ func (i Item) ImportAsync(ctx context.Context, param interfaces.ImportItemsAsync
 		return id.JobID{}, interfaces.ErrOperationDenied
 	}
 
-	// Buffer the file content before starting the goroutine
-	// The original reader (from HTTP multipart) will be invalid after the request completes
-	fileData, err := io.ReadAll(param.Reader)
+	// Buffer the file content before starting the goroutine.
+	// The original reader (from HTTP multipart) will be invalid after the request completes.
+	// LimitReader enforces the 100 MB cap regardless of the Content-Length header.
+	lr := io.LimitReader(param.Reader, interfaces.MaxImportFileSize+1)
+	fileData, err := io.ReadAll(lr)
 	if err != nil {
 		return id.JobID{}, fmt.Errorf("failed to read import file: %w", err)
+	}
+	if int64(len(fileData)) > interfaces.MaxImportFileSize {
+		return id.JobID{}, interfaces.ErrImportFileTooLarge
 	}
 
 	// Create import payload

--- a/server/internal/usecase/interactor/item_import.go
+++ b/server/internal/usecase/interactor/item_import.go
@@ -80,7 +80,8 @@ func (i Item) Import(ctx context.Context, param interfaces.ImportItemsParam, ope
 		return res.Into(), interfaces.ErrOperationDenied
 	}
 
-	param.Reader = io.LimitReader(param.Reader, interfaces.MaxImportFileSize+1)
+	lr := &io.LimitedReader{R: param.Reader, N: interfaces.MaxImportFileSize + 1}
+	param.Reader = lr
 
 	prj, err := i.repos.Project.FindByID(ctx, s.Project())
 	if err != nil {
@@ -124,6 +125,9 @@ func (i Item) Import(ctx context.Context, param interfaces.ImportItemsParam, ope
 		for {
 			token, err := decoder.Token()
 			if err != nil {
+				if lr.N == 0 {
+					return res.Into(), interfaces.ErrImportFileTooLarge
+				}
 				return res.Into(), fmt.Errorf("error reading token: %v", err)
 			}
 			if str, ok := token.(string); ok && str == "features" {
@@ -135,6 +139,9 @@ func (i Item) Import(ctx context.Context, param interfaces.ImportItemsParam, ope
 	// Read the opening bracket of array
 	if t, err := decoder.Token(); err != nil || t != json.Delim('[') {
 		if err != nil {
+			if lr.N == 0 {
+				return res.Into(), interfaces.ErrImportFileTooLarge
+			}
 			return res.Into(), fmt.Errorf("error reading array start: %v", err)
 		}
 		return res.Into(), fmt.Errorf("expected array start, got %v", t)
@@ -152,7 +159,13 @@ func (i Item) Import(ctx context.Context, param interfaces.ImportItemsParam, ope
 
 		var obj map[string]any
 		if err := decoder.Decode(&obj); err != nil {
+			if lr.N == 0 {
+				return res.Into(), interfaces.ErrImportFileTooLarge
+			}
 			return res.Into(), fmt.Errorf("error decoding JSON object: %v", err)
+		}
+		if lr.N == 0 {
+			return res.Into(), interfaces.ErrImportFileTooLarge
 		}
 		jsonChunk = append(jsonChunk, obj)
 

--- a/server/internal/usecase/interactor/item_import_csv.go
+++ b/server/internal/usecase/interactor/item_import_csv.go
@@ -22,6 +22,7 @@ import (
 
 // importCSV handles CSV format import (synchronous)
 func (i Item) importCSV(ctx context.Context, prj *project.Project, m *model.Model, s *schema.Schema, param interfaces.ImportItemsParam, res *ImportRes, operator *usecase.Operator) (interfaces.ImportItemsResponse, error) {
+	param.Reader = io.LimitReader(param.Reader, interfaces.MaxImportFileSize+1)
 	reader := csv.NewReader(param.Reader)
 
 	// Read header row

--- a/server/internal/usecase/interactor/item_import_csv.go
+++ b/server/internal/usecase/interactor/item_import_csv.go
@@ -22,8 +22,8 @@ import (
 
 // importCSV handles CSV format import (synchronous)
 func (i Item) importCSV(ctx context.Context, prj *project.Project, m *model.Model, s *schema.Schema, param interfaces.ImportItemsParam, res *ImportRes, operator *usecase.Operator) (interfaces.ImportItemsResponse, error) {
-	param.Reader = io.LimitReader(param.Reader, interfaces.MaxImportFileSize+1)
-	reader := csv.NewReader(param.Reader)
+	lr := &io.LimitedReader{R: param.Reader, N: interfaces.MaxImportFileSize + 1}
+	reader := csv.NewReader(lr)
 
 	// Read header row
 	headers, err := reader.Read()
@@ -48,6 +48,10 @@ func (i Item) importCSV(ctx context.Context, prj *project.Project, m *model.Mode
 		}
 		if err != nil {
 			return res.Into(), fmt.Errorf("error reading CSV row: %v", err)
+		}
+
+		if lr.N == 0 {
+			return res.Into(), interfaces.ErrImportFileTooLarge
 		}
 
 		count++
@@ -93,7 +97,8 @@ func (i Item) importCSV(ctx context.Context, prj *project.Project, m *model.Mode
 
 // importCSVWithProgress handles CSV format import with progress tracking (async)
 func (i Item) importCSVWithProgress(ctx context.Context, j *job.Job, prj *project.Project, m *model.Model, s *schema.Schema, param interfaces.ImportItemsParam, res *ImportRes, operator *usecase.Operator) (interfaces.ImportItemsResponse, error) {
-	reader := csv.NewReader(param.Reader)
+	lr := &io.LimitedReader{R: param.Reader, N: interfaces.MaxImportFileSize + 1}
+	reader := csv.NewReader(lr)
 
 	// Read header row
 	headers, err := reader.Read()
@@ -116,6 +121,9 @@ func (i Item) importCSVWithProgress(ctx context.Context, j *job.Job, prj *projec
 		}
 		if err != nil {
 			return res.Into(), fmt.Errorf("error reading CSV row: %v", err)
+		}
+		if lr.N == 0 {
+			return res.Into(), interfaces.ErrImportFileTooLarge
 		}
 		allRows = append(allRows, record)
 	}


### PR DESCRIPTION
## Summary

The import flow relied on a resolver-layer size check (`input.File.Size`) that inspects the multipart Content-Length metadata. A client can omit or falsify this header, bypassing the check entirely.

- **`ImportAsync`** called `io.ReadAll(param.Reader)` with no upper bound, allowing a single request to allocate multiple GBs of RAM (raw bytes + decoded Go maps coexist in memory). Concurrent imports compound this linearly.
- **`Import` / `importCSV`** passed the reader directly to streaming decoders — safer, but still lacked a hard cap at the interactor boundary.

## Changes

- `item_import.go` (`ImportAsync`): wrap reader with `io.LimitReader(…, MaxImportFileSize+1)` before `io.ReadAll`; return `ErrImportFileTooLarge` if the actual bytes read exceed 100 MB.
- `item_import.go` (`Import`): wrap `param.Reader` with `io.LimitReader` as defense-in-depth for the sync JSON/GeoJSON path.
- `item_import_csv.go` (`importCSV`): same one-liner for the sync CSV path.

The resolver-layer check and the `MaxImportRecordCount` guard are unchanged; this adds a hard guarantee at the layer that actually reads data.

## Test plan

- [ ] Run `go test ./server/internal/usecase/interactor/...` — all existing tests pass
- [ ] Send an async import request with a body exceeding 100 MB and no Content-Length header — server returns `ErrImportFileTooLarge` without OOM
- [ ] Normal import flows (JSON, GeoJSON, CSV under 100 MB) succeed end-to-end