### PR TITLE
feat(web): drop project-level posting enabled flag

### DIFF
--- a/web/src/components/molecules/PublicAPI/types.ts
+++ b/web/src/components/molecules/PublicAPI/types.ts
@@ -6,7 +6,6 @@ export type PublicationSettings = {
 };
 
 export type PostingSettings = {
-  enabled: boolean;
   allowedOrigins: string[];
 };
 

--- a/web/src/components/organisms/DataConverters/project.ts
+++ b/web/src/components/organisms/DataConverters/project.ts
@@ -28,7 +28,6 @@ export const fromGraphQLProject = (project: GQLProject): Project => ({
             },
           })) ?? [],
         posting: {
-          enabled: project.accessibility.posting?.enabled ?? false,
           allowedOrigins: project.accessibility.posting?.allowedOrigins ?? [],
         },
       }

--- a/web/src/components/organisms/Project/PublicAPI/PublicAPI/hooks.ts
+++ b/web/src/components/organisms/Project/PublicAPI/PublicAPI/hooks.ts
@@ -155,13 +155,12 @@ export default () => {
       setUpdateLoading(true);
 
       try {
-        // enabled is derived from origins: an empty list means deny-all (disabled).
+        // Project posting is controlled by allowedOrigins: an empty list means deny-all.
         const projRes = await updateProjectMutation({
           variables: {
             projectId: currentProject.id,
             accessibility: {
               posting: {
-                enabled: origins.length > 0,
                 allowedOrigins: origins,
               },
             },

--- a/web/src/gql/__generated__/graphql.generated.ts
+++ b/web/src/gql/__generated__/graphql.generated.ts
@@ -1426,7 +1426,6 @@ export type Pagination = {
 export type PostingSettings = {
   __typename?: "PostingSettings";
   allowedOrigins: Array<Scalars["String"]["output"]>;
-  enabled: Scalars["Boolean"]["output"];
 };
 
 export enum PreviewType {
@@ -2348,7 +2347,6 @@ export type UpdateModelsOrderInput = {
 
 export type UpdatePostingSettingsInput = {
   allowedOrigins: Array<Scalars["String"]["input"]>;
-  enabled: Scalars["Boolean"]["input"];
 };
 
 export type UpdateProjectAccessibilityInput = {

--- a/web/src/gql/__generated__/project.generated.ts
+++ b/web/src/gql/__generated__/project.generated.ts
@@ -42,11 +42,7 @@ export type GetProjectQuery = {
               publicAssets: boolean;
             };
           }> | null;
-          posting: {
-            __typename: "PostingSettings";
-            enabled: boolean;
-            allowedOrigins: Array<string>;
-          };
+          posting: { __typename: "PostingSettings"; allowedOrigins: Array<string> };
         };
       }
     | { __typename: "Request"; id: string }
@@ -415,7 +411,6 @@ export const GetProjectDocument = {
                               selectionSet: {
                                 kind: "SelectionSet",
                                 selections: [
-                                  { kind: "Field", name: { kind: "Name", value: "enabled" } },
                                   {
                                     kind: "Field",
                                     name: { kind: "Name", value: "allowedOrigins" },

--- a/web/src/gql/queries/project.ts
+++ b/web/src/gql/queries/project.ts
@@ -27,7 +27,6 @@ export const GET_PROJECT = gql`
             }
           }
           posting {
-            enabled
             allowedOrigins
           }
         }


### PR DESCRIPTION
# Overview

Align frontend with PR #1908 which removed `enabled` from project `PostingSettings`/`UpdatePostingSettingsInput`. Project posting is now controlled solely by `allowedOrigins` (empty = deny-all); per-model posting enable stays via the model-level flag.

## Memo
