### PR TITLE
chore(server): remove outdated capture range variable comment in claude.md

### DIFF
--- a/server/.claude/skills/server-conventions/SKILL.md
+++ b/server/.claude/skills/server-conventions/SKILL.md
@@ -56,7 +56,7 @@ Shared helpers come from `reearthx`: `rerror`, `usecasex`, `util`, `accountdomai
 
 ## Testing (see `write-go-tests`)
 
-- Table-driven, `t.Parallel()` on both the parent and each subtest, capture `tt := tt`.
+- Table-driven, `t.Parallel()` on both the parent and each subtest.
 - Interactor tests use `internal/infrastructure/memory` repos.
 - e2e tests need `REEARTH_CMS_DB` set or they skip (`testing.Short()`).
 

--- a/server/claude.md
+++ b/server/claude.md
@@ -369,7 +369,6 @@ func TestItem_UpdateField(t *testing.T) {
     }
 
     for _, tt := range tests {
-        tt := tt // Capture range variable for parallel execution
         t.Run(tt.name, func(t *testing.T) {
             t.Parallel() // Run each subtest in parallel
 
@@ -437,7 +436,6 @@ func TestField_Validate(t *testing.T) {
     }
 
     for _, tt := range tests {
-        tt := tt
         t.Run(tt.name, func(t *testing.T) {
             t.Parallel()
 


### PR DESCRIPTION
## Summary
- Removes `tt := tt` capture-range-variable lines from the test examples in `server/claude.md`

## Motivation
Go 1.22+ changed loop variable semantics so each iteration gets its own copy of the loop variable, making the `tt := tt` workaround unnecessary. The example code in `claude.md` still showed this outdated pattern, which could mislead contributors into adding it unnecessarily in new tests.