### PR TITLE
ci(web): fix test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.web == 'true'
     uses: ./.github/workflows/ci_web.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   ci-server:
     needs: prepare

--- a/.github/workflows/ci_web.yml
+++ b/.github/workflows/ci_web.yml
@@ -1,6 +1,9 @@
 name: ci-web
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 jobs:
   validate-nginx-config:
     uses: reearth/actions/.github/workflows/validate-nginx-config.yml@4a7719ea2bfbcf3841b58eaedb01e91d3520227a
@@ -105,6 +108,7 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           flags: web
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     name: build


### PR DESCRIPTION
## Overview

The web CI's "Send coverage report" step passed an empty `token` to `codecov/codecov-action@v7`, so coverage uploads were unauthenticated. This wires the `CODECOV_TOKEN` secret through to the web coverage upload, matching the pattern already used by the server and worker CI workflows (#1912).

## Changes

- **`ci_web.yml`**: set `token: ${{ secrets.CODECOV_TOKEN }}` on the Codecov upload step (previously an empty `${{ }}`), and declare `CODECOV_TOKEN` as an optional secret on the `workflow_call` trigger so the reusable workflow can receive it.
- **`ci.yml`**: pass `CODECOV_TOKEN` down to the `ci-web` reusable workflow job.

## Testing

CI will run on this PR; verify the "Send coverage report" step uploads successfully to Codecov with the token.