### PR TITLE
feat(server): payload limits

### DIFF
--- a/server/e2e/publicapi_test.go
+++ b/server/e2e/publicapi_test.go
@@ -2,8 +2,10 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -1222,6 +1224,7 @@ func TestPublicAPI_PostItem(t *testing.T) {
 	createField(e, mIdV, "agreed", "", "agreed", false, false, false, false, "Checkbox", map[string]any{"checkbox": map[string]any{}})
 	createField(e, mIdV, "publishedAt", "", "publishedAt", false, false, false, false, "Date", map[string]any{"date": map[string]any{}})
 	createField(e, mIdV, "website", "", "website", false, false, false, false, "URL", map[string]any{"url": map[string]any{}})
+	createField(e, mIdV, "location", "", "location", false, false, false, false, "GeometryObject", map[string]any{"geometryObject": map[string]any{"defaultValue": nil, "supportedTypes": []string{"POINT", "LINESTRING"}}})
 
 	postV := func(fields map[string]any) *httpexpect.Object {
 		return e.POST("/api/p/{workspace}/{project}/{model}/items", wId.String(), pIdV, mKeyV).
@@ -1400,6 +1403,42 @@ func TestPublicAPI_PostItem(t *testing.T) {
 	})
 	t.Run("url valid value returns 201", func(t *testing.T) {
 		postVOK(map[string]any{"title": "hello", "website": "https://example.com"})
+	})
+
+	// --- URL hard limit (2,048 chars) ---
+	t.Run("url at exactly 2048 chars returns 201", func(t *testing.T) {
+		u := "https://e.com/"
+		postVOK(map[string]any{"title": "hello", "website": u + strings.Repeat("a", 2048-len(u))})
+	})
+	t.Run("url exceeding 2048 chars returns MAX_LENGTH_EXCEEDED", func(t *testing.T) {
+		assertFieldError(postV(map[string]any{"title": "hello", "website": "https://e.com/" + strings.Repeat("a", 2049)}), "website", "MAX_LENGTH_EXCEEDED")
+	})
+
+	// --- Geo hard limits (structure + size) ---
+	t.Run("geo valid structure returns 201", func(t *testing.T) {
+		postVOK(map[string]any{"title": "hello", "location": `{"type":"Point","coordinates":[1,2]}`})
+	})
+	t.Run("geo invalid structure returns INVALID_GEO_STRUCTURE", func(t *testing.T) {
+		assertFieldError(postV(map[string]any{"title": "hello", "location": `{"type":"Point"}`}), "location", "INVALID_GEO_STRUCTURE")
+	})
+	t.Run("geo exceeding 10KB returns MAX_SIZE_EXCEEDED", func(t *testing.T) {
+		coords := make([][]float64, 0, 1400)
+		for i := 0; i < 1400; i++ {
+			coords = append(coords, []float64{1.234567, 2.345678})
+		}
+		big, _ := json.Marshal(map[string]any{"type": "LineString", "coordinates": coords})
+		assertFieldError(postV(map[string]any{"title": "hello", "location": string(big)}), "location", "MAX_SIZE_EXCEEDED")
+	})
+
+	// --- payload size limit (256 KB) ---
+	t.Run("payload exceeding 256KB returns 413 before parsing", func(t *testing.T) {
+		e.POST("/api/p/{workspace}/{project}/{model}/items", wId.String(), pIdV, mKeyV).
+			WithHeader("Origin", "https://example.com").
+			WithJSON(map[string]any{"fields": map[string]any{"title": strings.Repeat("a", 270000)}}).
+			Expect().
+			Status(http.StatusRequestEntityTooLarge).
+			JSON().Object().
+			Value("code").IsEqual("payload_too_large")
 	})
 
 	// --- single vs multiple ---

--- a/server/internal/adapter/publicapi/api.go
+++ b/server/internal/adapter/publicapi/api.go
@@ -27,6 +27,9 @@ var controllerCK = contextKey("controller")
 const defaultLimit = 50
 const maxLimit = 100
 
+// maxPayloadBytes caps the raw posting request body before parsing (256 KB).
+const maxPayloadBytes = 256 * 1024
+
 func AttachController(ctx context.Context, c *Controller) context.Context {
 	return context.WithValue(ctx, controllerCK, c)
 }
@@ -266,20 +269,26 @@ func PostItem() echo.HandlerFunc {
 		ws, p, m := c.Param("workspace"), c.Param("project"), c.Param("model")
 		origin := c.Request().Header.Get("Origin")
 
+		if err := ctrl.ValidatePostingAccess(ctx, ws, p, m, origin); err != nil {
+			return postingAccessErrorResponse(c, err)
+		}
+
+		r := c.Request()
+		r.Body = http.MaxBytesReader(c.Response(), r.Body, maxPayloadBytes)
+
 		var req postItemRequest
-		if c.Request().ContentLength != 0 {
-			if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
+		if r.ContentLength != 0 {
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				var maxBytesErr *http.MaxBytesError
+				if errors.As(err, &maxBytesErr) {
+					return c.JSON(http.StatusRequestEntityTooLarge, newAPIError(codePayloadTooLarge, msgPayloadTooLarge, nil))
+				}
 				return c.JSON(http.StatusBadRequest, newAPIError(codeInvalidJSON, msgInvalidJSON, nil))
 			}
 		}
 		if req.Fields == nil {
 			req.Fields = map[string]any{}
 		}
-
-		if err := ctrl.ValidatePostingAccess(ctx, ws, p, m, origin); err != nil {
-			return postingAccessErrorResponse(c, err)
-		}
-
 		result := ctrl.PostItem(ctx, ws, p, m, req.Fields)
 		if result.Err != nil {
 			if errors.Is(result.Err, rerror.ErrNotFound) {

--- a/server/internal/adapter/publicapi/error.go
+++ b/server/internal/adapter/publicapi/error.go
@@ -55,6 +55,7 @@ var PostingErrorCodes = []string{
 	codeModelPostingDisabled,
 	codeOriginNotAllowed,
 	codeNotFound,
+	codePayloadTooLarge,
 }
 
 // newAPIError builds a uniform error body with both code and message set.

--- a/server/internal/adapter/publicapi/error.go
+++ b/server/internal/adapter/publicapi/error.go
@@ -31,6 +31,7 @@ const (
 	codeModelPostingDisabled = "model_posting_disabled"
 	codeOriginNotAllowed     = "origin_not_allowed"
 	codeNotFound             = "not_found"
+	codePayloadTooLarge      = "payload_too_large"
 )
 
 // Human-readable messages paired with each error code.
@@ -42,6 +43,7 @@ const (
 	msgNoOriginsConfigured  = "No origins are configured for posting on this project."
 	msgOriginNotAllowed     = "Origin is not allowed for posting on this project."
 	msgNotFound             = "The requested resource was not found."
+	msgPayloadTooLarge      = "Request body exceeds the allowed limit"
 )
 
 // PostingErrorCodes lists every machine-readable code the posting endpoint can

--- a/server/internal/adapter/publicapi/openapi.go
+++ b/server/internal/adapter/publicapi/openapi.go
@@ -248,6 +248,10 @@ func (c *Controller) GetOpenAPISchema(ctx context.Context, wsAlias, pAlias strin
 						"description": "Not found",
 						"content":     errorContent,
 					},
+					"413": map[string]interface{}{
+						"description": "Request body exceeds the allowed size limit",
+						"content":     errorContent,
+					},
 				},
 			}
 		}

--- a/server/internal/adapter/publicapi/payload_limit_test.go
+++ b/server/internal/adapter/publicapi/payload_limit_test.go
@@ -37,16 +37,19 @@ func TestHandler_PostItem_PayloadLimit(t *testing.T) {
 	// bodyOfSize returns a JSON posting request whose serialized length is
 	// exactly size bytes, padded via a field not present in the schema.
 	bodyOfSize := func(size int) []byte {
-		base, _ := json.Marshal(postItemRequest{Fields: map[string]any{"pad": ""}})
+		base, err := json.Marshal(postItemRequest{Fields: map[string]any{"pad": ""}})
+		require.NoError(t, err)
 		pad := size - len(base)
 		if pad < 0 {
 			pad = 0
 		}
-		b, _ := json.Marshal(postItemRequest{Fields: map[string]any{"pad": strings.Repeat("a", pad)}})
+		b, err := json.Marshal(postItemRequest{Fields: map[string]any{"pad": strings.Repeat("a", pad)}})
+		require.NoError(t, err)
 		return b
 	}
 	jsonBody := func(fields map[string]any) []byte {
-		b, _ := json.Marshal(postItemRequest{Fields: fields})
+		b, err := json.Marshal(postItemRequest{Fields: fields})
+		require.NoError(t, err)
 		return b
 	}
 

--- a/server/internal/adapter/publicapi/payload_limit_test.go
+++ b/server/internal/adapter/publicapi/payload_limit_test.go
@@ -1,0 +1,160 @@
+package publicapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+	"github.com/reearth/reearth-cms/server/pkg/id"
+	"github.com/reearth/reearth-cms/server/pkg/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func textField(key string) *schema.Field {
+	return schema.NewField(schema.NewText(nil).TypeProperty()).NewID().Key(id.NewKey(key)).MustBuild()
+}
+
+func urlField(key string) *schema.Field {
+	return schema.NewField(schema.NewURL().TypeProperty()).NewID().Key(id.NewKey(key)).MustBuild()
+}
+
+// fieldDetail mirrors a single entry of the validation_error "details" array.
+type fieldDetail struct {
+	Field string `json:"field"`
+	Code  string `json:"code"`
+}
+
+func TestHandler_PostItem_PayloadLimit(t *testing.T) {
+	t.Parallel()
+
+	const allowedOrigin = "https://example.com"
+
+	// bodyOfSize returns a JSON posting request whose serialized length is
+	// exactly size bytes, padded via a field not present in the schema.
+	bodyOfSize := func(size int) []byte {
+		base, _ := json.Marshal(postItemRequest{Fields: map[string]any{"pad": ""}})
+		pad := size - len(base)
+		if pad < 0 {
+			pad = 0
+		}
+		b, _ := json.Marshal(postItemRequest{Fields: map[string]any{"pad": strings.Repeat("a", pad)}})
+		return b
+	}
+	jsonBody := func(fields map[string]any) []byte {
+		b, _ := json.Marshal(postItemRequest{Fields: fields})
+		return b
+	}
+
+	tests := []struct {
+		name        string
+		fields      []*schema.Field
+		origin      string
+		body        []byte
+		wantStatus  int
+		wantCode    string       // expected error/code in the envelope; "" skips the envelope check (success)
+		wantMessage string       // expected human message
+		wantDetail  *fieldDetail // optional details[0] assertion
+	}{
+		{
+			name:       "body exactly at limit passes",
+			fields:     []*schema.Field{textField("title")},
+			origin:     allowedOrigin,
+			body:       bodyOfSize(maxPayloadBytes),
+			wantStatus: http.StatusAccepted,
+		},
+		{
+			name:        "body exceeding limit rejected with 413 before parsing",
+			fields:      []*schema.Field{textField("title")},
+			origin:      allowedOrigin,
+			body:        bodyOfSize(maxPayloadBytes + 1),
+			wantStatus:  http.StatusRequestEntityTooLarge,
+			wantCode:    codePayloadTooLarge,
+			wantMessage: msgPayloadTooLarge,
+		},
+		{
+			name:        "CORS rejection happens before size check",
+			fields:      []*schema.Field{textField("title")},
+			origin:      "https://evil.com", // not in allowed origins → 403, not 413
+			body:        bodyOfSize(maxPayloadBytes + 1),
+			wantStatus:  http.StatusForbidden,
+			wantCode:    codeOriginNotAllowed,
+			wantMessage: msgOriginNotAllowed,
+		},
+		{
+			name:        "field limit violation returns 400 validation shape",
+			fields:      []*schema.Field{urlField("link")},
+			origin:      allowedOrigin,
+			body:        jsonBody(map[string]any{"link": "https://e.com/" + strings.Repeat("a", 2049)}),
+			wantStatus:  http.StatusBadRequest,
+			wantCode:    codeValidationError,
+			wantMessage: msgValidationError,
+			wantDetail:  &fieldDetail{Field: "link", Code: string(schema.FieldValidationCodeMaxLengthExceeded)},
+		},
+		{
+			name:       "legitimate submission within limits reaches stub",
+			fields:     []*schema.Field{textField("title")},
+			origin:     allowedOrigin,
+			body:       jsonBody(map[string]any{"title": "hello"}),
+			wantStatus: http.StatusAccepted,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := doPost(t, tt.fields, []string{allowedOrigin}, tt.origin, tt.body)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantCode == "" {
+				return // success case — no error envelope to assert
+			}
+
+			var resp struct {
+				Error   string        `json:"error"`
+				Code    string        `json:"code"`
+				Message string        `json:"message"`
+				Details []fieldDetail `json:"details"`
+			}
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.Equal(t, tt.wantCode, resp.Error)
+			assert.Equal(t, tt.wantCode, resp.Code)
+			assert.Equal(t, tt.wantMessage, resp.Message)
+			if tt.wantDetail != nil {
+				require.Len(t, resp.Details, 1)
+				assert.Equal(t, *tt.wantDetail, resp.Details[0])
+			}
+		})
+	}
+}
+
+// doPost runs the PostItem handler against an in-memory controller.
+func doPost(t *testing.T, fields []*schema.Field, allowedOrigins []string, origin string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	ctrl, wAlias, pAlias, mKey, baseCtx := setupPostingTest(t, nil, allowedOrigins, nil, fields...)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+	}
+	rec := httptest.NewRecorder()
+
+	req = req.WithContext(AttachController(baseCtx, ctrl))
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{
+		{Name: "workspace", Value: wAlias},
+		{Name: "project", Value: pAlias},
+		{Name: "model", Value: mKey},
+	})
+
+	require.NoError(t, PostItem()(c))
+	return rec
+}

--- a/server/pkg/schema/fields_validation.go
+++ b/server/pkg/schema/fields_validation.go
@@ -1,15 +1,29 @@
 package schema
 
 import (
+	"encoding/json"
+	"unicode/utf8"
+
 	"github.com/reearth/reearth-cms/server/pkg/value"
 )
 
 type FieldValidationCode string
 
 const (
-	FieldValidationCodeRequired     FieldValidationCode = "FIELD_REQUIRED"
-	FieldValidationCodeTypeMismatch FieldValidationCode = "TYPE_MISMATCH"
-	FieldValidationCodeConstraint   FieldValidationCode = "CONSTRAINT_VIOLATION"
+	FieldValidationCodeRequired            FieldValidationCode = "FIELD_REQUIRED"
+	FieldValidationCodeTypeMismatch        FieldValidationCode = "TYPE_MISMATCH"
+	FieldValidationCodeConstraint          FieldValidationCode = "CONSTRAINT_VIOLATION"
+	FieldValidationCodeMaxLengthExceeded   FieldValidationCode = "MAX_LENGTH_EXCEEDED"
+	FieldValidationCodeMaxSizeExceeded     FieldValidationCode = "MAX_SIZE_EXCEEDED"
+	FieldValidationCodeInvalidGeoStructure FieldValidationCode = "INVALID_GEO_STRUCTURE"
+)
+
+// Global hard limits enforced on every posting request.
+const (
+	// maxURLFieldLength is the hard character cap for URL fields.
+	maxURLFieldLength = 2048
+	// maxGeoFieldBytes caps the serialized size of a single Geo field (10 KB).
+	maxGeoFieldBytes = 10 * 1024
 )
 
 type FieldValidationError struct {
@@ -47,6 +61,11 @@ func (s *Schema) ValidateFields(fields map[string]any) []FieldValidationError {
 			continue
 		}
 
+		if le := checkFieldLimits(f, raw); le != nil {
+			errs = append(errs, *le)
+			continue
+		}
+
 		// type coercion + constraint validation
 		if err := validateFieldEntry(f, raw); err != nil {
 			errs = append(errs, *err)
@@ -54,6 +73,69 @@ func (s *Schema) ValidateFields(fields map[string]any) []FieldValidationError {
 	}
 
 	return errs
+}
+
+// checkFieldLimits enforces the global hard limits for URL and Geo fields.
+// It returns the first violation found, or nil when the value is within limits.
+func checkFieldLimits(f *Field, raw any) *FieldValidationError {
+	key := f.Key().String()
+
+	for _, v := range toLimitSlice(raw) {
+		if v == nil {
+			continue
+		}
+		switch f.Type() {
+		case value.TypeURL:
+			// URL fields have a hard 2,048 character cap.
+			if s, ok := v.(string); ok && utf8.RuneCountInString(s) > maxURLFieldLength {
+				return &FieldValidationError{Field: key, Code: FieldValidationCodeMaxLengthExceeded}
+			}
+		case value.TypeGeometryObject, value.TypeGeometryEditor:
+			if e := checkGeoLimits(key, v); e != nil {
+				return e
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkGeoLimits validates a Geo field value: structure first, then size.
+func checkGeoLimits(key string, raw any) *FieldValidationError {
+	gj, ok := geoJSONString(raw)
+	if !ok {
+		return &FieldValidationError{Field: key, Code: FieldValidationCodeInvalidGeoStructure}
+	}
+	if _, valid := isValidGeoJSON(gj); !valid {
+		return &FieldValidationError{Field: key, Code: FieldValidationCodeInvalidGeoStructure}
+	}
+	if len(gj) > maxGeoFieldBytes {
+		return &FieldValidationError{Field: key, Code: FieldValidationCodeMaxSizeExceeded}
+	}
+	return nil
+}
+
+// geoJSONString returns the serialized GeoJSON for a raw value. Geo values may
+// arrive as a JSON string or as a nested JSON object; both are normalized to
+// their serialized string form.
+func geoJSONString(raw any) (string, bool) {
+	if s, ok := raw.(string); ok {
+		return s, true
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return "", false
+	}
+	return string(b), true
+}
+
+// toLimitSlice normalizes a raw field value into a slice so scalar and array
+// values can be checked uniformly.
+func toLimitSlice(raw any) []any {
+	if arr, ok := raw.([]any); ok {
+		return arr
+	}
+	return []any{raw}
 }
 
 func isEmptyFieldValue(v any) bool {

--- a/server/pkg/schema/fields_validation.go
+++ b/server/pkg/schema/fields_validation.go
@@ -106,11 +106,11 @@ func checkGeoLimits(key string, raw any) *FieldValidationError {
 	if !ok {
 		return &FieldValidationError{Field: key, Code: FieldValidationCodeInvalidGeoStructure}
 	}
-	if _, valid := isValidGeoJSON(gj); !valid {
-		return &FieldValidationError{Field: key, Code: FieldValidationCodeInvalidGeoStructure}
-	}
 	if len(gj) > maxGeoFieldBytes {
 		return &FieldValidationError{Field: key, Code: FieldValidationCodeMaxSizeExceeded}
+	}
+	if _, valid := isValidGeoJSON(gj); !valid {
+		return &FieldValidationError{Field: key, Code: FieldValidationCodeInvalidGeoStructure}
 	}
 	return nil
 }

--- a/server/pkg/schema/fields_validation_test.go
+++ b/server/pkg/schema/fields_validation_test.go
@@ -14,16 +14,19 @@ import (
 
 // bigValidGeoJSON builds a valid GeoJSON LineString whose serialized form is at
 // least size bytes by padding it with coordinate pairs.
-func bigValidGeoJSON(size int) string {
+func bigValidGeoJSON(t *testing.T, size int) string {
+	t.Helper()
 	coords := make([][]float64, 0, size/8)
-	for len(coords) < 2 || len(mustMarshalJSON(map[string]any{"type": "LineString", "coordinates": coords})) < size {
+	for len(coords) < 2 || len(mustMarshalJSON(t, map[string]any{"type": "LineString", "coordinates": coords})) < size {
 		coords = append(coords, []float64{1.234567, 2.345678})
 	}
-	return string(mustMarshalJSON(map[string]any{"type": "LineString", "coordinates": coords}))
+	return string(mustMarshalJSON(t, map[string]any{"type": "LineString", "coordinates": coords}))
 }
 
-func mustMarshalJSON(v any) []byte {
-	b, _ := json.Marshal(v)
+func mustMarshalJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
 	return b
 }
 
@@ -267,7 +270,7 @@ func TestSchema_ValidateFields(t *testing.T) {
 		{
 			name:      "geo exceeding size cap",
 			schema:    s,
-			body:      map[string]any{"title": "hello", "location": bigValidGeoJSON(maxGeoFieldBytes + 1)},
+			body:      map[string]any{"title": "hello", "location": bigValidGeoJSON(t, maxGeoFieldBytes+1)},
 			wantCodes: map[string]FieldValidationCode{"location": FieldValidationCodeMaxSizeExceeded},
 		},
 		// multiple errors at once
@@ -311,7 +314,7 @@ func TestSchema_ValidateFields_GlobalLimits(t *testing.T) {
 	t.Parallel()
 
 	overURL := "https://e.com/" + strings.Repeat("a", maxURLFieldLength)
-	overGeo := bigValidGeoJSON(maxGeoFieldBytes + 1)
+	overGeo := bigValidGeoJSON(t, maxGeoFieldBytes+1)
 
 	// buildTestSchema assigns a fresh workspace/project ID on each call, so these
 	// two schemas belong to different projects.

--- a/server/pkg/schema/fields_validation_test.go
+++ b/server/pkg/schema/fields_validation_test.go
@@ -14,20 +14,16 @@ import (
 
 // bigValidGeoJSON builds a valid GeoJSON LineString whose serialized form is at
 // least size bytes by padding it with coordinate pairs.
-func bigValidGeoJSON(t *testing.T, size int) string {
-	t.Helper()
+func bigValidGeoJSON(size int) string {
 	coords := make([][]float64, 0, size/8)
-	for len(coords) < 2 || len(mustMarshalJSON(t, map[string]any{"type": "LineString", "coordinates": coords})) < size {
+	for len(coords) < 2 || len(mustMarshalJSON(map[string]any{"type": "LineString", "coordinates": coords})) < size {
 		coords = append(coords, []float64{1.234567, 2.345678})
 	}
-	return string(mustMarshalJSON(t, map[string]any{"type": "LineString", "coordinates": coords}))
+	return string(mustMarshalJSON(map[string]any{"type": "LineString", "coordinates": coords}))
 }
 
-func mustMarshalJSON(t *testing.T, v any) []byte {
-	t.Helper()
-	b, err := json.Marshal(v)
-	require.NoError(t, err)
-	return b
+func mustMarshalJSON(v any) []byte {
+	return lo.Must(json.Marshal(v))
 }
 
 func buildTestField(key string, tp *TypeProperty, required bool) *Field {
@@ -270,7 +266,7 @@ func TestSchema_ValidateFields(t *testing.T) {
 		{
 			name:      "geo exceeding size cap",
 			schema:    s,
-			body:      map[string]any{"title": "hello", "location": bigValidGeoJSON(t, maxGeoFieldBytes+1)},
+			body:      map[string]any{"title": "hello", "location": bigValidGeoJSON(maxGeoFieldBytes + 1)},
 			wantCodes: map[string]FieldValidationCode{"location": FieldValidationCodeMaxSizeExceeded},
 		},
 		// multiple errors at once
@@ -314,7 +310,7 @@ func TestSchema_ValidateFields_GlobalLimits(t *testing.T) {
 	t.Parallel()
 
 	overURL := "https://e.com/" + strings.Repeat("a", maxURLFieldLength)
-	overGeo := bigValidGeoJSON(t, maxGeoFieldBytes+1)
+	overGeo := bigValidGeoJSON(maxGeoFieldBytes + 1)
 
 	// buildTestSchema assigns a fresh workspace/project ID on each call, so these
 	// two schemas belong to different projects.

--- a/server/pkg/schema/fields_validation_test.go
+++ b/server/pkg/schema/fields_validation_test.go
@@ -1,13 +1,31 @@
 package schema
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/reearth/reearth-cms/server/pkg/id"
 	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// bigValidGeoJSON builds a valid GeoJSON LineString whose serialized form is at
+// least size bytes by padding it with coordinate pairs.
+func bigValidGeoJSON(size int) string {
+	coords := make([][]float64, 0, size/8)
+	for len(coords) < 2 || len(mustMarshalJSON(map[string]any{"type": "LineString", "coordinates": coords})) < size {
+		coords = append(coords, []float64{1.234567, 2.345678})
+	}
+	return string(mustMarshalJSON(map[string]any{"type": "LineString", "coordinates": coords}))
+}
+
+func mustMarshalJSON(v any) []byte {
+	b, _ := json.Marshal(v)
+	return b
+}
 
 func buildTestField(key string, tp *TypeProperty, required bool) *Field {
 	k := id.NewKey(key)
@@ -44,6 +62,9 @@ func TestSchema_ValidateFields(t *testing.T) {
 		buildTestField("agreed", NewCheckbox().TypeProperty(), false),
 		buildTestField("publishedAt", NewDateTime().TypeProperty(), false),
 		buildTestField("website", NewURL().TypeProperty(), false),
+		buildTestField("location", NewGeometryObject(GeometryObjectSupportedTypeList{
+			GeometryObjectSupportedTypePoint, GeometryObjectSupportedTypeLineString,
+		}).TypeProperty(), false),
 		buildTestField("tag", NewText(nil).TypeProperty(), false),
 		buildTestFieldMultiple("tags", NewText(nil).TypeProperty(), false),
 		buildTestFieldMultiple("counts", intField.TypeProperty(), false),
@@ -213,6 +234,42 @@ func TestSchema_ValidateFields(t *testing.T) {
 			body:      map[string]any{"title": "hello", "counts": []any{float64(5), float64(999)}},
 			wantCodes: map[string]FieldValidationCode{"counts": FieldValidationCodeConstraint},
 		},
+		// URL hard limit (2,048 chars)
+		{
+			name:   "url at max length passes",
+			schema: s,
+			body:   map[string]any{"title": "hello", "website": "https://example.com/" + strings.Repeat("a", maxURLFieldLength-len("https://example.com/"))},
+		},
+		{
+			name:      "url exceeding max length",
+			schema:    s,
+			body:      map[string]any{"title": "hello", "website": "https://example.com/" + strings.Repeat("a", maxURLFieldLength)},
+			wantCodes: map[string]FieldValidationCode{"website": FieldValidationCodeMaxLengthExceeded},
+		},
+		// Geo hard limits (structure + size)
+		{
+			name:   "valid geo within bounds passes",
+			schema: s,
+			body:   map[string]any{"title": "hello", "location": `{"type":"Point","coordinates":[1,2]}`},
+		},
+		{
+			name:      "invalid geo structure",
+			schema:    s,
+			body:      map[string]any{"title": "hello", "location": `{"type":"Point"}`},
+			wantCodes: map[string]FieldValidationCode{"location": FieldValidationCodeInvalidGeoStructure},
+		},
+		{
+			name:      "non-json geo value is invalid structure",
+			schema:    s,
+			body:      map[string]any{"title": "hello", "location": "not json"},
+			wantCodes: map[string]FieldValidationCode{"location": FieldValidationCodeInvalidGeoStructure},
+		},
+		{
+			name:      "geo exceeding size cap",
+			schema:    s,
+			body:      map[string]any{"title": "hello", "location": bigValidGeoJSON(maxGeoFieldBytes + 1)},
+			wantCodes: map[string]FieldValidationCode{"location": FieldValidationCodeMaxSizeExceeded},
+		},
 		// multiple errors at once
 		{
 			name:   "multiple field errors reported together",
@@ -244,5 +301,35 @@ func TestSchema_ValidateFields(t *testing.T) {
 				assert.Equal(t, wantCode, fe.Code)
 			}
 		})
+	}
+}
+
+// TestSchema_ValidateFields_GlobalLimits asserts the hard limits are fixed and
+// global: two schemas in different workspaces/projects reject the same
+// over-limit values identically. There is no per-project configuration.
+func TestSchema_ValidateFields_GlobalLimits(t *testing.T) {
+	t.Parallel()
+
+	overURL := "https://e.com/" + strings.Repeat("a", maxURLFieldLength)
+	overGeo := bigValidGeoJSON(maxGeoFieldBytes + 1)
+
+	// buildTestSchema assigns a fresh workspace/project ID on each call, so these
+	// two schemas belong to different projects.
+	for i, s := range []*Schema{
+		buildTestSchema(buildTestField("website", NewURL().TypeProperty(), false)),
+		buildTestSchema(buildTestField("website", NewURL().TypeProperty(), false)),
+	} {
+		errs := s.ValidateFields(map[string]any{"website": overURL})
+		require.Len(t, errs, 1, "schema %d", i)
+		assert.Equal(t, FieldValidationCodeMaxLengthExceeded, errs[0].Code, "schema %d", i)
+	}
+
+	for i, s := range []*Schema{
+		buildTestSchema(buildTestField("location", NewGeometryObject(GeometryObjectSupportedTypeList{GeometryObjectSupportedTypeLineString}).TypeProperty(), false)),
+		buildTestSchema(buildTestField("location", NewGeometryObject(GeometryObjectSupportedTypeList{GeometryObjectSupportedTypeLineString}).TypeProperty(), false)),
+	} {
+		errs := s.ValidateFields(map[string]any{"location": overGeo})
+		require.Len(t, errs, 1, "schema %d", i)
+		assert.Equal(t, FieldValidationCodeMaxSizeExceeded, errs[0].Code, "schema %d", i)
 	}
 }


### PR DESCRIPTION
# Overview
Adds abuse/DoS protection to the public, unauthenticated posting endpoint POST /api/p/{workspace}/{project}/{model}/items:

Payload size cap (256 KB) enforced in the handler via http.MaxBytesReader, before JSON parsing — rejected with 413.
Per-field hard limits enforced inside the existing WP3-T2 schema validation (Schema.ValidateFields): URL fields ≤ 2,048 chars, Geo fields validated for structure and serialized size ≤ 10 KB.
Schema-defined limits (e.g. text maxLength) continue to be enforced where configured.
Limits are fixed globally — no per-project/model configuration.
Enforcement order in the handler: CORS/posting access → payload size → schema + field-limit validation → create.

Error contract
All errors share one envelope: { error, code, message, details? } (error and code are the same machine code).

413 — payload too large

`{ "error": "payload_too_large", "code": "payload_too_large", "message": "Request body exceeds the allowed limit" }`

400 — field validation failed (details lists one entry per failing field)

```
{
  "error": "validation_error",
  "code": "validation_error",
  "message": "One or more fields failed validation.",
  "details": [ { "field": "url-test", "code": "MAX_LENGTH_EXCEEDED" } ]
}
```

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
