### PR TITLE
feat: switch decompressor to reearth/gcs-unzip v0.1.10 with built-in gzip

### DIFF
--- a/server/internal/infrastructure/gcp/config.go
+++ b/server/internal/infrastructure/gcp/config.go
@@ -9,7 +9,6 @@ type TaskConfig struct {
 	GCSPublic               bool   `pp:",omitempty"`
 	DecompressorImage       string `default:"reearth/reearth-cms-decompressor"`
 	DecompressorTopic       string `default:"decompress"`
-	DecompressorGzipExt     string `default:"gml"`
 	DecompressorMachineType string `default:"E2_HIGHCPU_8"`
 	DecompressorDiskSideGb  int64  `default:"2000"`
 	CopierImage             string `default:"reearth/reearth-cms-copier"`

--- a/server/internal/infrastructure/gcp/taskrunner.go
+++ b/server/internal/infrastructure/gcp/taskrunner.go
@@ -124,7 +124,7 @@ func decompressAsset(ctx context.Context, p task.Payload, conf *TaskConfig) erro
 		Steps: []*cloudbuild.BuildStep{
 			{
 				Name: conf.DecompressorImage,
-				Args: []string{"-v", "-n=192", "-gc=5000", "-chunk=1m", "-disk-limit=20g", "-gzip-ext=" + conf.DecompressorGzipExt, "-skip-top", "-old-windows", src, dest},
+				Args: []string{"-v", "-n=192", "-gc=5000", "-chunk=1m", "-disk-limit=20g", "-skip-top", "-old-windows", src, dest},
 				Env: []string{
 					"GOOGLE_CLOUD_PROJECT=" + project,
 					"REEARTH_CMS_DECOMPRESSOR_TOPIC=" + conf.DecompressorTopic,

--- a/server/internal/infrastructure/gcp/taskrunner_test.go
+++ b/server/internal/infrastructure/gcp/taskrunner_test.go
@@ -33,10 +33,9 @@ func TestTaskRunner(t *testing.T) {
 		GCPProject:          gcpProject,
 		GCPRegion:           gcpRegion,
 		GCSBucket:           gcsBucket,
-		DecompressorImage:   decompressorImage,
-		DecompressorTopic:   "decompress",
-		DecompressorGzipExt: "gml",
-		CopierImage:         copierImage,
+		DecompressorImage: decompressorImage,
+		DecompressorTopic: "decompress",
+		CopierImage:       copierImage,
 	})
 	require.NoError(t, err)
 

--- a/worker/decompressor.Dockerfile
+++ b/worker/decompressor.Dockerfile
@@ -3,6 +3,6 @@ WORKDIR /app
 COPY . .
 RUN CGO_ENABLED=0 go build ./cmd/decompressor
 
-FROM ghcr.io/orisano/gcs-unzip:v0.1.9
+FROM ghcr.io/reearth/gcs-unzip:v0.1.10
 COPY --from=build /app/decompressor /decompressor
 ENTRYPOINT ["/decompressor", "/gcs-unzip"]


### PR DESCRIPTION
## Summary

Switch the decompressor base image from `ghcr.io/orisano/gcs-unzip:v0.1.9` to `ghcr.io/reearth/gcs-unzip:v0.1.10`. The new image gzip-compresses a built-in list of compressible extensions (`.gml`, `.glb`, `.gltf`, etc.) automatically, so:

- `-gzip-ext=` arg is no longer needed
- `DecompressorGzipExt` config field is no longer needed (removed)

## Test plan

- [ ] CI passes
- [ ] On a deployment with the new image, upload a zip containing compressible files (e.g. `.glb`, `.gltf`) and confirm extracted objects have `Content-Encoding: gzip` on GCS