### PR TITLE
ci(server, worker): fix test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,11 +58,15 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.server == 'true'
     uses: ./.github/workflows/ci_server.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   ci-worker:
     needs: prepare
     if: needs.prepare.outputs.worker == 'true'
     uses: ./.github/workflows/ci_worker.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -111,7 +111,7 @@ jobs:
           check-latest: true
           cache-dependency-path: 'server/go.sum'
       - name: test
-        run: go test ./... -v -race -coverprofile=coverage.txt -covermode=atomic -timeout 10m
+        run: go test -v -race -coverprofile=coverage.txt -covermode=atomic -timeout 10m ./...
         working-directory: server
         env:
           REEARTH_CMS_DB: mongodb://localhost

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -119,5 +119,4 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           flags: server
-          files: coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -120,3 +120,4 @@ jobs:
         with:
           flags: server
           files: coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -1,6 +1,9 @@
 name: ci-server
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 jobs:
   ci-server-lint:

--- a/.github/workflows/ci_worker.yml
+++ b/.github/workflows/ci_worker.yml
@@ -1,6 +1,9 @@
 name: ci-worker
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 jobs:
   ci-server-lint:
     name: lint

--- a/.github/workflows/ci_worker.yml
+++ b/.github/workflows/ci_worker.yml
@@ -65,5 +65,4 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           flags: worker
-          files: coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci_worker.yml
+++ b/.github/workflows/ci_worker.yml
@@ -66,3 +66,4 @@ jobs:
         with:
           flags: worker
           files: coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci_worker.yml
+++ b/.github/workflows/ci_worker.yml
@@ -57,7 +57,7 @@ jobs:
           check-latest: true
           cache-dependency-path: 'worker/go.sum'
       - name: test
-        run: go test ./... -v -race -coverprofile=coverage.txt -covermode=atomic -timeout 10m
+        run: go test -v -race -coverprofile=coverage.txt -covermode=atomic -timeout 10m ./...
         working-directory: worker
         env:
           REEARTH_CMS_DB: mongodb://localhost
@@ -65,4 +65,4 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           flags: worker
-          file: coverage.txt
+          files: coverage.txt


### PR DESCRIPTION
## Overview

Fixes the Go test coverage reporting in the server and worker CI workflows.

## Changes

- Reorder the `go test` arguments so the package pattern (`./...`) comes after the flags, following Go's convention of placing flags before packages. This ensures `-coverprofile`, `-covermode`, and other flags are applied correctly.
- Update the worker's codecov upload step to use the `files:` input instead of the deprecated `file:` input, matching the `codecov/codecov-action@v7` API.

## Motivation

The previous argument ordering and the deprecated `file:` input prevented coverage from being collected/uploaded reliably after the bump to `codecov/codecov-action@v7`.

## Testing

CI workflows (`ci_server`, `ci_worker`) will validate the test and coverage upload steps.