### PR TITLE
feat(server): integrate Cerbos permission checks for thread operations

### DIFF
--- a/server/internal/usecase/interactor/thread.go
+++ b/server/internal/usecase/interactor/thread.go
@@ -8,7 +8,10 @@ import (
 	"github.com/reearth/reearth-cms/server/internal/usecase/interfaces"
 	"github.com/reearth/reearth-cms/server/internal/usecase/repo"
 	"github.com/reearth/reearth-cms/server/pkg/id"
+	"github.com/reearth/reearth-cms/server/pkg/rbac"
 	"github.com/reearth/reearth-cms/server/pkg/thread"
+	"github.com/reearth/reearthx/account/accountdomain"
+	"github.com/samber/lo"
 )
 
 type Thread struct {
@@ -23,18 +26,42 @@ func NewThread(r *repo.Container, g *gateway.Container) interfaces.Thread {
 	}
 }
 
+// checkPermissions enforces a Cerbos check on the thread resource for the given
+// workspaces. When no workspace is supplied there is nothing to authorize
+// (e.g. an empty result set), so the check is skipped.
+func (i *Thread) checkPermissions(ctx context.Context, action rbac.Action, workspaceIDs ...accountdomain.WorkspaceID) error {
+	if len(workspaceIDs) == 0 {
+		return nil
+	}
+	return doCheckPermission(ctx, i.gateways, rbac.ResourceThread, action, lo.Uniq(workspaceIDs)...)
+}
+
 func (i *Thread) FindByID(ctx context.Context, aid id.ThreadID, op *usecase.Operator) (*thread.Thread, error) {
 	return Run1(
 		ctx, op, i.repos,
 		Usecase().Transaction(),
 		func(ctx context.Context) (*thread.Thread, error) {
-			return i.repos.Thread.FindByID(ctx, aid)
+			th, err := i.repos.Thread.FindByID(ctx, aid)
+			if err != nil {
+				return nil, err
+			}
+			if err := i.checkPermissions(ctx, rbac.ActionRead, th.Workspace()); err != nil {
+				return nil, err
+			}
+			return th, nil
 		},
 	)
 }
 
 func (i *Thread) FindByIDs(ctx context.Context, threads []id.ThreadID, operator *usecase.Operator) (thread.List, error) {
-	return i.repos.Thread.FindByIDs(ctx, threads)
+	th, err := i.repos.Thread.FindByIDs(ctx, threads)
+	if err != nil {
+		return nil, err
+	}
+	if err := i.checkPermissions(ctx, rbac.ActionRead, thread.List(th).Workspaces()...); err != nil {
+		return nil, err
+	}
+	return th, nil
 }
 
 func (i *Thread) CreateThreadWithComment(ctx context.Context, input interfaces.CreateThreadWithCommentInput, op *usecase.Operator) (*thread.Thread, *thread.Comment, error) {
@@ -42,6 +69,9 @@ func (i *Thread) CreateThreadWithComment(ctx context.Context, input interfaces.C
 		ctx, op, i.repos,
 		Usecase().WithWritableWorkspaces(input.WorkspaceID).Transaction(),
 		func(ctx context.Context) (*thread.Thread, *thread.Comment, error) {
+			if err := i.checkPermissions(ctx, rbac.ActionCreate, input.WorkspaceID); err != nil {
+				return nil, nil, err
+			}
 			th, err := thread.New().NewID().Workspace(input.WorkspaceID).Build()
 			if err != nil {
 				return nil, nil, err
@@ -132,6 +162,10 @@ func (i *Thread) addComment(ctx context.Context, thid id.ThreadID, content strin
 		return nil, nil, interfaces.ErrOperationDenied
 	}
 
+	if err := i.checkPermissions(ctx, rbac.ActionComment, th.Workspace()); err != nil {
+		return nil, nil, err
+	}
+
 	comment := thread.NewComment(thread.NewCommentID(), op.Operator(), content)
 	if err := th.AddComment(comment); err != nil {
 		return nil, nil, err
@@ -159,6 +193,10 @@ func (i *Thread) UpdateComment(ctx context.Context, thid id.ThreadID, cid id.Com
 
 			if !op.IsWritableWorkspace(th.Workspace()) {
 				return nil, nil, interfaces.ErrOperationDenied
+			}
+
+			if err := i.checkPermissions(ctx, rbac.ActionComment, th.Workspace()); err != nil {
+				return nil, nil, err
 			}
 
 			if err := th.UpdateComment(cid, content); err != nil {
@@ -189,6 +227,10 @@ func (i *Thread) DeleteComment(ctx context.Context, thid id.ThreadID, cid id.Com
 
 			if !op.IsWritableWorkspace(th.Workspace()) {
 				return nil, interfaces.ErrOperationDenied
+			}
+
+			if err := i.checkPermissions(ctx, rbac.ActionComment, th.Workspace()); err != nil {
+				return nil, err
 			}
 
 			if err := th.DeleteComment(cid); err != nil {

--- a/server/pkg/thread/list.go
+++ b/server/pkg/thread/list.go
@@ -3,11 +3,21 @@ package thread
 import (
 	"slices"
 
+	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/util"
 	"github.com/samber/lo"
 )
 
 type List []*Thread
+
+func (l List) Workspaces() accountdomain.WorkspaceIDList {
+	return lo.Uniq(lo.FilterMap(l, func(th *Thread, _ int) (accountdomain.WorkspaceID, bool) {
+		if th == nil {
+			return accountdomain.WorkspaceID{}, false
+		}
+		return th.Workspace(), true
+	}))
+}
 
 func (l List) SortByID() List {
 	m := slices.Clone(l)

--- a/server/pkg/thread/list_test.go
+++ b/server/pkg/thread/list_test.go
@@ -35,3 +35,47 @@ func TestList_Clone(t *testing.T) {
 	assert.Equal(t, list, got)
 	assert.NotSame(t, list[0], got[0])
 }
+
+func TestList_Workspaces(t *testing.T) {
+	wid1 := accountdomain.NewWorkspaceID()
+	wid2 := accountdomain.NewWorkspaceID()
+
+	tests := []struct {
+		name string
+		list List
+		want accountdomain.WorkspaceIDList
+	}{
+		{
+			name: "nil list",
+			list: nil,
+			want: accountdomain.WorkspaceIDList{},
+		},
+		{
+			name: "empty list",
+			list: List{},
+			want: accountdomain.WorkspaceIDList{},
+		},
+		{
+			name: "single workspace deduplicated",
+			list: List{&Thread{workspace: wid1}, &Thread{workspace: wid1}},
+			want: accountdomain.WorkspaceIDList{wid1},
+		},
+		{
+			name: "multiple workspaces deduplicated",
+			list: List{&Thread{workspace: wid1}, &Thread{workspace: wid1}, &Thread{workspace: wid2}},
+			want: accountdomain.WorkspaceIDList{wid1, wid2},
+		},
+		{
+			name: "nil entries are skipped",
+			list: List{nil, &Thread{workspace: wid1}, nil, &Thread{workspace: wid2}},
+			want: accountdomain.WorkspaceIDList{wid1, wid2},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.list.Workspaces())
+		})
+	}
+}


### PR DESCRIPTION
## Overview

This PR extends the Cerbos-based permission checking (introduced for model and project in #1819) to thread operations, so that thread and comment access is authorized against the workspace-level RBAC policies.

## What's changed

- **`Thread` interactor** (`server/internal/usecase/interactor/thread.go`):
  - Added a `checkPermissions` helper that runs a Cerbos check on the `thread` resource for the given workspace IDs (deduplicated; skipped when there is no workspace to authorize, e.g. an empty result set).
  - `FindByID` / `FindByIDs`: check `read` action against the workspace(s) of the fetched thread(s).
  - `CreateThreadWithComment`: check `create` action against the target workspace before building the thread.
  - `addComment` / `UpdateComment` / `DeleteComment`: check `comment` action against the thread's workspace.
- **`thread.List`** (`server/pkg/thread/list.go`):
  - Added a `Workspaces()` helper that returns the deduplicated workspace IDs of a thread list, skipping nil entries.
- **Tests** (`server/pkg/thread/list_test.go`):
  - Added table-driven tests for `List.Workspaces()` covering nil/empty lists, deduplication, and nil entries.

## Why

Thread and comment operations previously relied only on operator/workspace checks in the usecase layer. With the ongoing Cerbos integration, these operations should also be validated against the centralized permission policies, consistent with the model and project interactors.

## Testing

- Unit tests added for `List.Workspaces()`.
- Run with: `cd server && go test ./pkg/thread/... ./internal/usecase/interactor/...`