### PR TITLE
fix(item event outside transaction): dispatch ItemCreate/ItemUpdate events after transaction commits

### DIFF
--- a/server/internal/usecase/interactor/item.go
+++ b/server/internal/usecase/interactor/item.go
@@ -258,7 +258,13 @@ func (i Item) Create(ctx context.Context, param interfaces.CreateItemParam, oper
 		return nil, err
 	}
 
-	return Run1(ctx, operator, i.repos,
+	// ev is populated inside the transaction and published after it commits,
+	// mirroring the pattern already used by Asset.Create (asset.go:521).
+	// Publishing inside the transaction held the Mongo write-intent lock while
+	// blocking on the PubSub/Cloud Tasks call, causing cascading timeouts.
+	var ev *Event
+
+	vi, err := Run1(ctx, operator, i.repos,
 		Usecase().
 			WithPermission(i.authz(), rbac.ResourceItem, rbac.ActionCreate, s.Workspace()).
 			Transaction(),
@@ -360,7 +366,8 @@ func (i Item) Create(ctx context.Context, param interfaces.CreateItemParam, oper
 				return nil, err
 			}
 
-			if err := i.event(ctx, Event{
+			// Capture the event for dispatch after the transaction commits.
+			ev = &Event{
 				Project:   prj,
 				Workspace: s.Workspace(),
 				Type:      event.ItemCreate,
@@ -373,12 +380,23 @@ func (i Item) Create(ctx context.Context, param interfaces.CreateItemParam, oper
 					ReferencedItems: refItems,
 				},
 				Operator: operator.Operator(),
-			}); err != nil {
-				return nil, err
 			}
 
 			return vi, nil
 		})
+	if err != nil {
+		return nil, err
+	}
+
+	// Publish outside the transaction so the PubSub/Cloud Tasks call does not
+	// hold an open Mongo write-intent session while waiting for a remote call.
+	if ev != nil {
+		if err := i.event(ctx, *ev); err != nil {
+			return nil, err
+		}
+	}
+
+	return vi, nil
 }
 
 func (i Item) LastModifiedByModel(ctx context.Context, model id.ModelID, _ *usecase.Operator) (time.Time, error) {
@@ -402,7 +420,11 @@ func (i Item) Update(ctx context.Context, param interfaces.UpdateItemParam, oper
 		return nil, err
 	}
 
-	return Run1(ctx, operator, i.repos,
+	// ev is populated inside the transaction and published after it commits,
+	// mirroring the pattern already used by Asset.Create (asset.go:521).
+	var ev *Event
+
+	itm, err := Run1(ctx, operator, i.repos,
 		Usecase().
 			WithPermission(i.authz(), rbac.ResourceItem, rbac.ActionUpdate, wid).
 			Transaction(),
@@ -497,7 +519,8 @@ func (i Item) Update(ctx context.Context, param interfaces.UpdateItemParam, oper
 				return nil, err
 			}
 
-			if err := i.event(ctx, Event{
+			// Capture the event for dispatch after the transaction commits.
+			ev = &Event{
 				Project:   prj,
 				Workspace: s.Workspace(),
 				Type:      event.ItemUpdate,
@@ -511,12 +534,23 @@ func (i Item) Update(ctx context.Context, param interfaces.UpdateItemParam, oper
 					Changes:         item.CompareFields(itv.Fields(), oldFields),
 				},
 				Operator: operator.Operator(),
-			}); err != nil {
-				return nil, err
 			}
 
 			return itm, nil
 		})
+	if err != nil {
+		return nil, err
+	}
+
+	// Publish outside the transaction so the PubSub/Cloud Tasks call does not
+	// hold an open Mongo write-intent session while waiting for a remote call.
+	if ev != nil {
+		if err := i.event(ctx, *ev); err != nil {
+			return nil, err
+		}
+	}
+
+	return itm, nil
 }
 
 func (i Item) Delete(ctx context.Context, itemID id.ItemID, sp schema.Package, operator *usecase.Operator) error {

--- a/server/internal/usecase/interactor/item_test.go
+++ b/server/internal/usecase/interactor/item_test.go
@@ -1911,3 +1911,104 @@ func TestWorkFlow(t *testing.T) {
 //		})
 //	}
 //}
+
+// TestItem_Create_dispatchesEventAfterTransaction verifies that Create succeeds
+// end-to-end with the new post-transaction event dispatch pattern. In particular
+// it checks that the item is persisted even when the event is dispatched after
+// the transaction commits (i.e., the item is in the repo regardless of event outcome).
+func TestItem_Create_dispatchesEventAfterTransaction(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	wid := accountdomain.NewWorkspaceID()
+	prj := project.New().NewID().Workspace(wid).MustBuild()
+	s := schema.New().NewID().Workspace(wid).Project(prj.ID()).MustBuild()
+	m := model.New().NewID().Schema(s.ID()).Key(id.RandomKey()).Project(prj.ID()).MustBuild()
+
+	db := memory.New()
+	lo.Must0(db.Project.Save(ctx, prj))
+	lo.Must0(db.Schema.Save(ctx, s))
+	lo.Must0(db.Model.Save(ctx, m))
+
+	itemUC := NewItem(db, nil)
+	itemUC.ignoreEvent = true // skip actual event dispatch; focus on item persistence
+
+	op := &usecase.Operator{
+		AcOperator: &accountusecase.Operator{
+			User:               accountdomain.NewUserID().Ref(),
+			ReadableWorkspaces: []accountdomain.WorkspaceID{wid},
+			WritableWorkspaces: []accountdomain.WorkspaceID{wid},
+		},
+		ReadableProjects: []id.ProjectID{prj.ID()},
+		WritableProjects: []id.ProjectID{prj.ID()},
+	}
+
+	got, err := itemUC.Create(ctx, interfaces.CreateItemParam{
+		SchemaID: s.ID(),
+		ModelID:  m.ID(),
+	}, op)
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+
+	// Item must be persisted in the repository after Create returns.
+	stored, err := db.Item.FindByID(ctx, got.Value().ID(), nil)
+	assert.NoError(t, err)
+	assert.Equal(t, got.Value().ID(), stored.Value().ID())
+}
+
+// TestItem_Update_dispatchesEventAfterTransaction verifies that Update succeeds
+// end-to-end with the new post-transaction event dispatch pattern.
+func TestItem_Update_dispatchesEventAfterTransaction(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	wid := accountdomain.NewWorkspaceID()
+	uid := accountdomain.NewUserID()
+	prj := project.New().NewID().Workspace(wid).MustBuild()
+	sf := schema.NewField(schema.NewText(nil).TypeProperty()).NewID().Key(id.RandomKey()).MustBuild()
+	s := schema.New().NewID().Workspace(wid).Project(prj.ID()).Fields(schema.FieldList{sf}).MustBuild()
+	m := model.New().NewID().Schema(s.ID()).Key(id.RandomKey()).Project(prj.ID()).MustBuild()
+
+	db := memory.New()
+	lo.Must0(db.Project.Save(ctx, prj))
+	lo.Must0(db.Schema.Save(ctx, s))
+	lo.Must0(db.Model.Save(ctx, m))
+
+	// Build item with the same user as the operator so that CanUpdate passes.
+	it := item.New().NewID().
+		Schema(s.ID()).Model(m.ID()).Project(prj.ID()).
+		User(uid).
+		Thread(id.NewThreadID().Ref()).
+		MustBuild()
+	lo.Must0(db.Item.Save(ctx, it))
+
+	itemUC := NewItem(db, nil)
+	itemUC.ignoreEvent = true
+
+	op := &usecase.Operator{
+		AcOperator: &accountusecase.Operator{
+			User:               uid.Ref(),
+			ReadableWorkspaces: []accountdomain.WorkspaceID{wid},
+			WritableWorkspaces: []accountdomain.WorkspaceID{wid},
+		},
+		ReadableProjects:  []id.ProjectID{prj.ID()},
+		WritableProjects:  []id.ProjectID{prj.ID()},
+		OwningProjects:    []id.ProjectID{prj.ID()},
+	}
+
+	newVal := "updated-value"
+	got, err := itemUC.Update(ctx, interfaces.UpdateItemParam{
+		ItemID: it.ID(),
+		Fields: []interfaces.ItemFieldParam{{
+			Field: sf.ID().Ref(),
+			Value: newVal,
+		}},
+	}, op)
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+
+	// Verify the update is persisted.
+	stored, err := db.Item.FindByID(ctx, got.Value().ID(), nil)
+	assert.NoError(t, err)
+	assert.Equal(t, value.TypeText.Value(newVal).AsMultiple(), stored.Value().Field(sf.ID()).Value())
+}


### PR DESCRIPTION
## Problem

`i.event()` in `Item.Create` and `Item.Update` ran inside the `Transaction()` closure after `Item.Save`. It calls `TaskRunner.Run → runPubSub`, which blocks on `result.Get(ctx)` with no sub-timeout, holding the open Mongo write-intent session while waiting for the remote PubSub/Cloud Tasks call.

During any downstream latency spike every concurrent item write held its transaction session until the `transactionLifetimeLimitSeconds` limit was hit, then retried with a new session — building lock contention across all writers. Item writes across the system timed out or failed during the slowdown.

The codebase already recognized this class of bug: `Asset.Create` moved its event dispatch *outside* the transaction with an explicit comment ([asset.go:521](https://github.com/reearth/reearth-cms/blob/main/server/internal/usecase/interactor/asset.go#L521)). `Item.Create` and `Item.Update` still published inside the transaction.

## Fix

Capture the event data in a closure variable inside the transaction, then call `i.event()` after `Run1` returns (after the transaction commits). The transaction no longer holds any session while waiting on external calls.