### PR TITLE
ci: explicit blocklist for ci workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
       - name: checkout
         uses: actions/checkout@v6
       - name: changed files for web
@@ -73,7 +75,8 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >+
       - run: echo OK
 
   build-prepare:
@@ -89,7 +92,9 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
       - uses: reearth/actions/prepare-build@ff086d73d8dfc552101f9a84c9601c5b2b4a6299 # main
         id: prepare
         with:

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -10,7 +10,15 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            golangci-lint.run:443
+            proxy.golang.org:443
+            release-assets.githubusercontent.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
       - name: checkout
         uses: actions/checkout@v6
       - name: go setup
@@ -51,7 +59,13 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            proxy.golang.org:443
+            release-assets.githubusercontent.com:443
+            sum.golang.org:443
       - name: checkout
         uses: actions/checkout@v6
       - name: go setup
@@ -75,7 +89,19 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            cli.codecov.io:443
+            github.com:443
+            ingest.codecov.io:443
+            keybase.io:443
+            o26192.ingest.us.sentry.io:443
+            proxy.golang.org:443
+            reearth-dev.auth0.com:443
+            release-assets.githubusercontent.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
       - name: checkout
         uses: actions/checkout@v6
       - name: go setup
@@ -93,4 +119,4 @@ jobs:
         uses: codecov/codecov-action@v6
         with:
           flags: server
-          file: coverage.txt
+          files: coverage.txt

--- a/.github/workflows/cleanup-pr-revision.yml
+++ b/.github/workflows/cleanup-pr-revision.yml
@@ -13,7 +13,8 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >+
       - name: Print event information
         run: |
           echo "Event name: ${{ github.event_name }}"
@@ -42,7 +43,14 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            dl.google.com:443
+            github.com:443
+            iamcredentials.googleapis.com:443
+            raw.githubusercontent.com:443
+            sts.googleapis.com:443
+            us-central1-run.googleapis.com:443
       - name: Remove Cloud Run Tag
         uses: reearth/actions/remove-cloud-run-tag@ff086d73d8dfc552101f9a84c9601c5b2b4a6299 # main
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,9 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
       - uses: actions/labeler@v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -31,7 +33,9 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
       - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,7 +59,9 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
       - run: echo OK
   assign-author:
     runs-on: ubuntu-latest
@@ -63,5 +69,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
       - uses: toshimaru/auto-author-assign@v3.0.2


### PR DESCRIPTION
# Overview

## What I've done

Changed the `harden-runner` egress policy from `audit` to `block` across all CI workflows, and added explicit `allowed-endpoints` allowlists for each job. This enforces network-level restrictions so workflows can only reach the specific external hosts they need.

Also fixed a typo in `ci_server.yml`: `file:` → `files:` for the Codecov upload step.

## What I haven't done

- Did not add allowed endpoints for jobs where none are needed (empty list, block all egress).
- Did not audit whether every allowed endpoint is strictly necessary — some (e.g. Sentry, Auth0) are pulled in by test dependencies and may be removable.

## How I tested

Workflows run on push/PR — CI pass confirms the allowlists are sufficient for normal operation.

## Screenshot

N/A (CI workflow changes only)

## Which point I want you to review particularly

- `ci_server.yml` test job: the allowed-endpoints list includes `o26192.ingest.us.sentry.io` and `reearth-dev.auth0.com`. Confirm these are expected and not leaking prod credentials through tests.
- `cleanup-pr-revision.yml` first job has an empty `allowed-endpoints` block — verify that job truly needs no outbound access, or add the missing endpoints.

## Memo

`harden-runner` in `block` mode will fail the job if any step tries to reach an unlisted host. If a future dependency adds a new outbound call, CI will break with a network error — add the host to the allowlist in that job.
