### PR TITLE
fix: strip trailing slash from allowed posting origins

### DIFF
--- a/server/pkg/project/posting_settings.go
+++ b/server/pkg/project/posting_settings.go
@@ -21,7 +21,9 @@ func NewPostingSettings(enabled bool, allowedOrigins []string) (*PostingSettings
 		origins = []string{}
 	} else {
 		origins = make([]string, len(allowedOrigins))
-		copy(origins, allowedOrigins)
+		for i, o := range allowedOrigins {
+			origins[i] = strings.TrimSuffix(o, "/")
+		}
 	}
 	if err := ValidateOrigins(origins); err != nil {
 		return nil, err

--- a/server/pkg/project/posting_settings_test.go
+++ b/server/pkg/project/posting_settings_test.go
@@ -116,6 +116,18 @@ func TestNewPostingSettings(t *testing.T) {
 			allowedOrigins: []string{"*"},
 			wantErr:        true,
 		},
+		{
+			name:           "trailing slash is stripped before validation and storage",
+			enabled:        true,
+			allowedOrigins: []string{"https://example.com/"},
+			wantOrigins:    []string{"https://example.com"},
+		},
+		{
+			name:           "trailing slash stripped alongside untouched origins",
+			enabled:        true,
+			allowedOrigins: []string{"https://a.com/", "https://b.com"},
+			wantOrigins:    []string{"https://a.com", "https://b.com"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/web/src/components/molecules/PublicAPI/Posting/AllowedOrigins/index.test.tsx
+++ b/web/src/components/molecules/PublicAPI/Posting/AllowedOrigins/index.test.tsx
@@ -39,6 +39,18 @@ describe("AllowedOrigins", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  test("strips a trailing slash before adding the origin", async () => {
+    const { onChange } = renderComponent({ origins: [] });
+    await user.type(screen.getByRole("combobox"), "https://example.com/,");
+    expect(onChange).toHaveBeenCalledWith(["https://example.com"]);
+  });
+
+  test("does not add a duplicate when the normalized origin already exists", async () => {
+    const { onChange } = renderComponent({ origins: ["https://example.com"] });
+    await user.type(screen.getByRole("combobox"), "https://example.com/,");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   test("clears all origins, and the clear button is disabled when empty", async () => {
     const { onChange, rerender } = renderComponent({ origins: ["a.com"] });
     await user.click(screen.getByRole("button", { name: t("Clear all") }));

--- a/web/src/components/molecules/PublicAPI/Posting/AllowedOrigins/index.tsx
+++ b/web/src/components/molecules/PublicAPI/Posting/AllowedOrigins/index.tsx
@@ -37,7 +37,10 @@ const AllowedOrigins: React.FC<Props> = ({ origins, onChange }) => {
         return;
       }
 
-      onChange([...origins, added]);
+      const normalized = added.replace(/\/+$/, "");
+      if (origins.includes(normalized)) return;
+
+      onChange([...origins, normalized]);
     },
     [onChange, origins, t],
   );


### PR DESCRIPTION
# Overview

An origin saved with a trailing slash (e.g. https://example.com/) never matched real browser Origin headers (which never include one), silently blocking legitimate requests. Normalizes the trailing slash away on both save paths — backend (NewPostingSettings) and the frontend allowed-origins UI — before validation/storage.