### PR TITLE
feat(server): implement Cerbos permission checks for request operations

### DIFF
--- a/server/internal/usecase/interactor/request.go
+++ b/server/internal/usecase/interactor/request.go
@@ -69,19 +69,19 @@ func (r Request) FindByIDs(ctx context.Context, list id.RequestIDList, _ *usecas
 }
 
 func (r Request) FindByProject(ctx context.Context, pid id.ProjectID, filter interfaces.RequestFilter, sort *usecasex.Sort, pagination *usecasex.Pagination, _ *usecase.Operator) (request.List, *usecasex.PageInfo, error) {
-	reqs, pi, err := r.repos.Request.FindByProject(ctx, pid, repo.RequestFilter{
+	wid, err := workspaceIDForProject(ctx, r.repos, pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := r.checkPermissions(ctx, rbac.ActionList, wid); err != nil {
+		return nil, nil, err
+	}
+	return r.repos.Request.FindByProject(ctx, pid, repo.RequestFilter{
 		State:     filter.State,
 		Keyword:   filter.Keyword,
 		Reviewer:  filter.Reviewer,
 		CreatedBy: filter.CreatedBy,
 	}, sort, pagination)
-	if err != nil {
-		return nil, nil, err
-	}
-	if err := r.checkPermissions(ctx, rbac.ActionList, reqs.Workspaces()...); err != nil {
-		return nil, nil, err
-	}
-	return reqs, pi, nil
 }
 
 func (r Request) FindByItem(ctx context.Context, iId id.ItemID, filter *interfaces.RequestFilter, _ *usecase.Operator) (request.List, error) {
@@ -273,12 +273,16 @@ func (r Request) CloseAll(ctx context.Context, pid id.ProjectID, ids id.RequestI
 		return interfaces.ErrInvalidOperator
 	}
 
-	reqs, err := r.FindByIDs(ctx, ids, operator)
+	wid, err := workspaceIDForProject(ctx, r.repos, pid)
 	if err != nil {
 		return err
 	}
+	if err := r.checkPermissions(ctx, rbac.ActionUpdate, wid); err != nil {
+		return err
+	}
 
-	if err := r.checkPermissions(ctx, rbac.ActionUpdate, reqs.Workspaces()...); err != nil {
+	reqs, err := r.repos.Request.FindByIDs(ctx, ids)
+	if err != nil {
 		return err
 	}
 

--- a/server/internal/usecase/interactor/request.go
+++ b/server/internal/usecase/interactor/request.go
@@ -12,12 +12,15 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/event"
 	"github.com/reearth/reearth-cms/server/pkg/id"
 	"github.com/reearth/reearth-cms/server/pkg/item"
+	"github.com/reearth/reearth-cms/server/pkg/rbac"
 	"github.com/reearth/reearth-cms/server/pkg/request"
 	"github.com/reearth/reearth-cms/server/pkg/version"
+	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/i18n"
 	"github.com/reearth/reearthx/rerror"
 	"github.com/reearth/reearthx/usecasex"
 	"github.com/reearth/reearthx/util"
+	"github.com/samber/lo"
 )
 
 type Request struct {
@@ -33,21 +36,52 @@ func NewRequest(r *repo.Container, g *gateway.Container) *Request {
 	}
 }
 
+// checkPermissions enforces a Cerbos check on the request resource for the given
+// workspaces. When no workspace is supplied there is nothing to authorize
+// (e.g. an empty result set), so the check is skipped.
+func (r Request) checkPermissions(ctx context.Context, action rbac.Action, workspaceIDs ...accountdomain.WorkspaceID) error {
+	if len(workspaceIDs) == 0 {
+		return nil
+	}
+	return doCheckPermission(ctx, r.gateways, rbac.ResourceRequest, action, lo.Uniq(workspaceIDs)...)
+}
+
 func (r Request) FindByID(ctx context.Context, id id.RequestID, _ *usecase.Operator) (*request.Request, error) {
-	return r.repos.Request.FindByID(ctx, id)
+	req, err := r.repos.Request.FindByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.checkPermissions(ctx, rbac.ActionRead, req.Workspace()); err != nil {
+		return nil, err
+	}
+	return req, nil
 }
 
 func (r Request) FindByIDs(ctx context.Context, list id.RequestIDList, _ *usecase.Operator) (request.List, error) {
-	return r.repos.Request.FindByIDs(ctx, list)
+	reqs, err := r.repos.Request.FindByIDs(ctx, list)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.checkPermissions(ctx, rbac.ActionList, reqs.Workspaces()...); err != nil {
+		return nil, err
+	}
+	return reqs, nil
 }
 
 func (r Request) FindByProject(ctx context.Context, pid id.ProjectID, filter interfaces.RequestFilter, sort *usecasex.Sort, pagination *usecasex.Pagination, _ *usecase.Operator) (request.List, *usecasex.PageInfo, error) {
-	return r.repos.Request.FindByProject(ctx, pid, repo.RequestFilter{
+	reqs, pi, err := r.repos.Request.FindByProject(ctx, pid, repo.RequestFilter{
 		State:     filter.State,
 		Keyword:   filter.Keyword,
 		Reviewer:  filter.Reviewer,
 		CreatedBy: filter.CreatedBy,
 	}, sort, pagination)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := r.checkPermissions(ctx, rbac.ActionList, reqs.Workspaces()...); err != nil {
+		return nil, nil, err
+	}
+	return reqs, pi, nil
 }
 
 func (r Request) FindByItem(ctx context.Context, iId id.ItemID, filter *interfaces.RequestFilter, _ *usecase.Operator) (request.List, error) {
@@ -60,7 +94,14 @@ func (r Request) FindByItem(ctx context.Context, iId id.ItemID, filter *interfac
 			CreatedBy: filter.CreatedBy,
 		}
 	}
-	return r.repos.Request.FindByItems(ctx, id.ItemIDList{iId}, f)
+	reqs, err := r.repos.Request.FindByItems(ctx, id.ItemIDList{iId}, f)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.checkPermissions(ctx, rbac.ActionList, reqs.Workspaces()...); err != nil {
+		return nil, err
+	}
+	return reqs, nil
 }
 
 func (r Request) Create(ctx context.Context, param interfaces.CreateRequestParam, operator *usecase.Operator) (*request.Request, error) {
@@ -75,6 +116,10 @@ func (r Request) Create(ctx context.Context, param interfaces.CreateRequestParam
 		}
 		ws, err := r.repos.Workspace.FindByID(ctx, p.Workspace())
 		if err != nil {
+			return nil, err
+		}
+
+		if err := r.checkPermissions(ctx, rbac.ActionCreate, ws.ID()); err != nil {
 			return nil, err
 		}
 
@@ -135,6 +180,10 @@ func (r Request) Update(ctx context.Context, param interfaces.UpdateRequestParam
 
 		ws, err := r.repos.Workspace.FindByID(ctx, req.Workspace())
 		if err != nil {
+			return nil, err
+		}
+
+		if err := r.checkPermissions(ctx, rbac.ActionUpdate, req.Workspace()); err != nil {
 			return nil, err
 		}
 
@@ -229,6 +278,10 @@ func (r Request) CloseAll(ctx context.Context, pid id.ProjectID, ids id.RequestI
 		return err
 	}
 
+	if err := r.checkPermissions(ctx, rbac.ActionUpdate, reqs.Workspaces()...); err != nil {
+		return err
+	}
+
 	reqs.UpdateStatus(request.StateClosed)
 	return r.repos.Request.SaveAll(ctx, pid, reqs)
 }
@@ -245,6 +298,9 @@ func (r Request) Approve(ctx context.Context, requestID id.RequestID, operator *
 		}
 		if !operator.IsOwningWorkspace(req.Workspace()) && !operator.IsMaintainingWorkspace(req.Workspace()) {
 			return nil, interfaces.ErrInvalidOperator
+		}
+		if err := r.checkPermissions(ctx, rbac.ActionApprove, req.Workspace()); err != nil {
+			return nil, err
 		}
 		// only reviewers can approve
 		if !req.Reviewers().Has(*operator.AcOperator.User) {

--- a/server/internal/usecase/interactor/request_test.go
+++ b/server/internal/usecase/interactor/request_test.go
@@ -228,9 +228,10 @@ func TestRequest_FindByIDs(t *testing.T) {
 }
 
 func TestRequest_FindByProject(t *testing.T) {
-	pid := id.NewProjectID()
 	item, _ := request.NewItemWithVersion(id.NewItemID(), version.New().OrRef())
 	wid := accountdomain.NewWorkspaceID()
+	prj := project.New().NewID().Workspace(wid).MustBuild()
+	pid := prj.ID()
 
 	req1 := request.New().
 		NewID().
@@ -317,7 +318,15 @@ func TestRequest_FindByProject(t *testing.T) {
 		{
 			name:           "mock error",
 			mockRequestErr: true,
-			wantErr:        errors.New("test"),
+			args: struct {
+				pid      id.ProjectID
+				filter   interfaces.RequestFilter
+				operator *usecase.Operator
+			}{
+				pid:      pid,
+				operator: op,
+			},
+			wantErr: errors.New("test"),
 		},
 	}
 
@@ -331,6 +340,7 @@ func TestRequest_FindByProject(t *testing.T) {
 			if tc.mockRequestErr {
 				memory.SetRequestError(db.Request, tc.wantErr)
 			}
+			assert.NoError(t, db.Project.Save(ctx, prj))
 			for _, p := range tc.seeds {
 				err := db.Request.Save(ctx, p)
 				assert.NoError(t, err)

--- a/server/pkg/request/list.go
+++ b/server/pkg/request/list.go
@@ -1,6 +1,20 @@
 package request
 
+import (
+	"github.com/reearth/reearthx/account/accountdomain"
+	"github.com/samber/lo"
+)
+
 type List []*Request
+
+func (l List) Workspaces() accountdomain.WorkspaceIDList {
+	return lo.Uniq(lo.FilterMap(l, func(r *Request, _ int) (accountdomain.WorkspaceID, bool) {
+		if r == nil {
+			return accountdomain.WorkspaceID{}, false
+		}
+		return r.Workspace(), true
+	}))
+}
 
 func (l List) UpdateStatus(state State) {
 	for _, request := range l {

--- a/server/pkg/request/list_test.go
+++ b/server/pkg/request/list_test.go
@@ -39,3 +39,47 @@ func TestList_CloseAll(t *testing.T) {
 		assert.Equal(t, StateClosed, request.State())
 	}
 }
+
+func TestList_Workspaces(t *testing.T) {
+	wid1 := accountdomain.NewWorkspaceID()
+	wid2 := accountdomain.NewWorkspaceID()
+
+	tests := []struct {
+		name string
+		list List
+		want accountdomain.WorkspaceIDList
+	}{
+		{
+			name: "nil list",
+			list: nil,
+			want: accountdomain.WorkspaceIDList{},
+		},
+		{
+			name: "empty list",
+			list: List{},
+			want: accountdomain.WorkspaceIDList{},
+		},
+		{
+			name: "single workspace deduplicated",
+			list: List{&Request{workspace: wid1}, &Request{workspace: wid1}},
+			want: accountdomain.WorkspaceIDList{wid1},
+		},
+		{
+			name: "multiple workspaces deduplicated",
+			list: List{&Request{workspace: wid1}, &Request{workspace: wid1}, &Request{workspace: wid2}},
+			want: accountdomain.WorkspaceIDList{wid1, wid2},
+		},
+		{
+			name: "nil entries are skipped",
+			list: List{nil, &Request{workspace: wid1}, nil, &Request{workspace: wid2}},
+			want: accountdomain.WorkspaceIDList{wid1, wid2},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.list.Workspaces())
+		})
+	}
+}


### PR DESCRIPTION
# Overview

Add Cerbos-based permission checks to the request interactor so that request operations are authorized against the workspace-level RBAC policies, following the same pattern already applied to the model and project interactors (#1819).

## What I've done

- Added a `checkPermissions` helper to the request interactor that runs `doCheckPermission` on the `request` resource for one or more workspaces (deduplicated, skipped when there is no workspace to authorize, e.g. empty result sets).
- Enforced permission checks on request operations:
  - `FindByID` → `read`
  - `FindByIDs`, `FindByProject`, `FindByItem` → `list`
  - `Create` → `create`
  - `Update`, `CloseAll` → `update`
  - `Approve` → `approve`
- Added `request.List.Workspaces()` to collect the unique workspace IDs of a request list (nil-safe), used by the list-returning operations.

## What I haven't done

- `Delete` and other operations not listed above are unchanged.
- Existing role-based checks (owner/maintainer/reviewer validations) are kept as-is; Cerbos checks run in addition to them.

## How I tested

- Added unit tests for `request.List.Workspaces()` covering nil/empty lists, deduplication, and nil entries.
- Ran existing server tests.

## Screenshot

## Which point I want you to review particularly

- Placement of the checks relative to the existing operator-based validations (Cerbos check runs after fetching the resource / resolving the workspace).

## Memo