### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,25 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: reearth-cms
+  namespace: reearth
+  description: Tailor-made CMS platform for GIS data; data structure management for
+    non-developers
+  annotations:
+    github.com/project-slug: reearth/reearth-cms
+  links:
+  - url: https://github.com/reearth/reearth-cms
+    title: GitHub
+    icon: github
+  - url: https://reearth.io/product/cms
+    title: Website
+    icon: web
+  tags:
+  - typescript
+  - go
+  - cms
+  - gis
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/cms


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `reearth-cms` (namespace `reearth`)
- **Owner:** `reearth/cms`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.