### PR TITLE
fix(server): restore h2c support to fix 502 errors after deployment

### DIFF
--- a/server/internal/app/main.go
+++ b/server/internal/app/main.go
@@ -101,14 +101,9 @@ func NewServer(_ context.Context, appCtx *ApplicationContext) *WebServer {
 		}
 		address := host + ":" + port
 
-		protocols := new(http.Protocols)
-		protocols.SetHTTP1(true)
-		protocols.SetUnencryptedHTTP2(true)
-
 		w.appAddress = address
 		w.appServer = &http.Server{
-			Handler:   initEcho(appCtx),
-			Protocols: protocols,
+			Handler: initEcho(appCtx),
 		}
 	}
 
@@ -135,6 +130,13 @@ func (w *WebServer) Run(ctx context.Context) {
 				GracefulTimeout: 10 * time.Second,
 				HideBanner:      true,
 				HidePort:        true,
+				BeforeServeFunc: func(s *http.Server) error {
+					protocols := new(http.Protocols)
+					protocols.SetHTTP1(true)
+					protocols.SetUnencryptedHTTP2(true)
+					s.Protocols = protocols
+					return nil
+				},
 			}
 			if err := sc.Start(ctx, w.appServer.Handler); err != nil &&
 				!errors.Is(err, context.Canceled) &&


### PR DESCRIPTION
## Overview

Fixes 502 errors occurring after deployment, introduced by #1854.

## What

When starting the HTTP server, the `http.Protocols` config (HTTP/1.1 + unencrypted HTTP/2) was set on `w.appServer`, but the server is started via `echo.StartConfig.Start(ctx, w.appServer.Handler)`, which only consumes the handler and constructs its own internal `http.Server`. As a result, the configured `Protocols` were silently discarded and the running server fell back to HTTP/1.1 only.

This change moves the protocol configuration into `BeforeServeFunc`, so it is applied to the `http.Server` that `StartConfig` actually serves — mirroring the pattern already used in the worker.

## Why

#1854 replaced the previous `h2c.NewHandler(...)` wrapper with Go's `http.Server.Protocols` API to enable h2c. Because the wrapper used to be applied directly to the handler, h2c survived being passed to `StartConfig.Start`. After the change, h2c was no longer enabled at runtime, breaking HTTP/2 cleartext used end-to-end by Cloud Run's load balancer and causing 502 Bad Gateway responses.

The worker was unaffected because it already configures `Protocols` via `BeforeServeFunc`.

## Testing

- `go build ./...` passes
- After deployment, verify the service responds (no 502) with HTTP/2 end-to-end enabled