### PR TITLE
fix: enforce access control on internal gRPC API for projects, assets, models, and items

### DIFF
--- a/server/e2e/gql_porject_test.go
+++ b/server/e2e/gql_porject_test.go
@@ -57,6 +57,53 @@ func createProject(e *httpexpect.Expect, wID, name, desc, alias string) (string,
 	return res.Path("$.data.createProject.project.id").Raw().(string), res
 }
 
+func getProject(e *httpexpect.Expect, pID string) (string, *httpexpect.Value) {
+	requestBody := GraphQLRequest{
+		Query: `query GetProject($projectId: ID!) {
+    	node(id: $projectId, type: PROJECT) {
+		id
+        ... on Project {
+            id
+            name
+            description
+            alias
+            accessibility {
+                visibility
+                publication {
+                    publicAssets
+                    publicModels
+                }
+                apiKeys {
+                    id
+                    name
+                    description
+                    key
+                    publication {
+                        publicAssets
+                        publicModels
+                    }
+                }
+            }
+        }
+    }
+}`,
+		Variables: map[string]any{
+			"projectId": pID,
+		},
+	}
+
+	res := e.POST("/api/graphql").
+		WithHeader("Origin", "https://example.com").
+		WithHeader("X-Reearth-Debug-User", uId1.String()).
+		WithHeader("Content-Type", "application/json").
+		WithJSON(requestBody).
+		Expect().
+		Status(http.StatusOK).
+		JSON()
+
+	return res.Path("$.data.node.id").Raw().(string), res
+}
+
 func updateProject(e *httpexpect.Expect, pID, name, desc, alias, visibility string, publicAssets bool, publicModels []string) (string, *httpexpect.Value) {
 	requestBody := GraphQLRequest{
 		Query: `mutation UpdateProject($projectId: ID!, $name: String!, $description: String!, $alias: String!, $visibility: ProjectVisibility!,  $publicAssets: Boolean!, $publicModels: [ID!]!) {

--- a/server/e2e/integration_item_test.go
+++ b/server/e2e/integration_item_test.go
@@ -57,9 +57,11 @@ var (
 	aid1    = id.NewAssetID()
 	aid2    = id.NewAssetID()
 	aid3    = id.NewAssetID() // no thread
+	aid4    = id.NewAssetID() // private project (pid2)
 	auuid1  = uuid.NewString()
 	auuid2  = uuid.NewString()
 	auuid3  = uuid.NewString()
+	auuid4  = uuid.NewString()
 	itmId1  = id.NewItemID()
 	itmId2  = id.NewItemID()
 	itmId3  = id.NewItemID()
@@ -515,6 +517,13 @@ func baseSeeder(ctx context.Context, r *repo.Container, g *gateway.Container) er
 		Size(1000).
 		UUID(auuid3).
 		MustBuild()
+	a4 := asset.New().ID(aid4).
+		Project(p2.ID()).
+		CreatedByUser(u.ID()).
+		FileName("ddd.jpg").
+		Size(1000).
+		UUID(auuid4).
+		MustBuild()
 
 	if err := r.Asset.Save(ctx, a1); err != nil {
 		return err
@@ -523,6 +532,9 @@ func baseSeeder(ctx context.Context, r *repo.Container, g *gateway.Container) er
 		return err
 	}
 	if err := r.Asset.Save(ctx, a3); err != nil {
+		return err
+	}
+	if err := r.Asset.Save(ctx, a4); err != nil {
 		return err
 	}
 	if err := r.AssetFile.Save(ctx, a1.ID(), f1); err != nil {

--- a/server/e2e/internal_asset_test.go
+++ b/server/e2e/internal_asset_test.go
@@ -1,0 +1,248 @@
+package e2e
+
+import (
+	"testing"
+
+	pb "github.com/reearth/reearth-cms/server/internal/adapter/internalapi/schemas/internalapi/v1"
+	"github.com/reearth/reearth-cms/server/internal/app"
+	"github.com/reearth/reearth-cms/server/pkg/id"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// GRPC List Assets in Project
+func TestInternalListAssetsInProjectAPI(t *testing.T) {
+	StartServer(t, &app.Config{
+		InternalApi: app.InternalApiConfig{
+			Active: true,
+			Port:   "52050",
+			Token:  "TestToken",
+		},
+	}, true, baseSeeder)
+
+	clientConn, err := grpc.NewClient("localhost:52050",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithMaxCallAttempts(5))
+	assert.NoError(t, err)
+
+	client := pb.NewReEarthCMSClient(clientConn)
+
+	tests := []struct {
+		name            string
+		user            string
+		request         *pb.ListAssetsRequest
+		wantErrCode     codes.Code
+		wantErrContains string
+		wantTotal       int64
+		verify          func(t *testing.T, resp *pb.ListAssetsResponse)
+	}{
+		// Error cases
+		{
+			name:            "empty project_id returns invalid argument",
+			user:            uId.String(),
+			request:         &pb.ListAssetsRequest{ProjectId: ""},
+			wantErrCode:     codes.InvalidArgument,
+			wantErrContains: "project_id is required",
+		},
+		{
+			name:            "non-existent project returns not found",
+			user:            uId.String(),
+			request:         &pb.ListAssetsRequest{ProjectId: id.NewProjectID().String()},
+			wantErrCode:     codes.Unknown,
+			wantErrContains: "not found",
+		},
+		{
+			name:            "non-member user cannot list assets from private project",
+			user:            uId_2.String(),
+			request:         &pb.ListAssetsRequest{ProjectId: pid2.String()},
+			wantErrCode:     codes.NotFound,
+			wantErrContains: "not found",
+		},
+		{
+			name:            "no user cannot list assets from private project",
+			user:            "",
+			request:         &pb.ListAssetsRequest{ProjectId: pid2.String()},
+			wantErrCode:     codes.NotFound,
+			wantErrContains: "not found",
+		},
+		// Success cases
+		{
+			name:      "workspace member can list assets from public project",
+			user:      uId.String(),
+			request:   &pb.ListAssetsRequest{ProjectId: pid.String()},
+			wantTotal: 3,
+			verify: func(t *testing.T, resp *pb.ListAssetsResponse) {
+				a := resp.Assets[0]
+				assert.Equal(t, aid1.String(), a.Id)
+				assert.Equal(t, "aaa.jpg", a.Filename)
+				assert.Nil(t, a.PreviewType)
+				assert.Equal(t, uint64(1000), a.Size)
+				assert.Nil(t, a.ArchiveExtractionStatus)
+				assert.Equal(t, pid.String(), a.ProjectId)
+				assert.Equal(t, false, a.Public)
+			},
+		},
+		{
+			name:      "workspace member can list assets from private project",
+			user:      uId.String(),
+			request:   &pb.ListAssetsRequest{ProjectId: pid2.String()},
+			wantTotal: 1,
+		},
+		{
+			name:      "non-member user can list assets from public project",
+			user:      uId_2.String(),
+			request:   &pb.ListAssetsRequest{ProjectId: pid.String()},
+			wantTotal: 3,
+		},
+		{
+			name:      "no user can list assets from public project",
+			user:      "",
+			request:   &pb.ListAssetsRequest{ProjectId: pid.String()},
+			wantTotal: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			md := metadata.New(map[string]string{
+				"Authorization": "Bearer TestToken",
+				"User-Id":       tt.user,
+			})
+			mdCtx := metadata.NewOutgoingContext(t.Context(), md)
+
+			l, err := client.ListAssets(mdCtx, tt.request)
+			if tt.wantErrCode != codes.OK {
+				assert.Error(t, err)
+				assert.Nil(t, l)
+				st, ok := status.FromError(err)
+				assert.True(t, ok, "error should be a gRPC status error")
+				assert.Equal(t, tt.wantErrCode, st.Code())
+				if tt.wantErrContains != "" {
+					assert.Contains(t, st.Message(), tt.wantErrContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTotal, l.TotalCount)
+			assert.Len(t, l.Assets, int(tt.wantTotal))
+			if tt.verify != nil {
+				tt.verify(t, l)
+			}
+		})
+	}
+}
+
+// GRPC Get Asset
+func TestInternalGetAssetAPI(t *testing.T) {
+	StartServer(t, &app.Config{
+		InternalApi: app.InternalApiConfig{
+			Active: true,
+			Port:   "52050",
+			Token:  "TestToken",
+		},
+	}, true, baseSeeder)
+
+	clientConn, err := grpc.NewClient("localhost:52050",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithMaxCallAttempts(5))
+	assert.NoError(t, err)
+
+	client := pb.NewReEarthCMSClient(clientConn)
+
+	tests := []struct {
+		name            string
+		user            string
+		assetId         string
+		wantErrCode     codes.Code
+		wantErrContains string
+		verify          func(t *testing.T, a *pb.Asset)
+	}{
+		// Error cases
+		{
+			name:            "non-existent asset returns not found",
+			user:            uId.String(),
+			assetId:         id.NewAssetID().String(),
+			wantErrCode:     codes.Unknown,
+			wantErrContains: "not found",
+		},
+		{
+			name:            "non-member user cannot get asset from private project",
+			user:            uId_2.String(),
+			assetId:         aid4.String(),
+			wantErrCode:     codes.NotFound,
+			wantErrContains: "not found",
+		},
+		{
+			name:            "no user cannot get asset from private project",
+			user:            "",
+			assetId:         aid4.String(),
+			wantErrCode:     codes.NotFound,
+			wantErrContains: "not found",
+		},
+		// Success cases
+		{
+			name:    "workspace member can get asset",
+			user:    uId.String(),
+			assetId: aid1.String(),
+			verify: func(t *testing.T, a *pb.Asset) {
+				assert.Equal(t, aid1.String(), a.Id)
+				assert.Equal(t, "aaa.jpg", a.Filename)
+				assert.Nil(t, a.PreviewType)
+				assert.Equal(t, uint64(1000), a.Size)
+				assert.Nil(t, a.ArchiveExtractionStatus)
+				assert.Equal(t, pid.String(), a.ProjectId)
+				assert.Equal(t, false, a.Public)
+			},
+		},
+		{
+			name:    "non-member user can get asset from public project",
+			user:    uId_2.String(),
+			assetId: aid1.String(),
+		},
+		{
+			name:    "no user can get asset from public project",
+			user:    "",
+			assetId: aid1.String(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			md := metadata.New(map[string]string{
+				"Authorization": "Bearer TestToken",
+				"User-Id":       tt.user,
+			})
+			mdCtx := metadata.NewOutgoingContext(t.Context(), md)
+
+			resp, err := client.GetAsset(mdCtx, &pb.AssetRequest{AssetId: tt.assetId})
+			if tt.wantErrCode != codes.OK {
+				assert.Error(t, err)
+				assert.Nil(t, resp)
+				st, ok := status.FromError(err)
+				assert.True(t, ok, "error should be a gRPC status error")
+				assert.Equal(t, tt.wantErrCode, st.Code())
+				if tt.wantErrContains != "" {
+					assert.Contains(t, st.Message(), tt.wantErrContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp.Asset)
+			assert.Equal(t, tt.assetId, resp.Asset.Id)
+			if tt.verify != nil {
+				tt.verify(t, resp.Asset)
+			}
+		})
+	}
+}

--- a/server/e2e/internal_model_test.go
+++ b/server/e2e/internal_model_test.go
@@ -1,0 +1,375 @@
+package e2e
+
+import (
+	"testing"
+
+	pb "github.com/reearth/reearth-cms/server/internal/adapter/internalapi/schemas/internalapi/v1"
+	"github.com/reearth/reearth-cms/server/internal/app"
+	"github.com/reearth/reearth-cms/server/pkg/id"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// GRPC List Models in Project
+func TestInternalListModelsInProjectAPI(t *testing.T) {
+	StartServer(t, &app.Config{
+		InternalApi: app.InternalApiConfig{
+			Active: true,
+			Port:   "52050",
+			Token:  "TestToken",
+		},
+	}, true, baseSeeder)
+
+	clientConn, err := grpc.NewClient("localhost:52050",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithMaxCallAttempts(5))
+	assert.NoError(t, err)
+
+	client := pb.NewReEarthCMSClient(clientConn)
+
+	tests := []struct {
+		name            string
+		user            string
+		projectId       string
+		wantErrCode     codes.Code
+		wantErrContains string
+		wantTotal       int64
+	}{
+		// Error cases
+		{
+			name:            "empty project_id returns invalid argument",
+			user:            uId.String(),
+			projectId:       "",
+			wantErrCode:     codes.InvalidArgument,
+			wantErrContains: "project_id is required",
+		},
+		{
+			name:            "non-existent project returns not found",
+			user:            uId.String(),
+			projectId:       id.NewProjectID().String(),
+			wantErrCode:     codes.Unknown,
+			wantErrContains: "not found",
+		},
+		{
+			name:            "non-member user cannot list models from private project",
+			user:            uId_2.String(),
+			projectId:       pid2.String(),
+			wantErrCode:     codes.NotFound,
+			wantErrContains: "not found",
+		},
+		// Success cases
+		{
+			name:      "workspace member can list models from public project",
+			user:      uId.String(),
+			projectId: pid.String(),
+			wantTotal: 7,
+		},
+		{
+			name:      "workspace member can list models from private project",
+			user:      uId.String(),
+			projectId: pid2.String(),
+			wantTotal: 1,
+		},
+		{
+			name:      "non-member user can list models from public project",
+			user:      uId_2.String(),
+			projectId: pid.String(),
+			wantTotal: 7,
+		},
+		{
+			name:      "no user can list models from public project",
+			user:      "",
+			projectId: pid.String(),
+			wantTotal: 7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			md := metadata.New(map[string]string{
+				"Authorization": "Bearer TestToken",
+				"User-Id":       tt.user,
+			})
+			mdCtx := metadata.NewOutgoingContext(t.Context(), md)
+
+			l, err := client.ListModels(mdCtx, &pb.ListModelsRequest{ProjectId: tt.projectId})
+			if tt.wantErrCode != codes.OK {
+				assert.Error(t, err)
+				assert.Nil(t, l)
+				st, ok := status.FromError(err)
+				assert.True(t, ok, "error should be a gRPC status error")
+				assert.Equal(t, tt.wantErrCode, st.Code())
+				if tt.wantErrContains != "" {
+					assert.Contains(t, st.Message(), tt.wantErrContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTotal, l.TotalCount)
+			assert.Len(t, l.Models, int(tt.wantTotal))
+		})
+	}
+}
+
+// GRPC Get Model
+func TestInternalGetModelAPI(t *testing.T) {
+	e := StartServer(t, &app.Config{
+		InternalApi: app.InternalApiConfig{
+			Active: true,
+			Port:   "52050",
+			Token:  "TestToken",
+		},
+	}, true, baseSeeder)
+	clientConn, err := grpc.NewClient("localhost:52050",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithMaxCallAttempts(5))
+	require.NoError(t, err)
+
+	client := pb.NewReEarthCMSClient(clientConn)
+
+	nonMemberUserID := id.NewUserID().String()
+
+	tests := []struct {
+		name    string
+		userID  string
+		req     *pb.ModelRequest
+		wantErr error
+		wantID  string
+	}{
+		{
+			name:   "get model by IDs",
+			userID: uId.String(),
+			req:    &pb.ModelRequest{WorkspaceIdOrAlias: wId0.String(), ProjectIdOrAlias: pid.String(), ModelIdOrAlias: mId1.String()},
+			wantID: mId1.String(),
+		},
+		{
+			name:   "get model by aliases",
+			userID: uId.String(),
+			req:    &pb.ModelRequest{WorkspaceIdOrAlias: wId0.String(), ProjectIdOrAlias: palias, ModelIdOrAlias: ikey1.String()},
+			wantID: mId1.String(),
+		},
+		{
+			name:   "get model from private project owned by the user",
+			userID: uId.String(),
+			req:    &pb.ModelRequest{WorkspaceIdOrAlias: wId0.String(), ProjectIdOrAlias: palias2, ModelIdOrAlias: mId6.String()},
+			wantID: mId6.String(),
+		},
+		{
+			name:   "get model from public project without logged in user",
+			userID: "",
+			req:    &pb.ModelRequest{WorkspaceIdOrAlias: wId0.String(), ProjectIdOrAlias: palias, ModelIdOrAlias: ikey1.String()},
+			wantID: mId1.String(),
+		},
+		{
+			name:   "get model from public project with non-member user",
+			userID: uId_2.String(),
+			req:    &pb.ModelRequest{WorkspaceIdOrAlias: wId0.String(), ProjectIdOrAlias: palias, ModelIdOrAlias: ikey1.String()},
+			wantID: mId1.String(),
+		},
+		{
+			name:    "get model from private project with non-member user",
+			userID:  nonMemberUserID,
+			req:     &pb.ModelRequest{WorkspaceIdOrAlias: wId0.String(), ProjectIdOrAlias: palias2, ModelIdOrAlias: mId6.String()},
+			wantErr: status.Error(codes.NotFound, "not found"),
+		},
+		{
+			name:    "get model from private project without logged in user",
+			userID:  "",
+			req:     &pb.ModelRequest{WorkspaceIdOrAlias: wId0.String(), ProjectIdOrAlias: palias2, ModelIdOrAlias: mId6.String()},
+			wantErr: status.Error(codes.NotFound, "not found"),
+		},
+		{
+			name:    "non-existent model returns not found",
+			userID:  uId.String(),
+			req:     &pb.ModelRequest{WorkspaceIdOrAlias: wId0.String(), ProjectIdOrAlias: palias, ModelIdOrAlias: id.NewModelID().String()},
+			wantErr: status.Error(codes.Unknown, "not found"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md := metadata.New(map[string]string{
+				"Authorization": "Bearer TestToken",
+				"User-Id":       tt.userID,
+			})
+			mdCtx := metadata.NewOutgoingContext(t.Context(), md)
+
+			m, err := client.GetModel(mdCtx, tt.req)
+			if tt.wantErr != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.wantErr, err)
+				assert.Nil(t, m)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantID, m.Model.Id)
+
+			_, _, res := getModel(e, tt.wantID)
+			assert.Equal(t, res.Path("$.data.node.name").Raw().(string), m.Model.Name)
+			assert.Equal(t, res.Path("$.data.node.key").Raw().(string), m.Model.Key)
+			assert.Equal(t, res.Path("$.data.node.description").Raw().(string), m.Model.Description)
+			assert.Equal(t, res.Path("$.data.node.schema.id").Raw().(string), m.Model.Schema.SchemaId)
+		})
+	}
+}
+
+// GRPC List Items in Model
+func TestInternalListItemsInModelAPI(t *testing.T) {
+	e := StartServer(t, &app.Config{
+		InternalApi: app.InternalApiConfig{
+			Active: true,
+			Port:   "52050",
+			Token:  "TestToken",
+		},
+	}, true, baseSeeder)
+
+	clientConn, err := grpc.NewClient("localhost:52050",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithMaxCallAttempts(5))
+	assert.NoError(t, err)
+
+	client := pb.NewReEarthCMSClient(clientConn)
+
+	tests := []struct {
+		name            string
+		setup           func()
+		user            string
+		request         *pb.ListItemsRequest
+		wantErrCode     codes.Code
+		wantErrContains string
+		wantTotal       int64
+		wantItemIds     []string
+		verify          func(t *testing.T, items []*pb.Item)
+	}{
+		// Error cases
+		{
+			name:            "empty model_id returns invalid argument",
+			user:            uId.String(),
+			request:         &pb.ListItemsRequest{ProjectId: pid.String(), ModelId: ""},
+			wantErrCode:     codes.InvalidArgument,
+			wantErrContains: "model_id is required",
+		},
+		{
+			name:            "non-existent model returns not found",
+			user:            uId.String(),
+			request:         &pb.ListItemsRequest{ProjectId: pid.String(), ModelId: id.NewModelID().String()},
+			wantErrCode:     codes.Unknown,
+			wantErrContains: "not found",
+		},
+		// Sequential success cases — each setup builds on the previous state
+		{
+			name:      "model with no published items returns empty list",
+			user:      uId.String(),
+			request:   &pb.ListItemsRequest{ProjectId: pid.String(), ModelId: mId1.String()},
+			wantTotal: 0,
+		},
+		{
+			name: "model returns item after its request is approved",
+			setup: func() {
+				res := createRequest2(e, pid.String(), "test", lo.ToPtr("test"), lo.ToPtr("WAITING"), []string{uId.String()}, []any{map[string]any{"itemId": itmId1.String(), "version": "latest"}})
+				approveRequest2(e, res.Path("$.data.createRequest.request.id").String().Raw())
+			},
+			user:        uId.String(),
+			request:     &pb.ListItemsRequest{ProjectId: pid.String(), ModelId: mId1.String()},
+			wantTotal:   1,
+			wantItemIds: []string{itmId1.String()},
+		},
+		{
+			name:        "non-member user can list published items from public project model",
+			user:        uId_2.String(),
+			request:     &pb.ListItemsRequest{ProjectId: pid.String(), ModelId: mId1.String()},
+			wantTotal:   1,
+			wantItemIds: []string{itmId1.String()},
+		},
+		{
+			name:        "no user can list published items from public project model",
+			user:        "",
+			request:     &pb.ListItemsRequest{ProjectId: pid.String(), ModelId: mId1.String()},
+			wantTotal:   1,
+			wantItemIds: []string{itmId1.String()},
+		},
+		{
+			name:            "non-member user cannot list items from private project model",
+			user:            uId_2.String(),
+			request:         &pb.ListItemsRequest{ProjectId: pid2.String(), ModelId: mId6.String()},
+			wantErrCode:     codes.NotFound,
+			wantErrContains: "not found",
+		},
+		{
+			name:            "no user cannot list items from private project model",
+			user:            "",
+			request:         &pb.ListItemsRequest{ProjectId: pid2.String(), ModelId: mId6.String()},
+			wantErrCode:     codes.NotFound,
+			wantErrContains: "not found",
+		},
+		{
+			name: "model with number and integer fields returns correct field values",
+			setup: func() {
+				res := createRequest2(e, pid.String(), "test", lo.ToPtr("test"), lo.ToPtr("WAITING"), []string{uId.String()}, []any{map[string]any{"itemId": itmId6.String(), "version": "latest"}})
+				approveRequest2(e, res.Path("$.data.createRequest.request.id").String().Raw())
+			},
+			user:        uId.String(),
+			request:     &pb.ListItemsRequest{ProjectId: pid.String(), ModelId: mId5.String()},
+			wantTotal:   1,
+			wantItemIds: []string{itmId6.String()},
+			verify: func(t *testing.T, items []*pb.Item) {
+				f, err := convertAnyToFloat32(items[0].Fields["number-key"])
+				assert.NoError(t, err)
+				assert.Equal(t, float32(21.2), f)
+
+				i, err := convertAnyToInt64(items[0].Fields["integer-key"])
+				assert.NoError(t, err)
+				assert.Equal(t, int64(123), i)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup()
+			}
+
+			md := metadata.New(map[string]string{
+				"Authorization": "Bearer TestToken",
+				"User-Id":       tt.user,
+			})
+			mdCtx := metadata.NewOutgoingContext(t.Context(), md)
+
+			l, err := client.ListItems(mdCtx, tt.request)
+			if tt.wantErrCode != codes.OK {
+				assert.Error(t, err)
+				assert.Nil(t, l)
+				st, ok := status.FromError(err)
+				assert.True(t, ok, "error should be a gRPC status error")
+				assert.Equal(t, tt.wantErrCode, st.Code())
+				if tt.wantErrContains != "" {
+					assert.Contains(t, st.Message(), tt.wantErrContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTotal, l.TotalCount)
+			assert.Len(t, l.Items, int(tt.wantTotal))
+			for i, wantId := range tt.wantItemIds {
+				if i < len(l.Items) {
+					assert.Equal(t, wantId, l.Items[i].Id)
+				}
+			}
+
+			if tt.verify != nil {
+				tt.verify(t, l.Items)
+			}
+		})
+	}
+}

--- a/server/e2e/internal_project_test.go
+++ b/server/e2e/internal_project_test.go
@@ -25,7 +25,7 @@ import (
 
 // GRPC List Projects
 func TestInternalListProjectsAPI(t *testing.T) {
-	StartServer(t, &app.Config{
+	e := StartServer(t, &app.Config{
 		InternalApi: app.InternalApiConfig{
 			Active: true,
 			Port:   "52050",
@@ -40,185 +40,140 @@ func TestInternalListProjectsAPI(t *testing.T) {
 
 	client := pb.NewReEarthCMSClient(clientConn)
 
-	md := metadata.New(map[string]string{
-		"Authorization": "Bearer TestToken",
-		"User-Id":       uId.String(),
-	})
-	mdCtx := metadata.NewOutgoingContext(t.Context(), md)
+	tests := []struct {
+		name         string
+		userId       string
+		request      *pb.ListProjectsRequest
+		wantTotal    int64
+		wantProjects project.IDList
+		wantErr      error
+	}{
+		{
+			name:         "without any parameters should return only public projects",
+			userId:       uId.String(),
+			request:      &pb.ListProjectsRequest{},
+			wantTotal:    1,
+			wantProjects: project.IDList{pid},
+		},
+		{
+			name:         "for the workspace should return all projects in the workspace",
+			userId:       uId.String(),
+			request:      &pb.ListProjectsRequest{WorkspaceIds: []string{wId0.String()}},
+			wantTotal:    2,
+			wantProjects: project.IDList{pid, pid2},
+		},
+		{
+			name:         "for the workspace with PublicOnly = true should return only public projects in the workspace",
+			userId:       uId.String(),
+			request:      &pb.ListProjectsRequest{WorkspaceIds: []string{wId0.String()}, PublicOnly: true},
+			wantTotal:    1,
+			wantProjects: project.IDList{pid},
+		},
+		{
+			name:         "with keyword (exact project id)",
+			userId:       uId.String(),
+			request:      &pb.ListProjectsRequest{Keyword: pid.StringRef()},
+			wantTotal:    1,
+			wantProjects: project.IDList{pid},
+		},
+		{
+			name:         "with keyword (alias)",
+			userId:       uId.String(),
+			request:      &pb.ListProjectsRequest{Keyword: &palias},
+			wantTotal:    1,
+			wantProjects: project.IDList{pid},
+		},
+		{
+			name:         "with keyword (topics)",
+			userId:       uId.String(),
+			request:      &pb.ListProjectsRequest{Keyword: lo.ToPtr("topic1")},
+			wantTotal:    1,
+			wantProjects: project.IDList{pid},
+		},
+		{
+			name:         "with topics",
+			userId:       uId.String(),
+			request:      &pb.ListProjectsRequest{Topics: []string{"topic1"}},
+			wantTotal:    1,
+			wantProjects: project.IDList{pid},
+		},
+		{
+			name:         "with topic (private project)",
+			userId:       uId.String(),
+			request:      &pb.ListProjectsRequest{WorkspaceIds: []string{wId0.String()}, PublicOnly: false, Topics: []string{"topic2"}},
+			wantTotal:    1,
+			wantProjects: project.IDList{pid2},
+		},
+		{
+			name:         "with multiple topics",
+			userId:       uId.String(),
+			request:      &pb.ListProjectsRequest{WorkspaceIds: []string{wId0.String()}, PublicOnly: false, Topics: []string{"topic1", "topic3"}},
+			wantTotal:    1,
+			wantProjects: project.IDList{pid},
+		},
+		{
+			name:         "with non-existence topics",
+			userId:       uId.String(),
+			request:      &pb.ListProjectsRequest{Topics: []string{"non-existence-topic"}},
+			wantTotal:    0,
+			wantProjects: project.IDList{},
+		},
+		{
+			name:         "for workspace with non-member user should return only public projects",
+			userId:       uId_2.String(),
+			request:      &pb.ListProjectsRequest{WorkspaceIds: []string{wId0.String()}},
+			wantTotal:    1,
+			wantProjects: project.IDList{pid},
+		},
+		{
+			name:    "for workspace with member & non-member user should return not supported error",
+			userId:  uId_2.String(),
+			request: &pb.ListProjectsRequest{WorkspaceIds: []string{wId0.String(), wId1.String()}},
+			wantErr: status.Error(codes.InvalidArgument, "mixed workspaces"),
+		},
+		{
+			name:         "for workspace with non-existing user should return only public projects",
+			userId:       id.NewUserID().String(),
+			request:      &pb.ListProjectsRequest{WorkspaceIds: []string{wId0.String()}},
+			wantTotal:    1,
+			wantProjects: project.IDList{pid},
+		},
+	}
 
-	t.Run("List Projects without any parameters should return only public projects", func(t *testing.T) {
-		l, err := client.ListProjects(mdCtx, &pb.ListProjectsRequest{})
-		assert.NoError(t, err)
-		assert.Equal(t, int64(1), l.TotalCount)
-		assert.Equal(t, 1, len(l.Projects))
+	for _, tt := range tests {
+		t.Run("List Projects "+tt.name, func(t *testing.T) {
+			md := metadata.New(map[string]string{
+				"Authorization": "Bearer TestToken",
+				"User-Id":       tt.userId,
+			})
+			mdCtx := metadata.NewOutgoingContext(t.Context(), md)
 
-		p1 := l.Projects[0]
-		assert.Equal(t, pid.String(), p1.Id)
-		assert.Equal(t, "p1", p1.Name)
-		assert.Equal(t, palias, p1.Alias)
-		assert.Equal(t, wId0.String(), p1.WorkspaceId)
-		assert.Equal(t, lo.ToPtr("p1 desc"), p1.Description)
-	})
+			l, err := client.ListProjects(mdCtx, tt.request)
+			if tt.wantErr != nil {
+				assert.Nil(t, l)
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantTotal, l.TotalCount)
+			assert.Len(t, l.Projects, len(tt.wantProjects))
 
-	t.Run("List Projects for the workspace should return all projects in the workspace", func(t *testing.T) {
-		l, err := client.ListProjects(mdCtx, &pb.ListProjectsRequest{WorkspaceIds: []string{wId0.String()}})
-		assert.NoError(t, err)
+			for i, want := range tt.wantProjects {
+				if i >= len(l.Projects) {
+					break
+				}
+				gotProject := l.Projects[i]
+				_, wantProject := getProject(e, want.String())
 
-		assert.Equal(t, int64(2), l.TotalCount)
-		assert.Equal(t, 2, len(l.Projects))
+				assert.Equal(t, wantProject.Path("$.data.node.name").Raw().(string), gotProject.GetName())
+				assert.Equal(t, wantProject.Path("$.data.node.alias").Raw().(string), gotProject.GetAlias())
+				//assert.Equal(t, wantProject.Path("$.data.workspace.id"), gotProject.WorkspaceId)
+				assert.Equal(t, wantProject.Path("$.data.node.description").Raw().(string), gotProject.GetDescription())
 
-		p1 := l.Projects[0]
-		assert.Equal(t, pid.String(), p1.Id)
-		assert.Equal(t, "p1", p1.Name)
-		assert.Equal(t, palias, p1.Alias)
-		assert.Equal(t, wId0.String(), p1.WorkspaceId)
-		assert.Equal(t, lo.ToPtr("p1 desc"), p1.Description)
-
-		p2 := l.Projects[1]
-		assert.Equal(t, pid2.String(), p2.Id)
-		assert.Equal(t, "p2", p2.Name)
-		assert.Equal(t, palias2, p2.Alias)
-		assert.Equal(t, wId0.String(), p2.WorkspaceId)
-		assert.Equal(t, lo.ToPtr("p2 desc"), p2.Description)
-	})
-
-	t.Run("List Projects for the workspace with PublicOnly = true should return only public projects in the workspace", func(t *testing.T) {
-		l, err := client.ListProjects(mdCtx, &pb.ListProjectsRequest{WorkspaceIds: []string{wId0.String()}, PublicOnly: true})
-		assert.NoError(t, err)
-
-		assert.Equal(t, int64(1), l.TotalCount)
-		assert.Equal(t, 1, len(l.Projects))
-
-		p1 := l.Projects[0]
-		assert.Equal(t, pid.String(), p1.Id)
-		assert.Equal(t, "p1", p1.Name)
-		assert.Equal(t, palias, p1.Alias)
-		assert.Equal(t, wId0.String(), p1.WorkspaceId)
-		assert.Equal(t, lo.ToPtr("p1 desc"), p1.Description)
-	})
-
-	t.Run("List Projects with keyword (exact project id)", func(t *testing.T) {
-		l, err := client.ListProjects(mdCtx, &pb.ListProjectsRequest{
-			Keyword: pid.StringRef(),
+				// TODO: assert ptoject.topics
+			}
 		})
-		assert.NoError(t, err)
-
-		assert.Equal(t, int64(1), l.TotalCount)
-		assert.Equal(t, 1, len(l.Projects))
-
-		p1 := l.Projects[0]
-		assert.Equal(t, pid.String(), p1.Id)
-		assert.Equal(t, "p1", p1.Name)
-		assert.Equal(t, palias, p1.Alias)
-		assert.Equal(t, wId0.String(), p1.WorkspaceId)
-		assert.Equal(t, lo.ToPtr("p1 desc"), p1.Description)
-	})
-
-	t.Run("List Projects with keyword (alias)", func(t *testing.T) {
-		l, err := client.ListProjects(mdCtx, &pb.ListProjectsRequest{
-			Keyword: &palias,
-		})
-		assert.NoError(t, err)
-
-		assert.Equal(t, int64(1), l.TotalCount)
-		assert.Equal(t, 1, len(l.Projects))
-
-		p1 := l.Projects[0]
-		assert.Equal(t, pid.String(), p1.Id)
-		assert.Equal(t, "p1", p1.Name)
-		assert.Equal(t, palias, p1.Alias)
-		assert.Equal(t, wId0.String(), p1.WorkspaceId)
-		assert.Equal(t, lo.ToPtr("p1 desc"), p1.Description)
-	})
-
-	t.Run("List Projects with keyword (topics)", func(t *testing.T) {
-		l, err := client.ListProjects(mdCtx, &pb.ListProjectsRequest{
-			Keyword: lo.ToPtr("topic1"),
-		})
-		assert.NoError(t, err)
-
-		assert.Equal(t, int64(1), l.TotalCount)
-		assert.Equal(t, 1, len(l.Projects))
-
-		p1 := l.Projects[0]
-		assert.Equal(t, pid.String(), p1.Id)
-		assert.Equal(t, "p1", p1.Name)
-		assert.Equal(t, palias, p1.Alias)
-		assert.Equal(t, wId0.String(), p1.WorkspaceId)
-		assert.Equal(t, lo.ToPtr("p1 desc"), p1.Description)
-	})
-
-	t.Run("List Projects with topics", func(t *testing.T) {
-		l, err := client.ListProjects(mdCtx, &pb.ListProjectsRequest{
-			Topics: []string{"topic1"},
-		})
-		assert.NoError(t, err)
-
-		assert.Equal(t, int64(1), l.TotalCount)
-		assert.Equal(t, 1, len(l.Projects))
-
-		p1 := l.Projects[0]
-		assert.Equal(t, pid.String(), p1.Id)
-		assert.Equal(t, "p1", p1.Name)
-		assert.Equal(t, palias, p1.Alias)
-		assert.Equal(t, wId0.String(), p1.WorkspaceId)
-		assert.Equal(t, lo.ToPtr("p1 desc"), p1.Description)
-		assert.NotNil(t, p1.Topics)
-		assert.Equal(t, "topic1", p1.Topics[0])
-	})
-
-	t.Run("List Projects with topic (private project)", func(t *testing.T) {
-		l, err := client.ListProjects(mdCtx, &pb.ListProjectsRequest{
-			WorkspaceIds: []string{wId0.String()},
-			PublicOnly:   false,
-			Topics:       []string{"topic2"},
-		})
-		assert.NoError(t, err)
-
-		assert.Equal(t, int64(1), l.TotalCount)
-		assert.Equal(t, 1, len(l.Projects))
-
-		assert.Equal(t, pid2.String(), l.Projects[0].Id)
-	})
-
-	t.Run("List Projects with multiple topics", func(t *testing.T) {
-		l, err := client.ListProjects(mdCtx, &pb.ListProjectsRequest{
-			WorkspaceIds: []string{wId0.String()},
-			PublicOnly:   false,
-			Topics:       []string{"topic1", "topic3"},
-		})
-		assert.NoError(t, err)
-
-		assert.Equal(t, int64(1), l.TotalCount)
-		assert.Equal(t, 1, len(l.Projects))
-
-		assert.Equal(t, pid.String(), l.Projects[0].Id)
-	})
-
-	t.Run("List Projects with non-existence topics", func(t *testing.T) {
-		l, err := client.ListProjects(mdCtx, &pb.ListProjectsRequest{
-			Topics: []string{"non-existence-topic"},
-		})
-		assert.NoError(t, err)
-
-		assert.Equal(t, int64(0), l.TotalCount)
-		assert.Equal(t, 0, len(l.Projects))
-	})
-
-	t.Run("List Projects for workspace with non-existing user should return only public projects", func(t *testing.T) {
-		mdNonMember := metadata.New(map[string]string{
-			"Authorization": "Bearer TestToken",
-			"User-Id":       id.NewUserID().String(),
-		})
-		mdCtxNonMember := metadata.NewOutgoingContext(t.Context(), mdNonMember)
-
-		l, err := client.ListProjects(mdCtxNonMember, &pb.ListProjectsRequest{WorkspaceIds: []string{wId0.String()}})
-		assert.NoError(t, err)
-
-		assert.Equal(t, int64(1), l.TotalCount)
-		assert.Equal(t, 1, len(l.Projects))
-		assert.Equal(t, pid.String(), l.Projects[0].Id)
-	})
+	}
 }
 
 // GRPC Get Project
@@ -373,52 +328,105 @@ func TestInternalCreateProjectAPI(t *testing.T) {
 	assert.NoError(t, err)
 
 	client := pb.NewReEarthCMSClient(clientConn)
-	md := metadata.New(map[string]string{
-		"Authorization": "Bearer TestToken",
-		"User-Id":       uId.String(),
-	})
 
-	mdCtx := metadata.NewOutgoingContext(t.Context(), md)
-	_, err = client.CreateProject(mdCtx, &pb.CreateProjectRequest{
-		Name:        "New Project",
-		Alias:       "new_project",
-		Description: lo.ToPtr("This is a new project"),
-		WorkspaceId: wId0.String(),
-	})
-	assert.NoError(t, err)
+	tests := []struct {
+		name       string
+		user       string
+		request    *pb.CreateProjectRequest
+		wantName   string
+		wantAlias  string
+		wantDesc   *string
+		wantTopics []string
+		wantError  error
+	}{
+		{
+			name: "basic project without topics",
+			user: uId.String(),
+			request: &pb.CreateProjectRequest{
+				Name:        "New Project",
+				Alias:       "new_project",
+				Description: lo.ToPtr("This is a new project"),
+				WorkspaceId: wId0.String(),
+			},
+			wantName:  "New Project",
+			wantAlias: "new_project",
+			wantDesc:  lo.ToPtr("This is a new project"),
+		},
+		{
+			name: "project with topics deduplicates and removes empty values",
+			user: uId.String(),
+			request: &pb.CreateProjectRequest{
+				Name:        "Project With Topics",
+				Alias:       "project_with_topics",
+				Description: lo.ToPtr("Project with topics"),
+				Topics:      &pb.Topics{Values: []string{"topic1", "topic2", "", "topic1", "topic3", "", "topic2"}},
+				WorkspaceId: wId0.String(),
+			},
+			wantName:   "Project With Topics",
+			wantAlias:  "project_with_topics",
+			wantDesc:   lo.ToPtr("Project with topics"),
+			wantTopics: []string{"topic1", "topic2", "topic3"},
+		},
+		{
+			name: "create project on a workspace without user",
+			user: "",
+			request: &pb.CreateProjectRequest{
+				Name:        "Project 1",
+				Alias:       "project_1",
+				Description: lo.ToPtr("Project"),
+				WorkspaceId: wId0.String(),
+			},
+			wantError: status.Error(codes.PermissionDenied, "no permission to create project in this workspace"),
+		},
+		{
+			name: "create project on a workspace with non-member user",
+			user: uId_2.String(),
+			request: &pb.CreateProjectRequest{
+				Name:        "Project 1",
+				Alias:       "project_1",
+				Description: lo.ToPtr("Project"),
+				WorkspaceId: wId0.String(),
+			},
+			wantError: status.Error(codes.PermissionDenied, "no permission to create project in this workspace"),
+		},
+	}
 
-	// Verify the project was created
-	l, err := client.ListProjects(mdCtx, &pb.ListProjectsRequest{WorkspaceIds: []string{wId0.String()}})
-	assert.NoError(t, err)
-	assert.Equal(t, int64(3), l.TotalCount)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md := metadata.New(map[string]string{
+				"Authorization": "Bearer TestToken",
+				"User-Id":       tt.user,
+			})
+			mdCtx := metadata.NewOutgoingContext(t.Context(), md)
 
-	// Test different project creation scenarios
-	t.Run("should create project with topics and handle duplicates and empty values", func(t *testing.T) {
-		_, err := client.CreateProject(mdCtx, &pb.CreateProjectRequest{
-			Name:        "Project With Topics",
-			Alias:       "project_with_topics",
-			Description: lo.ToPtr("Project with topics"),
-			Topics:      &pb.Topics{Values: []string{"topic1", "topic2", "", "topic1", "topic3", "", "topic2"}},
-			WorkspaceId: wId0.String(),
-		})
-		assert.NoError(t, err)
-
-		// Verify the project was created with unique topics only, no duplicates or empty values
-		l, err := client.ListProjects(mdCtx, &pb.ListProjectsRequest{WorkspaceIds: []string{wId0.String()}})
-		assert.NoError(t, err)
-		var found bool
-		for _, p := range l.Projects {
-			if p.Alias == "project_with_topics" {
-				assert.Equal(t, "Project With Topics", p.Name)
-				assert.Equal(t, lo.ToPtr("Project with topics"), p.Description)
-				assert.Equal(t, wId0.String(), p.WorkspaceId)
-				assert.Equal(t, []string{"topic1", "topic2", "topic3"}, p.Topics)
-				found = true
-				break
+			res, err := client.CreateProject(mdCtx, tt.request)
+			if tt.wantError != nil {
+				assert.ErrorIs(t, err, tt.wantError)
+				assert.Nil(t, res)
+				return
 			}
-		}
-		assert.True(t, found, "Project with topics was not found")
-	})
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantName, res.Project.Name)
+			assert.Equal(t, tt.wantAlias, res.Project.Alias)
+			assert.Equal(t, tt.request.WorkspaceId, res.Project.WorkspaceId)
+			assert.Equal(t, tt.wantDesc, res.Project.Description)
+			assert.Equal(t, tt.wantTopics, res.Project.Topics)
+
+			p, err := client.GetProject(mdCtx, &pb.ProjectRequest{
+				WorkspaceIdOrAlias: tt.request.WorkspaceId,
+				ProjectIdOrAlias:   tt.request.Alias,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, p.Project)
+
+			assert.Equal(t, tt.wantName, p.Project.Name)
+			assert.Equal(t, tt.wantAlias, p.Project.Alias)
+			assert.Equal(t, tt.request.WorkspaceId, p.Project.WorkspaceId)
+			assert.Equal(t, tt.wantDesc, p.Project.Description)
+			assert.Equal(t, tt.wantTopics, p.Project.Topics)
+		})
+	}
 }
 
 // GRPC Update Project
@@ -436,55 +444,124 @@ func TestInternalUpdateProjectAPI(t *testing.T) {
 	assert.NoError(t, err)
 
 	client := pb.NewReEarthCMSClient(clientConn)
-	md := metadata.New(map[string]string{
-		"Authorization": "Bearer TestToken",
-		"User-Id":       uId.String(),
-	})
-	mdCtx := metadata.NewOutgoingContext(t.Context(), md)
 
-	_, err = client.UpdateProject(mdCtx, &pb.UpdateProjectRequest{
-		ProjectId:   pid.String(),
-		Name:        lo.ToPtr("Updated Project Name"),
-		Description: lo.ToPtr("Updated project description"),
-		Alias:       lo.ToPtr("updated_alias"),
-	})
-	assert.NoError(t, err)
+	tests := []struct {
+		name        string
+		user        string
+		request     *pb.UpdateProjectRequest
+		lookupAlias string
+		wantName    string
+		wantAlias   string
+		wantDesc    *string
+		wantId      string
+		wantTopics  []string
+		wantErr     error
+	}{
+		{
+			name: "update name, description and alias",
+			user: uId.String(),
+			request: &pb.UpdateProjectRequest{
+				ProjectId:   pid.String(),
+				Name:        lo.ToPtr("Updated Project Name"),
+				Description: lo.ToPtr("Updated project description"),
+				Alias:       lo.ToPtr("updated_alias"),
+			},
+			lookupAlias: "updated_alias",
+			wantName:    "Updated Project Name",
+			wantAlias:   "updated_alias",
+			wantDesc:    lo.ToPtr("Updated project description"),
+			wantId:      pid.String(),
+			wantTopics:  []string{"topic1", "", "topic3"},
+		},
+		{
+			name: "update topics deduplicates and removes empty values",
+			user: uId.String(),
+			request: &pb.UpdateProjectRequest{
+				ProjectId: pid.String(),
+				Topics:    &pb.Topics{Values: []string{"topic1", "", "topic2", "topic1", "", "topic3", "topic2"}},
+			},
+			wantId:      pid.String(),
+			lookupAlias: pid.String(),
+			wantTopics:  []string{"topic1", "topic2", "topic3"},
+		},
+		{
+			name: "empty topics array clears topics",
+			user: uId.String(),
+			request: &pb.UpdateProjectRequest{
+				ProjectId: pid.String(),
+				Topics:    &pb.Topics{Values: []string{}},
+			},
+			wantId:      pid.String(),
+			lookupAlias: pid.String(),
+			wantTopics:  nil,
+		},
+		{
+			name: "non-member user should fail",
+			user: uId_2.String(),
+			request: &pb.UpdateProjectRequest{
+				ProjectId: pid.String(),
+				Name:      new("new name"),
+			},
+			wantErr: status.Error(codes.PermissionDenied, "no permission to update this project"),
+		},
+		{
+			name: "without user should fail",
+			user: "",
+			request: &pb.UpdateProjectRequest{
+				ProjectId: pid.String(),
+				Name:      new("new name"),
+			},
+			wantErr: status.Error(codes.PermissionDenied, "no permission to update this project"),
+		},
+	}
 
-	// Verify the project was updated
-	p, err := client.GetProject(mdCtx, &pb.ProjectRequest{WorkspaceIdOrAlias: wId0.String(), ProjectIdOrAlias: "updated_alias"})
-	assert.NoError(t, err)
-	assert.Equal(t, "Updated Project Name", p.Project.Name)
-	assert.Equal(t, lo.ToPtr("Updated project description"), p.Project.Description)
-	assert.Equal(t, "updated_alias", p.Project.Alias)
-	assert.Equal(t, wId0.String(), p.Project.WorkspaceId)
-	assert.Equal(t, pid.String(), p.Project.Id)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md := metadata.New(map[string]string{
+				"Authorization": "Bearer TestToken",
+				"User-Id":       tt.user,
+			})
+			mdCtx := metadata.NewOutgoingContext(t.Context(), md)
 
-	// Test updating project topics
-	t.Run("should update project topics and handle duplicates and empty values", func(t *testing.T) {
-		_, err := client.UpdateProject(mdCtx, &pb.UpdateProjectRequest{
-			ProjectId: pid.String(),
-			Topics:    &pb.Topics{Values: []string{"topic1", "", "topic2", "topic1", "", "topic3", "topic2"}},
+			res, err := client.UpdateProject(mdCtx, tt.request)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, res)
+				return
+			}
+
+			require.NoError(t, err)
+
+			p, err := client.GetProject(mdCtx, &pb.ProjectRequest{
+				WorkspaceIdOrAlias: wId0.String(),
+				ProjectIdOrAlias:   tt.lookupAlias,
+			})
+
+			require.NoError(t, err)
+			require.NotNil(t, p.Project)
+
+			assert.Equal(t, tt.wantId, p.Project.Id)
+			assert.Equal(t, tt.wantId, res.Project.Id)
+			assert.Equal(t, wId0.String(), p.Project.WorkspaceId)
+			assert.Equal(t, wId0.String(), res.Project.WorkspaceId)
+			if tt.request.Name != nil {
+				assert.Equal(t, tt.wantName, p.Project.Name)
+				assert.Equal(t, tt.wantName, res.Project.Name)
+			}
+			if tt.request.Alias != nil {
+				assert.Equal(t, tt.wantAlias, p.Project.Alias)
+				assert.Equal(t, tt.wantAlias, res.Project.Alias)
+			}
+			if tt.request.Description != nil {
+				assert.Equal(t, tt.wantDesc, p.Project.Description)
+				assert.Equal(t, tt.wantDesc, res.Project.Description)
+			}
+			if tt.request.Topics != nil {
+				assert.Equal(t, tt.wantTopics, p.Project.Topics)
+				assert.Equal(t, tt.wantTopics, res.Project.Topics)
+			}
 		})
-		assert.NoError(t, err)
-
-		// Verify topics were updated with unique values only, no duplicates or empty values
-		p, err := client.GetProject(mdCtx, &pb.ProjectRequest{WorkspaceIdOrAlias: wId0.String(), ProjectIdOrAlias: pid.String()})
-		assert.NoError(t, err)
-		assert.Equal(t, []string{"topic1", "topic2", "topic3"}, p.Project.Topics)
-	})
-
-	t.Run("empty topics array should delete topics", func(t *testing.T) {
-		_, err := client.UpdateProject(mdCtx, &pb.UpdateProjectRequest{
-			ProjectId: pid.String(),
-			Topics:    &pb.Topics{Values: []string{}},
-		})
-		assert.NoError(t, err)
-
-		// Verify topics were not deleted
-		p, err := client.GetProject(mdCtx, &pb.ProjectRequest{WorkspaceIdOrAlias: wId0.String(), ProjectIdOrAlias: pid.String()})
-		assert.NoError(t, err)
-		assert.Nil(t, p.Project.Topics)
-	})
+	}
 }
 
 // GRPC Delete Project
@@ -502,23 +579,72 @@ func TestInternalDeleteProjectAPI(t *testing.T) {
 	assert.NoError(t, err)
 
 	client := pb.NewReEarthCMSClient(clientConn)
-	md := metadata.New(map[string]string{
-		"Authorization": "Bearer TestToken",
-		"User-Id":       uId.String(),
-	})
-	mdCtx := metadata.NewOutgoingContext(t.Context(), md)
 
-	_, err = client.DeleteProject(mdCtx, &pb.DeleteProjectRequest{ProjectId: pid.String()})
-	assert.NoError(t, err)
+	tests := []struct {
+		name      string
+		user      string
+		projectId string
+		wantErr   error
+	}{
+		{
+			name:      "without user cannot delete project",
+			user:      "",
+			projectId: pid.String(),
+			wantErr:   status.Error(codes.PermissionDenied, "no permission to delete this project"),
+		},
+		{
+			name:      "non-member user cannot delete project",
+			user:      uId_2.String(),
+			projectId: pid.String(),
+			wantErr:   status.Error(codes.PermissionDenied, "no permission to delete this project"),
+		},
+		{
+			name:      "non-existent project should return not found",
+			user:      uId.String(),
+			projectId: id.NewProjectID().String(),
+			wantErr:   errors.New("not found"),
+		},
+		{
+			name:      "workspace member with write permission can delete project",
+			user:      uId.String(),
+			projectId: pid.String(),
+		},
+	}
 
-	// Verify the project was deleted
-	l, err := client.ListProjects(mdCtx, &pb.ListProjectsRequest{WorkspaceIds: []string{wId0.String()}})
-	assert.NoError(t, err)
-	assert.Equal(t, int64(1), l.TotalCount)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md := metadata.New(map[string]string{
+				"Authorization": "Bearer TestToken",
+				"User-Id":       tt.user,
+			})
+			mdCtx := metadata.NewOutgoingContext(t.Context(), md)
+
+			res, err := client.DeleteProject(mdCtx, &pb.DeleteProjectRequest{ProjectId: tt.projectId})
+			if tt.wantErr != nil {
+				assert.Nil(t, res)
+				if _, ok := status.FromError(tt.wantErr); ok {
+					assert.ErrorIs(t, err, tt.wantErr)
+				} else {
+					assert.ErrorContains(t, err, tt.wantErr.Error())
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			assert.Equal(t, tt.projectId, res.ProjectId)
+
+			_, err = client.GetProject(mdCtx, &pb.ProjectRequest{
+				WorkspaceIdOrAlias: wId0.String(),
+				ProjectIdOrAlias:   tt.projectId,
+			})
+			assert.Error(t, err)
+		})
+	}
 }
 
-// GRPC List Models in Project
-func TestInternalListModelsInProjectAPI(t *testing.T) {
+// GRPC Star Project
+func TestInternalStarProjectAPI(t *testing.T) {
 	StartServer(t, &app.Config{
 		InternalApi: app.InternalApiConfig{
 			Active: true,
@@ -533,215 +659,172 @@ func TestInternalListModelsInProjectAPI(t *testing.T) {
 	assert.NoError(t, err)
 
 	client := pb.NewReEarthCMSClient(clientConn)
-	md := metadata.New(map[string]string{
-		"Authorization": "Bearer TestToken",
-		"User-Id":       uId.String(),
-	})
-	mdCtx := metadata.NewOutgoingContext(t.Context(), md)
 
-	l, err := client.ListModels(mdCtx, &pb.ListModelsRequest{ProjectId: pid.String()})
-	assert.NoError(t, err)
-	assert.Equal(t, int64(7), l.TotalCount)
-
-	// Verify that no models are returned for the project
-
-}
-
-// GRPC Get Model
-func TestInternalGetModelAPI(t *testing.T) {
-	StartServer(t, &app.Config{
-		InternalApi: app.InternalApiConfig{
-			Active: true,
-			Port:   "52050",
-			Token:  "TestToken",
+	tests := []struct {
+		name             string
+		user             string
+		workspaceAlias   string
+		projectAlias     string
+		wantErrCode      codes.Code
+		wantErrContains  string
+		wantStarCount    int64
+		wantStarredBy    []string
+		wantNotStarredBy []string
+	}{
+		// Error cases — do not modify star state
+		{
+			name:            "non-existent project alias returns not found",
+			user:            uId.String(),
+			workspaceAlias:  wId0.String(),
+			projectAlias:    "non-existent-project",
+			wantErrCode:     codes.Unknown,
+			wantErrContains: "not found",
 		},
-	}, true, baseSeeder)
-	clientConn, err := grpc.NewClient("localhost:52050",
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithMaxCallAttempts(5))
-	assert.NoError(t, err)
-
-	client := pb.NewReEarthCMSClient(clientConn)
-	md := metadata.New(map[string]string{
-		"Authorization": "Bearer TestToken",
-		"User-Id":       uId.String(),
-	})
-	mdCtx := metadata.NewOutgoingContext(t.Context(), md)
-
-	// Get model by IDs
-	m, err := client.GetModel(mdCtx, &pb.ModelRequest{WorkspaceIdOrAlias: wId0.String(), ProjectIdOrAlias: pid.String(), ModelIdOrAlias: mId1.String()})
-	assert.NoError(t, err)
-	assert.Equal(t, mId1.String(), m.Model.Id)
-	assert.Equal(t, ikey1.String(), m.Model.Key)
-	assert.Equal(t, "m1", m.Model.Name)
-	assert.Equal(t, pid.String(), m.Model.ProjectId)
-	assert.Equal(t, "m1 desc", m.Model.Description)
-	assert.NotNil(t, m.Model.Schema)
-
-	// Get model by aliases
-	m, err = client.GetModel(mdCtx, &pb.ModelRequest{WorkspaceIdOrAlias: wId0.String(), ProjectIdOrAlias: palias, ModelIdOrAlias: ikey1.String()})
-	assert.NoError(t, err)
-	assert.Equal(t, mId1.String(), m.Model.Id)
-	assert.Equal(t, ikey1.String(), m.Model.Key)
-	assert.Equal(t, "m1", m.Model.Name)
-	assert.Equal(t, pid.String(), m.Model.ProjectId)
-	assert.Equal(t, "m1 desc", m.Model.Description)
-	assert.NotNil(t, m.Model.Schema)
-
-	// region Private Project
-	// Get model from private project owned by the user = should return the model
-	m, err = client.GetModel(mdCtx, &pb.ModelRequest{WorkspaceIdOrAlias: wId0.String(), ProjectIdOrAlias: palias2, ModelIdOrAlias: mId6.String()})
-	assert.NoError(t, err)
-	assert.Equal(t, mId6.String(), m.Model.Id)
-	assert.Equal(t, "m6", m.Model.Name)
-	assert.Equal(t, pid2.String(), m.Model.ProjectId)
-
-	// Get model from private project with non-existing user = should return not found
-	mdNonMember := metadata.New(map[string]string{
-		"Authorization": "Bearer TestToken",
-		"User-Id":       id.NewUserID().String(),
-	})
-	mdCtxNonMember := metadata.NewOutgoingContext(t.Context(), mdNonMember)
-
-	m, err = client.GetModel(mdCtxNonMember, &pb.ModelRequest{WorkspaceIdOrAlias: wId0.String(), ProjectIdOrAlias: palias2, ModelIdOrAlias: mId6.String()})
-	assert.Error(t, err)
-	assert.Equal(t, "rpc error: code = Unknown desc = not found", err.Error())
-	assert.Nil(t, m)
-	// endregion
-}
-
-// GRPC List Items in Model
-func TestInternalListItemsInModelAPI(t *testing.T) {
-	e := StartServer(t, &app.Config{
-		InternalApi: app.InternalApiConfig{
-			Active: true,
-			Port:   "52050",
-			Token:  "TestToken",
+		{
+			name:            "empty project alias returns invalid argument",
+			user:            uId.String(),
+			workspaceAlias:  wId0.String(),
+			projectAlias:    "",
+			wantErrCode:     codes.InvalidArgument,
+			wantErrContains: "project_alias is required",
 		},
-	}, true, baseSeeder)
-
-	clientConn, err := grpc.NewClient("localhost:52050",
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithMaxCallAttempts(5))
-	assert.NoError(t, err)
-
-	client := pb.NewReEarthCMSClient(clientConn)
-	md := metadata.New(map[string]string{
-		"Authorization": "Bearer TestToken",
-		"User-Id":       uId.String(),
-	})
-	mdCtx := metadata.NewOutgoingContext(t.Context(), md)
-
-	// 1- Model does not contain any published items
-	l, err := client.ListItems(mdCtx, &pb.ListItemsRequest{ProjectId: pid.String(), ModelId: mId1.String()})
-	assert.NoError(t, err)
-
-	assert.Equal(t, int64(0), l.TotalCount)
-	assert.Equal(t, 0, len(l.Items))
-
-	// 2- Model contains one published item
-
-	// create request & approve it to make the item published
-	res := createRequest2(e, pid.String(), "test", lo.ToPtr("test"), lo.ToPtr("WAITING"), []string{uId.String()}, []any{map[string]any{"itemId": itmId1.String(), "version": "latest"}})
-	approveRequest2(e, res.Path("$.data.createRequest.request.id").String().Raw())
-
-	l, err = client.ListItems(mdCtx, &pb.ListItemsRequest{ProjectId: pid.String(), ModelId: mId1.String()})
-	assert.NoError(t, err)
-
-	assert.Equal(t, int64(1), l.TotalCount)
-	assert.Equal(t, 1, len(l.Items))
-	item := l.Items[0]
-	assert.Equal(t, itmId1.String(), item.Id)
-
-	// 3- model contains items with different fields types
-
-	// create request & approve it to make the item published
-	res = createRequest2(e, pid.String(), "test", lo.ToPtr("test"), lo.ToPtr("WAITING"), []string{uId.String()}, []any{map[string]any{"itemId": itmId6.String(), "version": "latest"}})
-	approveRequest2(e, res.Path("$.data.createRequest.request.id").String().Raw())
-
-	l, err = client.ListItems(mdCtx, &pb.ListItemsRequest{ProjectId: pid.String(), ModelId: mId5.String()})
-	assert.NoError(t, err)
-
-	assert.Equal(t, int64(1), l.TotalCount)
-	assert.Equal(t, 1, len(l.Items))
-	item = l.Items[0]
-	assert.Equal(t, itmId6.String(), item.Id)
-	f, err := convertAnyToFloat32(item.Fields["number-key"])
-	assert.NoError(t, err)
-	assert.Equal(t, float32(21.2), f)
-
-	i, err := convertAnyToInt64(item.Fields["integer-key"])
-	assert.NoError(t, err)
-	assert.Equal(t, int64(123), i)
-}
-
-// GRPC List Assets in Project
-func TestInternalListAssetsInProjectAPI(t *testing.T) {
-	StartServer(t, &app.Config{
-		InternalApi: app.InternalApiConfig{
-			Active: true,
-			Port:   "52050",
-			Token:  "TestToken",
+		{
+			name:            "missing user ID in metadata returns user not found",
+			workspaceAlias:  wId0.String(),
+			projectAlias:    palias,
+			wantErrCode:     codes.Unknown,
+			wantErrContains: "user not found",
 		},
-	}, true, baseSeeder)
-
-	clientConn, err := grpc.NewClient("localhost:52050",
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithMaxCallAttempts(5))
-	assert.NoError(t, err)
-
-	client := pb.NewReEarthCMSClient(clientConn)
-	md := metadata.New(map[string]string{
-		"Authorization": "Bearer TestToken",
-		"User-Id":       uId.String(),
-	})
-	mdCtx := metadata.NewOutgoingContext(t.Context(), md)
-
-	l, err := client.ListAssets(mdCtx, &pb.ListAssetsRequest{ProjectId: pid.String()})
-	assert.NoError(t, err)
-	assert.Equal(t, int64(3), l.TotalCount)
-
-	a := l.Assets[0]
-	assert.Equal(t, a.Id, aid1.String())
-	assert.Equal(t, "aaa.jpg", a.Filename)
-	assert.Nil(t, a.PreviewType)
-	assert.Equal(t, uint64(1000), a.Size)
-	assert.Nil(t, a.ArchiveExtractionStatus)
-	assert.Equal(t, pid.String(), a.ProjectId)
-	assert.Equal(t, false, a.Public)
-}
-
-// GRPC Get Asset
-func TestInternalGetAssetAPI(t *testing.T) {
-	StartServer(t, &app.Config{
-		InternalApi: app.InternalApiConfig{
-			Active: true,
-			Port:   "52050",
-			Token:  "TestToken",
+		{
+			name:           "invalid user ID format returns error",
+			user:           "invalid-user-id",
+			workspaceAlias: wId0.String(),
+			projectAlias:   palias,
+			wantErrCode:    codes.Unknown,
 		},
-	}, true, baseSeeder)
+		// Sequential star/unstar operations — each row builds on the previous state
+		{
+			name:           "first star by member increments count to 1",
+			user:           uId.String(),
+			workspaceAlias: wId0.String(),
+			projectAlias:   palias,
+			wantStarCount:  1,
+			wantStarredBy:  []string{uId.String()},
+		},
+		{
+			name:             "second star by member decrements count to 0 (toggle unstar)",
+			user:             uId.String(),
+			workspaceAlias:   wId0.String(),
+			projectAlias:     palias,
+			wantStarCount:    0,
+			wantNotStarredBy: []string{uId.String()},
+		},
+		{
+			name:           "star again confirms toggle is idempotent",
+			user:           uId.String(),
+			workspaceAlias: wId0.String(),
+			projectAlias:   palias,
+			wantStarCount:  1,
+			wantStarredBy:  []string{uId.String()},
+		},
+		{
+			name:             "unstar again confirms toggle is idempotent",
+			user:             uId.String(),
+			workspaceAlias:   wId0.String(),
+			projectAlias:     palias,
+			wantStarCount:    0,
+			wantNotStarredBy: []string{uId.String()},
+		},
+		{
+			name:           "star using project ID instead of alias",
+			user:           uId.String(),
+			workspaceAlias: wId0.String(),
+			projectAlias:   pid.String(),
+			wantStarCount:  1,
+			wantStarredBy:  []string{uId.String()},
+		},
+		{
+			name:             "unstar using project ID",
+			user:             uId.String(),
+			workspaceAlias:   wId0.String(),
+			projectAlias:     pid.String(),
+			wantStarCount:    0,
+			wantNotStarredBy: []string{uId.String()},
+		},
+		// Non-member user can star and unstar public projects
+		{
+			name:           "star by non-member user succeeds",
+			user:           uId_2.String(),
+			workspaceAlias: wId0.String(),
+			projectAlias:   pid.String(),
+			wantStarCount:  1,
+			wantStarredBy:  []string{uId_2.String()},
+		},
+		{
+			name:             "unstar by non-member user succeeds",
+			user:             uId_2.String(),
+			workspaceAlias:   wId0.String(),
+			projectAlias:     pid.String(),
+			wantStarCount:    0,
+			wantNotStarredBy: []string{uId_2.String()},
+		},
+	}
 
-	clientConn, err := grpc.NewClient("localhost:52050",
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithMaxCallAttempts(5))
-	assert.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// t.Parallel() should not be used here as tests build on each other's state
+			mdFields := map[string]string{
+				"Authorization": "Bearer TestToken",
+				"User-Id":       tt.user,
+			}
+			mdCtx := metadata.NewOutgoingContext(t.Context(), metadata.New(mdFields))
 
-	client := pb.NewReEarthCMSClient(clientConn)
-	md := metadata.New(map[string]string{
-		"Authorization": "Bearer TestToken",
-		"User-Id":       uId.String(),
-	})
+			res, err := client.StarProject(mdCtx, &pb.StarRequest{
+				WorkspaceAlias: tt.workspaceAlias,
+				ProjectAlias:   tt.projectAlias,
+			})
 
-	mdCtx := metadata.NewOutgoingContext(t.Context(), md)
-	a, err := client.GetAsset(mdCtx, &pb.AssetRequest{AssetId: aid1.String()})
-	assert.NoError(t, err)
-	assert.Equal(t, aid1.String(), a.Asset.Id)
-	assert.Equal(t, "aaa.jpg", a.Asset.Filename)
-	assert.Nil(t, a.Asset.PreviewType)
-	assert.Equal(t, uint64(1000), a.Asset.Size)
-	assert.Nil(t, a.Asset.ArchiveExtractionStatus)
-	assert.Equal(t, pid.String(), a.Asset.ProjectId)
-	assert.Equal(t, false, a.Asset.Public)
+			if tt.wantErrCode != codes.OK {
+				assert.Error(t, err)
+				assert.Nil(t, res)
+				st, ok := status.FromError(err)
+				assert.True(t, ok, "error should be a gRPC status error")
+				assert.Equal(t, tt.wantErrCode, st.Code())
+				if tt.wantErrContains != "" {
+					assert.Contains(t, st.Message(), tt.wantErrContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			require.NotNil(t, res.Project)
+			assert.Equal(t, tt.wantStarCount, res.Project.StarCount)
+			assert.Len(t, res.Project.StarredBy, int(tt.wantStarCount))
+			for _, u := range tt.wantStarredBy {
+				assert.Contains(t, res.Project.StarredBy, u)
+			}
+			for _, u := range tt.wantNotStarredBy {
+				assert.NotContains(t, res.Project.StarredBy, u)
+			}
+
+			// Verify star state persists when fetched via GetProject
+			getRes, err := client.GetProject(mdCtx, &pb.ProjectRequest{
+				WorkspaceIdOrAlias: tt.workspaceAlias,
+				ProjectIdOrAlias:   tt.projectAlias,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, getRes.Project)
+			assert.Equal(t, tt.wantStarCount, getRes.Project.StarCount)
+			assert.Len(t, getRes.Project.StarredBy, int(tt.wantStarCount))
+			for _, u := range tt.wantStarredBy {
+				assert.Contains(t, getRes.Project.StarredBy, u)
+			}
+			for _, u := range tt.wantNotStarredBy {
+				assert.NotContains(t, getRes.Project.StarredBy, u)
+			}
+		})
+	}
 }
 
 // TODO: improve common methods usage instead of duplicating
@@ -842,283 +925,4 @@ func convertAnyToInt64(a *anypb.Any) (int64, error) {
 		return 0, fmt.Errorf("failed to unmarshal Any to IntValue: %w", err)
 	}
 	return int64(w.Value), nil
-}
-
-// GRPC Star Project
-func TestInternalStarProjectAPI(t *testing.T) {
-	StartServer(t, &app.Config{
-		InternalApi: app.InternalApiConfig{
-			Active: true,
-			Port:   "52050",
-			Token:  "TestToken",
-		},
-	}, true, baseSeeder)
-
-	clientConn, err := grpc.NewClient("localhost:52050",
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithMaxCallAttempts(5))
-	assert.NoError(t, err)
-
-	client := pb.NewReEarthCMSClient(clientConn)
-
-	t.Run("Star project (first time) - should add user to starredBy and increment count", func(t *testing.T) {
-		md := metadata.New(map[string]string{
-			"Authorization": "Bearer TestToken",
-			"User-Id":       uId.String(),
-		})
-		mdCtx := metadata.NewOutgoingContext(t.Context(), md)
-
-		// First call should star the project
-		resp, err := client.StarProject(mdCtx, &pb.StarRequest{
-			WorkspaceAlias: wId0.String(),
-			ProjectAlias:   palias,
-		})
-		assert.NoError(t, err)
-		assert.NotNil(t, resp.Project)
-
-		// Verify star count is 1 and user is in starredBy
-		assert.Equal(t, int64(1), resp.Project.StarCount)
-		assert.Contains(t, resp.Project.StarredBy, uId.String())
-		assert.Len(t, resp.Project.StarredBy, 1)
-	})
-
-	t.Run("Unstar project (second time) - should remove user from starredBy and decrement count", func(t *testing.T) {
-		md := metadata.New(map[string]string{
-			"Authorization": "Bearer TestToken",
-			"User-Id":       uId.String(),
-		})
-		mdCtx := metadata.NewOutgoingContext(t.Context(), md)
-
-		// Second call should unstar the project
-		resp, err := client.StarProject(mdCtx, &pb.StarRequest{
-			WorkspaceAlias: wId0.String(),
-			ProjectAlias:   palias,
-		})
-		assert.NoError(t, err)
-		assert.NotNil(t, resp.Project)
-
-		// Verify star count is 0 and user is not in starredBy
-		assert.Equal(t, int64(0), resp.Project.StarCount)
-		assert.NotContains(t, resp.Project.StarredBy, uId.String())
-		assert.Len(t, resp.Project.StarredBy, 0)
-	})
-
-	t.Run("Star and unstar multiple times", func(t *testing.T) {
-		md := metadata.New(map[string]string{
-			"Authorization": "Bearer TestToken",
-			"User-Id":       uId.String(),
-		})
-		mdCtx := metadata.NewOutgoingContext(t.Context(), md)
-
-		// Star the project (3rd time total)
-		resp1, err := client.StarProject(mdCtx, &pb.StarRequest{
-			WorkspaceAlias: wId0.String(),
-			ProjectAlias:   palias,
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, int64(1), resp1.Project.StarCount)
-		assert.Contains(t, resp1.Project.StarredBy, uId.String())
-		assert.Len(t, resp1.Project.StarredBy, 1)
-
-		// Unstar the project (4th time total)
-		resp2, err := client.StarProject(mdCtx, &pb.StarRequest{
-			WorkspaceAlias: wId0.String(),
-			ProjectAlias:   palias,
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, int64(0), resp2.Project.StarCount)
-		assert.NotContains(t, resp2.Project.StarredBy, uId.String())
-		assert.Len(t, resp2.Project.StarredBy, 0)
-
-		// Star again (5th time total)
-		resp3, err := client.StarProject(mdCtx, &pb.StarRequest{
-			WorkspaceAlias: wId0.String(),
-			ProjectAlias:   palias,
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, int64(1), resp3.Project.StarCount)
-		assert.Contains(t, resp3.Project.StarredBy, uId.String())
-		assert.Len(t, resp3.Project.StarredBy, 1)
-
-		// Clean up - unstar
-		_, err = client.StarProject(mdCtx, &pb.StarRequest{
-			WorkspaceAlias: wId0.String(),
-			ProjectAlias:   palias,
-		})
-		assert.NoError(t, err)
-	})
-
-	t.Run("Star project using project ID instead of alias", func(t *testing.T) {
-		md := metadata.New(map[string]string{
-			"Authorization": "Bearer TestToken",
-			"User-Id":       uId.String(),
-		})
-		mdCtx := metadata.NewOutgoingContext(t.Context(), md)
-
-		// Use project ID instead of alias
-		resp, err := client.StarProject(mdCtx, &pb.StarRequest{
-			WorkspaceAlias: wId0.String(),
-			ProjectAlias:   pid.String(),
-		})
-		assert.NoError(t, err)
-		assert.NotNil(t, resp.Project)
-
-		// Verify star count is 1 and user is in starredBy
-		assert.Equal(t, int64(1), resp.Project.StarCount)
-		assert.Contains(t, resp.Project.StarredBy, uId.String())
-		assert.Equal(t, pid.String(), resp.Project.Id)
-
-		// Clean up - unstar
-		_, err = client.StarProject(mdCtx, &pb.StarRequest{
-			WorkspaceAlias: wId0.String(),
-			ProjectAlias:   pid.String(),
-		})
-		assert.NoError(t, err)
-	})
-
-	t.Run("Star project by user does not belong to the workspace", func(t *testing.T) {
-		md := metadata.New(map[string]string{
-			"Authorization": "Bearer TestToken",
-			"User-Id":       uId_2.String(),
-		})
-		mdCtx := metadata.NewOutgoingContext(t.Context(), md)
-
-		// Use project ID instead of alias
-		resp, err := client.StarProject(mdCtx, &pb.StarRequest{
-			WorkspaceAlias: wId0.String(),
-			ProjectAlias:   pid.String(),
-		})
-		assert.NoError(t, err)
-		assert.NotNil(t, resp.Project)
-
-		// Verify star count is 1 and user is in starredBy
-		assert.Equal(t, int64(1), resp.Project.StarCount)
-		assert.Contains(t, resp.Project.StarredBy, uId_2.String())
-		assert.Equal(t, pid.String(), resp.Project.Id)
-	})
-
-	t.Run("Unstar project by user does not belong to the workspace", func(t *testing.T) {
-		md := metadata.New(map[string]string{
-			"Authorization": "Bearer TestToken",
-			"User-Id":       uId_2.String(),
-		})
-		mdCtx := metadata.NewOutgoingContext(t.Context(), md)
-
-		// Use project ID instead of alias
-		resp, err := client.StarProject(mdCtx, &pb.StarRequest{
-			WorkspaceAlias: wId0.String(),
-			ProjectAlias:   pid.String(),
-		})
-		assert.NoError(t, err)
-		assert.NotNil(t, resp.Project)
-
-		// Verify star count is 0 and user is not in starredBy
-		assert.Equal(t, int64(0), resp.Project.StarCount)
-		assert.NotContains(t, resp.Project.StarredBy, uId_2.String())
-		assert.Equal(t, pid.String(), resp.Project.Id)
-	})
-
-	t.Run("Error cases", func(t *testing.T) {
-		md := metadata.New(map[string]string{
-			"Authorization": "Bearer TestToken",
-			"User-Id":       uId.String(),
-		})
-		mdCtx := metadata.NewOutgoingContext(t.Context(), md)
-
-		// Non-existent project alias
-		_, err := client.StarProject(mdCtx, &pb.StarRequest{
-			WorkspaceAlias: wId0.String(),
-			ProjectAlias:   "non-existent-project",
-		})
-		assert.Error(t, err)
-		st, ok := status.FromError(err)
-		assert.True(t, ok, "error should be a gRPC status error")
-		assert.Equal(t, codes.Unknown, st.Code())
-		assert.Contains(t, st.Message(), "not found")
-
-		// Empty project alias
-		_, err = client.StarProject(mdCtx, &pb.StarRequest{
-			WorkspaceAlias: wId0.String(),
-			ProjectAlias:   "",
-		})
-		assert.Error(t, err)
-		st, ok = status.FromError(err)
-		assert.True(t, ok, "error should be a gRPC status error")
-		assert.Equal(t, codes.InvalidArgument, st.Code())
-
-		// Missing user ID in metadata
-		mdNoUser := metadata.New(map[string]string{
-			"Authorization": "Bearer TestToken",
-		})
-		mdCtxNoUser := metadata.NewOutgoingContext(t.Context(), mdNoUser)
-
-		_, err = client.StarProject(mdCtxNoUser, &pb.StarRequest{
-			WorkspaceAlias: wId0.String(),
-			ProjectAlias:   palias,
-		})
-		assert.Error(t, err)
-		st, ok = status.FromError(err)
-		assert.True(t, ok, "error should be a gRPC status error")
-		assert.Equal(t, codes.Unknown, st.Code())
-		assert.Contains(t, st.Message(), "user not found")
-
-		// Invalid user ID format (should be rejected by user ID validation)
-		mdInvalidUser := metadata.New(map[string]string{
-			"Authorization": "Bearer TestToken",
-			"User-Id":       "invalid-user-id",
-		})
-		mdCtxInvalidUser := metadata.NewOutgoingContext(t.Context(), mdInvalidUser)
-
-		_, err = client.StarProject(mdCtxInvalidUser, &pb.StarRequest{
-			WorkspaceAlias: wId0.String(),
-			ProjectAlias:   palias,
-		})
-		assert.Error(t, err)
-		st, ok = status.FromError(err)
-		assert.True(t, ok, "error should be a gRPC status error")
-		assert.Equal(t, codes.Unknown, st.Code())
-	})
-
-	t.Run("Star count persists across GetProject calls", func(t *testing.T) {
-		md := metadata.New(map[string]string{
-			"Authorization": "Bearer TestToken",
-			"User-Id":       uId.String(),
-		})
-		mdCtx := metadata.NewOutgoingContext(t.Context(), md)
-
-		// Star the project
-		starResp, err := client.StarProject(mdCtx, &pb.StarRequest{
-			WorkspaceAlias: wId0.String(),
-			ProjectAlias:   palias,
-		})
-		assert.NoError(t, err)
-		// Verify the star operation was successful
-		assert.Equal(t, int64(1), starResp.Project.StarCount)
-
-		// Get the project and verify the star count persisted
-		getResp, err := client.GetProject(mdCtx, &pb.ProjectRequest{
-			WorkspaceIdOrAlias: wId0.String(),
-			ProjectIdOrAlias:   palias,
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, int64(1), getResp.Project.StarCount)
-		assert.Contains(t, getResp.Project.StarredBy, uId.String())
-
-		// Unstar the project
-		unstarResp, err := client.StarProject(mdCtx, &pb.StarRequest{
-			WorkspaceAlias: wId0.String(),
-			ProjectAlias:   palias,
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, int64(0), unstarResp.Project.StarCount)
-
-		// Get the project again and verify the unstar persisted
-		getResp2, err := client.GetProject(mdCtx, &pb.ProjectRequest{
-			WorkspaceIdOrAlias: wId0.String(),
-			ProjectIdOrAlias:   palias,
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, int64(0), getResp2.Project.StarCount)
-		assert.Len(t, getResp2.Project.StarredBy, 0)
-	})
 }

--- a/server/e2e/internal_project_test.go
+++ b/server/e2e/internal_project_test.go
@@ -23,6 +23,19 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
+// assertGrpcError asserts that got is a gRPC status error with the same code
+// and message as want. Comparing freshly-constructed status errors directly
+// (e.g. with assert.Equal) relies on instance equality and is not reliable.
+func assertGrpcError(t *testing.T, want, got error) {
+	t.Helper()
+	wantSt, ok := status.FromError(want)
+	require.True(t, ok, "want should be a gRPC status error")
+	gotSt, ok := status.FromError(got)
+	require.True(t, ok, "error should be a gRPC status error")
+	assert.Equal(t, wantSt.Code(), gotSt.Code())
+	assert.Equal(t, wantSt.Message(), gotSt.Message())
+}
+
 // GRPC List Projects
 func TestInternalListProjectsAPI(t *testing.T) {
 	e := StartServer(t, &app.Config{
@@ -138,6 +151,13 @@ func TestInternalListProjectsAPI(t *testing.T) {
 			wantTotal:    1,
 			wantProjects: project.IDList{pid},
 		},
+		{
+			name:         "for workspace with no user should return only public projects",
+			userId:       "",
+			request:      &pb.ListProjectsRequest{WorkspaceIds: []string{wId0.String()}},
+			wantTotal:    1,
+			wantProjects: project.IDList{pid},
+		},
 	}
 
 	for _, tt := range tests {
@@ -151,7 +171,7 @@ func TestInternalListProjectsAPI(t *testing.T) {
 			l, err := client.ListProjects(mdCtx, tt.request)
 			if tt.wantErr != nil {
 				assert.Nil(t, l)
-				assert.ErrorIs(t, err, tt.wantErr)
+				assertGrpcError(t, tt.wantErr, err)
 				return
 			}
 			assert.NoError(t, err)
@@ -401,7 +421,7 @@ func TestInternalCreateProjectAPI(t *testing.T) {
 
 			res, err := client.CreateProject(mdCtx, tt.request)
 			if tt.wantError != nil {
-				assert.ErrorIs(t, err, tt.wantError)
+				assertGrpcError(t, tt.wantError, err)
 				assert.Nil(t, res)
 				return
 			}
@@ -525,7 +545,7 @@ func TestInternalUpdateProjectAPI(t *testing.T) {
 
 			res, err := client.UpdateProject(mdCtx, tt.request)
 			if tt.wantErr != nil {
-				assert.ErrorIs(t, err, tt.wantErr)
+				assertGrpcError(t, tt.wantErr, err)
 				assert.Nil(t, res)
 				return
 			}
@@ -623,7 +643,7 @@ func TestInternalDeleteProjectAPI(t *testing.T) {
 			if tt.wantErr != nil {
 				assert.Nil(t, res)
 				if _, ok := status.FromError(tt.wantErr); ok {
-					assert.ErrorIs(t, err, tt.wantErr)
+					assertGrpcError(t, tt.wantErr, err)
 				} else {
 					assert.ErrorContains(t, err, tt.wantErr.Error())
 				}

--- a/server/internal/adapter/internalapi/server.go
+++ b/server/internal/adapter/internalapi/server.go
@@ -47,6 +47,10 @@ func (s server) CreateProject(ctx context.Context, req *pb.CreateProjectRequest)
 		return nil, err
 	}
 
+	if op == nil || !op.IsWritableWorkspace(wId) {
+		return nil, status.Error(codes.PermissionDenied, "no permission to create project in this workspace")
+	}
+
 	p, err := uc.Project.Create(ctx, interfaces.CreateProjectParam{
 		WorkspaceID: wId,
 		Name:        &req.Name,
@@ -77,6 +81,17 @@ func (s server) UpdateProject(ctx context.Context, req *pb.UpdateProjectRequest)
 	pId, err := project.IDFrom(req.ProjectId)
 	if err != nil {
 		return nil, err
+	}
+
+	dbP, err := uc.Project.Fetch(ctx, project.IDList{pId}, op)
+	if err != nil {
+		return nil, err
+	}
+	if len(dbP) == 0 {
+		return nil, rerror.ErrNotFound
+	}
+	if op == nil || !op.IsWritableProject(pId) {
+		return nil, status.Error(codes.PermissionDenied, "no permission to update this project")
 	}
 
 	// todo accessibility
@@ -110,6 +125,17 @@ func (s server) DeleteProject(ctx context.Context, req *pb.DeleteProjectRequest)
 	pId, err := project.IDFrom(req.ProjectId)
 	if err != nil {
 		return nil, err
+	}
+
+	dbP, err := uc.Project.Fetch(ctx, project.IDList{pId}, op)
+	if err != nil {
+		return nil, err
+	}
+	if len(dbP) == 0 {
+		return nil, rerror.ErrNotFound
+	}
+	if op == nil || !op.IsWritableProject(pId) {
+		return nil, status.Error(codes.PermissionDenied, "no permission to delete this project")
 	}
 
 	err = uc.Project.Delete(ctx, pId, op)
@@ -152,6 +178,10 @@ func (s server) GetProject(ctx context.Context, req *pb.ProjectRequest) (*pb.Pro
 		return nil, err
 	}
 
+	if p.Accessibility().Visibility() != project.VisibilityPublic && (op == nil || !op.IsReadableProject(p.ID())) {
+		return nil, status.Error(codes.NotFound, "not found")
+	}
+
 	return &pb.ProjectResponse{
 		Project: internalapimodel.ToProject(p),
 	}, nil
@@ -173,7 +203,18 @@ func (s server) ListProjects(ctx context.Context, req *pb.ListProjectsRequest) (
 		}
 		return wId, true
 	})
-	if req.PublicOnly || len(wIds) == 0 {
+
+	// listing projects from workspaces that user is member and non-member at the same time is not supported
+	if i := op.AllReadableWorkspaces().Intersect(wIds); i.Len() > 0 && i.Len() < len(wIds) {
+		return nil, status.Error(codes.InvalidArgument, "mixed workspaces")
+	}
+
+	// enforce public filter if:
+	// - user intend to
+	// - user does not select workspaces
+	// - no logged-in user
+	// - user is not a member in the selected workspace
+	if req.PublicOnly || len(wIds) == 0 || op == nil || op.AcOperator.User == nil || !op.IsReadableWorkspace(wIds...) {
 		f.Visibility = lo.ToPtr(project.VisibilityPublic)
 	}
 
@@ -213,6 +254,19 @@ func (s server) GetAsset(ctx context.Context, req *pb.AssetRequest) (*pb.AssetRe
 		return nil, rerror.ErrNotFound
 	}
 
+	pl, err := uc.Project.Fetch(ctx, project.IDList{a.Project()}, op)
+	if err != nil {
+		return nil, err
+	}
+	if len(pl) == 0 {
+		return nil, rerror.ErrNotFound
+	}
+	p := pl[0]
+
+	if p.Accessibility().Visibility() != project.VisibilityPublic && (op == nil || !op.IsReadableProject(p.ID())) {
+		return nil, status.Error(codes.NotFound, "not found")
+	}
+
 	return &pb.AssetResponse{
 		Asset: internalapimodel.ToAsset(a),
 	}, nil
@@ -241,6 +295,10 @@ func (s server) ListAssets(ctx context.Context, req *pb.ListAssetsRequest) (*pb.
 
 	p := pl[0]
 
+	if p.Accessibility().Visibility() != project.VisibilityPublic && (op == nil || !op.IsReadableProject(p.ID())) {
+		return nil, status.Error(codes.NotFound, "not found")
+	}
+
 	f := interfaces.AssetFilter{
 		Sort:       internalapimodel.SortFromPB(req.SortInfo),
 		Pagination: internalapimodel.PaginationFromPB(req.PageInfo),
@@ -268,6 +326,10 @@ func (s server) GetModel(ctx context.Context, req *pb.ModelRequest) (*pb.ModelRe
 	p, err := uc.Project.FindByIDOrAlias(ctx, accountdomain.WorkspaceIDOrAlias(req.WorkspaceIdOrAlias), project.IDOrAlias(req.ProjectIdOrAlias), op)
 	if err != nil {
 		return nil, err
+	}
+
+	if p.Accessibility().Visibility() != project.VisibilityPublic && (op == nil || !op.IsReadableProject(p.ID())) {
+		return nil, status.Error(codes.NotFound, "not found")
 	}
 
 	m, err := uc.Model.FindByIDOrKey(ctx, p.ID(), model.IDOrKey(req.ModelIdOrAlias), op)
@@ -319,6 +381,10 @@ func (s server) ListModels(ctx context.Context, req *pb.ListModelsRequest) (*pb.
 	}
 	p := pl[0]
 
+	if p.Accessibility().Visibility() != project.VisibilityPublic && (op == nil || !op.IsReadableProject(p.ID())) {
+		return nil, status.Error(codes.NotFound, "not found")
+	}
+
 	ml, pi, err := uc.Model.FindByProject(ctx, pId, internalapimodel.PaginationFromPB(req.PageInfo), op)
 	if err != nil {
 		return nil, err
@@ -365,6 +431,19 @@ func (s server) ListItems(ctx context.Context, req *pb.ListItemsRequest) (*pb.Li
 	sp, err := uc.Schema.FindByModel(ctx, mId, op)
 	if err != nil {
 		return nil, err
+	}
+
+	pl, err := uc.Project.Fetch(ctx, project.IDList{sp.Schema().Project()}, op)
+	if err != nil {
+		return nil, err
+	}
+	if len(pl) == 0 {
+		return nil, rerror.ErrNotFound
+	}
+	p := pl[0]
+
+	if p.Accessibility().Visibility() != project.VisibilityPublic && (op == nil || !op.IsReadableProject(p.ID())) {
+		return nil, status.Error(codes.NotFound, "not found")
 	}
 
 	q := item.NewQuery(sp.Schema().Project(), mId, sp.Schema().ID().Ref(), req.GetKeyword(), version.Public.Ref())

--- a/server/internal/app/grpc.go
+++ b/server/internal/app/grpc.go
@@ -11,9 +11,7 @@ import (
 	"github.com/reearth/reearth-cms/server/internal/adapter/internalapi"
 	pb "github.com/reearth/reearth-cms/server/internal/adapter/internalapi/schemas/internalapi/v1"
 	"github.com/reearth/reearth-cms/server/internal/usecase/interactor"
-	"github.com/reearth/reearth-cms/server/internal/usecase/repo"
 	"github.com/reearth/reearthx/account/accountdomain"
-	"github.com/reearth/reearthx/account/accountusecase/accountrepo"
 	"github.com/reearth/reearthx/idx"
 	"github.com/reearth/reearthx/log"
 	"github.com/reearth/reearthx/rerror"
@@ -129,22 +127,11 @@ func unaryAttachUsecaseInterceptor(appCtx *ApplicationContext) grpc.UnaryServerI
 		}
 
 		r, ar, g, ag := appCtx.Repos, appCtx.AcRepos, appCtx.Gateways, appCtx.AcGateways
-		var r2 *repo.Container
-		var ar2 *accountrepo.Container
-		// use not filtered repos until filtering supports internal api usecases
-		r2 = r
-		ar2 = ar
-		//op := adapter.Operator(ctx)
-		//r2 = r.Filtered(repo.WorkspaceFilterFromOperator(op), repo.ProjectFilterFromOperator(op, true))
-		//if op != nil {
-		//	ar2 = ar.Filtered(accountrepo.WorkspaceFilterFromOperator(op.AcOperator))
-		//} else {
-		//	ar2 = ar
-		//}
-		uc := interactor.New(r2, g, ar2, ag, interactor.ContainerConfig{})
+		// TODO: use operator-filtered repos once filtering supports internal API usecases
+		uc := interactor.New(r, g, ar, ag, interactor.ContainerConfig{})
 		ctx = adapter.AttachUsecases(ctx, &uc)
 		ctx = adapter.AttachGateways(ctx, g)
-		ctx = adapter.AttachAcRepos(ctx, ar2)
+		ctx = adapter.AttachAcRepos(ctx, ar)
 
 		return handler(ctx, req)
 	}

--- a/server/internal/app/grpc.go
+++ b/server/internal/app/grpc.go
@@ -131,13 +131,16 @@ func unaryAttachUsecaseInterceptor(appCtx *ApplicationContext) grpc.UnaryServerI
 		r, ar, g, ag := appCtx.Repos, appCtx.AcRepos, appCtx.Gateways, appCtx.AcGateways
 		var r2 *repo.Container
 		var ar2 *accountrepo.Container
-		op := adapter.Operator(ctx)
-		r2 = r.Filtered(repo.WorkspaceFilterFromOperator(op), repo.ProjectFilterFromOperator(op, true))
-		if op != nil {
-			ar2 = ar.Filtered(accountrepo.WorkspaceFilterFromOperator(op.AcOperator))
-		} else {
-			ar2 = ar
-		}
+		// use not filtered repos until filtering supports internal api usecases
+		r2 = r
+		ar2 = ar
+		//op := adapter.Operator(ctx)
+		//r2 = r.Filtered(repo.WorkspaceFilterFromOperator(op), repo.ProjectFilterFromOperator(op, true))
+		//if op != nil {
+		//	ar2 = ar.Filtered(accountrepo.WorkspaceFilterFromOperator(op.AcOperator))
+		//} else {
+		//	ar2 = ar
+		//}
 		uc := interactor.New(r2, g, ar2, ag, interactor.ContainerConfig{})
 		ctx = adapter.AttachUsecases(ctx, &uc)
 		ctx = adapter.AttachGateways(ctx, g)


### PR DESCRIPTION
## Summary

- Added explicit permission checks to the internal gRPC API (`server.go`) for all project mutation operations (`CreateProject`, `UpdateProject`, `DeleteProject`) and read operations (`GetProject`, `ListProjects`, `GetAsset`, `ListAssets`, `GetModel`, `ListModels`, `ListItems`).
- Private projects are now hidden (returns `NOT_FOUND`) from unauthenticated callers or callers without read access to the project.
- `ListProjects` now correctly enforces public-only filtering when the caller is not a workspace member, is unauthenticated, or provides no workspace filter.
- Switched the internal gRPC middleware (`grpc.go`) to use unfiltered repositories, since repo-level workspace/project filtering was interfering with the manual access control checks now applied at the handler layer.
- Rewrote and expanded e2e tests for `internal_project_test.go` and added new e2e suites for `internal_asset_test.go`, `internal_model_test.go`, `gql_project_test.go`, and `integration_item_test.go` to cover the new access control scenarios.

## Motivation

The internal gRPC API previously had no access control: any caller with a valid token could read or mutate any project regardless of visibility or membership. This fix brings the internal API in line with the GraphQL API's access control model.

## Testing

All new and updated e2e tests cover:
- Anonymous (no auth) access to public vs. private resources
- Workspace-member access to private resources
- Non-member access denied on private resources
- Mutation operations (create/update/delete) requiring workspace/project write permission