### PR TITLE
fix(server): strip UTF-8 BOM from CSV imports to prevent first column values being dropped

### DIFF
--- a/server/e2e/gql_item_import_csv_test.go
+++ b/server/e2e/gql_item_import_csv_test.go
@@ -218,6 +218,34 @@ func TestGQLImportItemsAsyncCSV(t *testing.T) {
 			expectedTotal:  1,
 			expectedInsert: 1,
 		},
+		{
+			name: "CSV without BOM imports first column correctly",
+			fields: []createFieldParams{
+				{title: "name", key: "name", fType: "Text", typeProp: map[string]any{"text": map[string]any{}}},
+				{title: "count", key: "count", fType: "Integer", typeProp: map[string]any{"integer": map[string]any{}}},
+			},
+			fileName: "no_bom.csv",
+			fileContent: func() string {
+				return "name,count\nItem 1,10\nItem 2,20"
+			},
+			expectError:    false,
+			expectedTotal:  2,
+			expectedInsert: 2,
+		},
+		{
+			name: "CSV with UTF-8 BOM imports first column correctly",
+			fields: []createFieldParams{
+				{title: "name", key: "name", fType: "Text", typeProp: map[string]any{"text": map[string]any{}}},
+				{title: "count", key: "count", fType: "Integer", typeProp: map[string]any{"integer": map[string]any{}}},
+			},
+			fileName: "bom.csv",
+			fileContent: func() string {
+				return "\xEF\xBB\xBFname,count\nItem 1,10\nItem 2,20"
+			},
+			expectError:    false,
+			expectedTotal:  2,
+			expectedInsert: 2,
+		},
 	}
 
 	for _, tt := range tests {
@@ -403,6 +431,38 @@ func TestGQLImportItemsSyncCSV(t *testing.T) {
 			expectError:    false,
 			expectedTotal:  0,
 			expectedInsert: 0,
+			expectedUpdate: 0,
+			expectedIgnore: 0,
+		},
+		{
+			name: "CSV without BOM imports first column correctly",
+			fields: []createFieldParams{
+				{title: "name", key: "name", fType: "Text", typeProp: map[string]any{"text": map[string]any{}}},
+				{title: "count", key: "count", fType: "Integer", typeProp: map[string]any{"integer": map[string]any{}}},
+			},
+			fileName: "no_bom.csv",
+			fileContent: func() string {
+				return "name,count\nItem 1,10\nItem 2,20"
+			},
+			expectError:    false,
+			expectedTotal:  2,
+			expectedInsert: 2,
+			expectedUpdate: 0,
+			expectedIgnore: 0,
+		},
+		{
+			name: "CSV with UTF-8 BOM imports first column correctly",
+			fields: []createFieldParams{
+				{title: "name", key: "name", fType: "Text", typeProp: map[string]any{"text": map[string]any{}}},
+				{title: "count", key: "count", fType: "Integer", typeProp: map[string]any{"integer": map[string]any{}}},
+			},
+			fileName: "bom.csv",
+			fileContent: func() string {
+				return "\xEF\xBB\xBFname,count\nItem 1,10\nItem 2,20"
+			},
+			expectError:    false,
+			expectedTotal:  2,
+			expectedInsert: 2,
 			expectedUpdate: 0,
 			expectedIgnore: 0,
 		},

--- a/server/internal/usecase/interactor/item_import_csv.go
+++ b/server/internal/usecase/interactor/item_import_csv.go
@@ -1,7 +1,6 @@
 package interactor
 
 import (
-	"bufio"
 	"context"
 	"encoding/csv"
 	"fmt"
@@ -19,26 +18,14 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/schema"
 	"github.com/reearth/reearth-cms/server/pkg/value"
 	"github.com/reearth/reearthx/log"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
 )
-
-var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
-
-// skipBOM returns a reader that skips a leading UTF-8 BOM if present.
-// Excel and some other tools emit a BOM when saving UTF-8 CSV files, which
-// would otherwise corrupt the first header name and cause its values to be dropped.
-func skipBOM(r io.Reader) io.Reader {
-	br := bufio.NewReader(r)
-	b, err := br.Peek(3)
-	if err == nil && len(b) == 3 && b[0] == utf8BOM[0] && b[1] == utf8BOM[1] && b[2] == utf8BOM[2] {
-		_, _ = br.Discard(3)
-	}
-	return br
-}
 
 // importCSV handles CSV format import (synchronous)
 func (i Item) importCSV(ctx context.Context, prj *project.Project, m *model.Model, s *schema.Schema, param interfaces.ImportItemsParam, res *ImportRes, operator *usecase.Operator) (interfaces.ImportItemsResponse, error) {
 	lr := &io.LimitedReader{R: param.Reader, N: interfaces.MaxImportFileSize + 1}
-	reader := csv.NewReader(skipBOM(lr))
+	reader := csv.NewReader(transform.NewReader(lr, unicode.UTF8BOM.NewDecoder()))
 
 	// Read header row
 	headers, err := reader.Read()
@@ -113,7 +100,7 @@ func (i Item) importCSV(ctx context.Context, prj *project.Project, m *model.Mode
 // importCSVWithProgress handles CSV format import with progress tracking (async)
 func (i Item) importCSVWithProgress(ctx context.Context, j *job.Job, prj *project.Project, m *model.Model, s *schema.Schema, param interfaces.ImportItemsParam, res *ImportRes, operator *usecase.Operator) (interfaces.ImportItemsResponse, error) {
 	lr := &io.LimitedReader{R: param.Reader, N: interfaces.MaxImportFileSize + 1}
-	reader := csv.NewReader(skipBOM(lr))
+	reader := csv.NewReader(transform.NewReader(lr, unicode.UTF8BOM.NewDecoder()))
 
 	// Read header row
 	headers, err := reader.Read()

--- a/server/internal/usecase/interactor/item_import_csv.go
+++ b/server/internal/usecase/interactor/item_import_csv.go
@@ -22,10 +22,14 @@ import (
 	"golang.org/x/text/transform"
 )
 
+func newCSVReader(r io.Reader) (*csv.Reader, *io.LimitedReader) {
+	lr := &io.LimitedReader{R: r, N: interfaces.MaxImportFileSize + 1}
+	return csv.NewReader(transform.NewReader(lr, unicode.BOMOverride(transform.Nop))), lr
+}
+
 // importCSV handles CSV format import (synchronous)
 func (i Item) importCSV(ctx context.Context, prj *project.Project, m *model.Model, s *schema.Schema, param interfaces.ImportItemsParam, res *ImportRes, operator *usecase.Operator) (interfaces.ImportItemsResponse, error) {
-	lr := &io.LimitedReader{R: param.Reader, N: interfaces.MaxImportFileSize + 1}
-	reader := csv.NewReader(transform.NewReader(lr, unicode.UTF8BOM.NewDecoder()))
+	reader, lr := newCSVReader(param.Reader)
 
 	// Read header row
 	headers, err := reader.Read()
@@ -99,8 +103,7 @@ func (i Item) importCSV(ctx context.Context, prj *project.Project, m *model.Mode
 
 // importCSVWithProgress handles CSV format import with progress tracking (async)
 func (i Item) importCSVWithProgress(ctx context.Context, j *job.Job, prj *project.Project, m *model.Model, s *schema.Schema, param interfaces.ImportItemsParam, res *ImportRes, operator *usecase.Operator) (interfaces.ImportItemsResponse, error) {
-	lr := &io.LimitedReader{R: param.Reader, N: interfaces.MaxImportFileSize + 1}
-	reader := csv.NewReader(transform.NewReader(lr, unicode.UTF8BOM.NewDecoder()))
+	reader, lr := newCSVReader(param.Reader)
 
 	// Read header row
 	headers, err := reader.Read()

--- a/server/internal/usecase/interactor/item_import_csv.go
+++ b/server/internal/usecase/interactor/item_import_csv.go
@@ -1,6 +1,7 @@
 package interactor
 
 import (
+	"bufio"
 	"context"
 	"encoding/csv"
 	"fmt"
@@ -20,10 +21,24 @@ import (
 	"github.com/reearth/reearthx/log"
 )
 
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// skipBOM returns a reader that skips a leading UTF-8 BOM if present.
+// Excel and some other tools emit a BOM when saving UTF-8 CSV files, which
+// would otherwise corrupt the first header name and cause its values to be dropped.
+func skipBOM(r io.Reader) io.Reader {
+	br := bufio.NewReader(r)
+	b, err := br.Peek(3)
+	if err == nil && len(b) == 3 && b[0] == utf8BOM[0] && b[1] == utf8BOM[1] && b[2] == utf8BOM[2] {
+		_, _ = br.Discard(3)
+	}
+	return br
+}
+
 // importCSV handles CSV format import (synchronous)
 func (i Item) importCSV(ctx context.Context, prj *project.Project, m *model.Model, s *schema.Schema, param interfaces.ImportItemsParam, res *ImportRes, operator *usecase.Operator) (interfaces.ImportItemsResponse, error) {
 	lr := &io.LimitedReader{R: param.Reader, N: interfaces.MaxImportFileSize + 1}
-	reader := csv.NewReader(lr)
+	reader := csv.NewReader(skipBOM(lr))
 
 	// Read header row
 	headers, err := reader.Read()
@@ -98,7 +113,7 @@ func (i Item) importCSV(ctx context.Context, prj *project.Project, m *model.Mode
 // importCSVWithProgress handles CSV format import with progress tracking (async)
 func (i Item) importCSVWithProgress(ctx context.Context, j *job.Job, prj *project.Project, m *model.Model, s *schema.Schema, param interfaces.ImportItemsParam, res *ImportRes, operator *usecase.Operator) (interfaces.ImportItemsResponse, error) {
 	lr := &io.LimitedReader{R: param.Reader, N: interfaces.MaxImportFileSize + 1}
-	reader := csv.NewReader(lr)
+	reader := csv.NewReader(skipBOM(lr))
 
 	// Read header row
 	headers, err := reader.Read()

--- a/server/internal/usecase/interactor/item_import_csv_test.go
+++ b/server/internal/usecase/interactor/item_import_csv_test.go
@@ -1,6 +1,8 @@
 package interactor
 
 import (
+	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -8,6 +10,32 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/value"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestSkipBOM(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"no BOM passes through unchanged", "name,value\nfoo,bar", "name,value\nfoo,bar"},
+		{"UTF-8 BOM is stripped", "\xEF\xBB\xBFname,value\nfoo,bar", "name,value\nfoo,bar"},
+		{"empty reader", "", ""},
+		{"BOM only", "\xEF\xBB\xBF", ""},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := skipBOM(strings.NewReader(tt.input))
+			got, err := io.ReadAll(r)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, string(got))
+		})
+	}
+}
 
 func TestParseCSVValue(t *testing.T) {
 	t.Parallel()

--- a/server/internal/usecase/interactor/item_import_csv_test.go
+++ b/server/internal/usecase/interactor/item_import_csv_test.go
@@ -1,8 +1,6 @@
 package interactor
 
 import (
-	"io"
-	"strings"
 	"testing"
 	"time"
 
@@ -10,32 +8,6 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/value"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestSkipBOM(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{"no BOM passes through unchanged", "name,value\nfoo,bar", "name,value\nfoo,bar"},
-		{"UTF-8 BOM is stripped", "\xEF\xBB\xBFname,value\nfoo,bar", "name,value\nfoo,bar"},
-		{"empty reader", "", ""},
-		{"BOM only", "\xEF\xBB\xBF", ""},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			r := skipBOM(strings.NewReader(tt.input))
-			got, err := io.ReadAll(r)
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expected, string(got))
-		})
-	}
-}
 
 func TestParseCSVValue(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
# Summary

CSV files saved with a UTF-8 BOM (e.g. exported from Excel or Japanese-locale tools) had their first column silently dropped during import
The BOM bytes (\xEF\xBB\xBF) were being prepended to the first header name, causing it to not match any schema field key
Fixed by using unicode.UTF8BOM.NewDecoder() from golang.org/x/text to strip the BOM before passing the reader to csv.NewReader, applied to both sync and async import paths

## Root cause

Go's encoding/csv does not strip BOMs automatically. When the first header was \xEF\xBB\xBFname instead of name, buildFieldMap failed to match it against the schema field, and all values in that column were dropped with no error.
