### PR TITLE
fix(web): avoid Cesium Ion default base imagery 401

### DIFF
--- a/web/src/components/atoms/ResiumViewer/index.tsx
+++ b/web/src/components/atoms/ResiumViewer/index.tsx
@@ -157,7 +157,9 @@ const ResiumViewer: React.FC<Props> = ({
   }, [viewerRef, isLoading]);
 
   const imagery = useMemo(() => {
-    return workspaceSettings.tiles ? imageryGet(workspaceSettings.tiles.resources) : [];
+    // Always return at least the default provider so Cesium never falls back to
+    // its built-in Ion base imagery (asset 2), which 401s now that the Ion token is gone.
+    return imageryGet(workspaceSettings.tiles?.resources ?? []);
   }, [workspaceSettings.tiles]);
 
   const terrain = useMemo(() => {
@@ -177,6 +179,7 @@ const ResiumViewer: React.FC<Props> = ({
         sceneModePicker={false}
         baseLayerPicker={true}
         imageryProviderViewModels={imagery}
+        selectedImageryProviderViewModel={imagery[0]}
         selectedTerrainProviderViewModel={terrain[1]}
         terrainProviderViewModels={terrain}
         fullscreenButton={false}


### PR DESCRIPTION
# Overview

Pre-select the first imagery view model so Cesium builds the Viewer with baseLayer:false instead of falling back to ImageryLayer.fromWorldImagery() (Ion asset 2), which 401s now that the Ion token is dropped. Also ensure the imagery list is never empty so it can't silently fall back to the Ion default.

## Memo
