### PR TITLE
fix(async import memory): stream JSON/CSV import items without two-pass materialization

### DIFF
--- a/server/internal/usecase/interactor/item_import.go
+++ b/server/internal/usecase/interactor/item_import.go
@@ -452,58 +452,70 @@ func (i Item) importWithProgress(ctx context.Context, j *job.Job, param interfac
 		return res.Into(), fmt.Errorf("expected array start, got %v", t)
 	}
 
-	// First pass: decode all items to get total count
-	allItems := make([]map[string]any, 0)
-	for decoder.More() {
-		var obj map[string]any
-		if err := decoder.Decode(&obj); err != nil {
-			return res.Into(), fmt.Errorf("error decoding JSON object: %v", err)
-		}
-		allItems = append(allItems, obj)
-	}
-	totalCount := len(allItems)
-
-	// Second pass: process items in chunks
+	// Stream items in chunks directly from the decoder without a first pass that
+	// would materialize all items into memory. Progress is reported as processed
+	// count; the total is unknown until the stream ends, so Total is set to 0
+	// during streaming and updated in the final progress publish.
 	processed := 0
-	for start := 0; start < totalCount; start += chunkSize {
-		// Check if job was cancelled
+	chunk := make([]map[string]any, 0, chunkSize)
+
+	flushChunk := func() error {
+		if len(chunk) == 0 {
+			return nil
+		}
+
+		// Check if job was cancelled before processing each chunk.
 		currentJob, _ := i.repos.Job.FindByID(ctx, j.ID())
 		if currentJob != nil && currentJob.IsCancelled() {
-			return res.Into(), fmt.Errorf("job cancelled")
+			return fmt.Errorf("job cancelled")
 		}
 
-		end := min(start+chunkSize, totalCount)
-		jsonChunk := allItems[start:end]
-		chunkLen := len(jsonChunk)
-
-		items, err := itemsParamsFrom(jsonChunk, param.Format == interfaces.ImportFormatTypeGeoJSON, param.GeoField, param.SP)
+		items, err := itemsParamsFrom(chunk, param.Format == interfaces.ImportFormatTypeGeoJSON, param.GeoField, param.SP)
 		if err != nil {
-			return res.Into(), err
+			return err
 		}
-		err = i.saveChunk(ctx, prj, m, s, param, items, &res, operator)
-		if err != nil {
-			return res.Into(), err
+		if err := i.saveChunk(ctx, prj, m, s, param, items, &res, operator); err != nil {
+			return err
 		}
 
-		processed += chunkLen
+		processed += len(chunk)
+		chunk = chunk[:0] // reset slice, keep backing array
 
-		// Publish progress
-		progress := job.NewProgress(processed, totalCount)
+		// Report progress with unknown total (0) during streaming.
+		progress := job.NewProgress(processed, 0)
 		state := job.NewState(job.StatusInProgress, &progress, "")
 		if i.gateways.JobPubSub != nil {
 			if err := i.gateways.JobPubSub.Publish(ctx, j.ID(), state); err != nil {
 				log.Warnf("item: failed to publish job %s progress: %v", j.ID(), err)
 			}
 		}
-
-		// Update job progress
 		j.SetProgress(progress)
 		if err := i.repos.Job.Save(ctx, j); err != nil {
 			log.Errorf("item: import job %s failed to update progress: %v", j.ID(), err)
 		}
 
-		log.Printf("chunk with %d items saved.", chunkLen)
+		log.Printf("chunk with %d items saved.", len(items))
+		return nil
 	}
+
+	for decoder.More() {
+		var obj map[string]any
+		if err := decoder.Decode(&obj); err != nil {
+			return res.Into(), fmt.Errorf("error decoding JSON object: %v", err)
+		}
+		chunk = append(chunk, obj)
+
+		if len(chunk) >= chunkSize {
+			if err := flushChunk(); err != nil {
+				return res.Into(), err
+			}
+		}
+	}
+	// Flush any remaining items in the last (possibly partial) chunk.
+	if err := flushChunk(); err != nil {
+		return res.Into(), err
+	}
+
 	return res.Into(), nil
 }
 

--- a/server/internal/usecase/interactor/item_import_csv.go
+++ b/server/internal/usecase/interactor/item_import_csv.go
@@ -117,8 +117,64 @@ func (i Item) importCSVWithProgress(ctx context.Context, j *job.Job, prj *projec
 	// Build field map from headers to schema fields
 	fieldMap := buildFieldMap(headers, param.SP)
 
-	// First pass: read all records to get total count
-	allRows := make([][]string, 0)
+	// Stream records directly in chunks without a first pass that would
+	// materialize all rows into memory. Total is unknown during streaming.
+	processed := 0
+	chunk := make([][]string, 0, chunkSize)
+
+	flushCSVChunk := func() error {
+		if len(chunk) == 0 {
+			return nil
+		}
+
+		// Check if job was cancelled.
+		currentJob, err := i.repos.Job.FindByID(ctx, j.ID())
+		if err != nil {
+			log.Warnf("item: import job %s failed to check cancellation status: %v", j.ID(), err)
+		}
+		if currentJob != nil && currentJob.IsCancelled() {
+			return fmt.Errorf("job cancelled")
+		}
+
+		// Check max record limit.
+		if processed+len(chunk) > interfaces.MaxImportRecordCount {
+			return interfaces.ErrImportTooManyRecords
+		}
+
+		// Convert rows to maps.
+		csvChunk := make([]map[string]any, 0, len(chunk))
+		for _, record := range chunk {
+			csvChunk = append(csvChunk, csvRowToMap(headers, record, fieldMap))
+		}
+
+		items, err := itemsParamsFrom(csvChunk, false, nil, param.SP)
+		if err != nil {
+			return err
+		}
+		if err := i.saveChunk(ctx, prj, m, s, param, items, res, operator); err != nil {
+			return err
+		}
+
+		processed += len(chunk)
+		chunk = chunk[:0]
+
+		// Report progress with unknown total (0) during streaming.
+		progress := job.NewProgress(processed, 0)
+		state := job.NewState(job.StatusInProgress, &progress, "")
+		if i.gateways.JobPubSub != nil {
+			if err := i.gateways.JobPubSub.Publish(ctx, j.ID(), state); err != nil {
+				log.Warnf("item: import job %s failed to publish progress: %v", j.ID(), err)
+			}
+		}
+		j.SetProgress(progress)
+		if err := i.repos.Job.Save(ctx, j); err != nil {
+			log.Errorf("item: import job %s failed to update progress: %v", j.ID(), err)
+		}
+
+		log.Printf("chunk with %d items saved.", len(items))
+		return nil
+	}
+
 	for {
 		record, err := reader.Read()
 		if err == io.EOF {
@@ -130,65 +186,16 @@ func (i Item) importCSVWithProgress(ctx context.Context, j *job.Job, prj *projec
 		if lr.N == 0 {
 			return res.Into(), interfaces.ErrImportFileTooLarge
 		}
-		allRows = append(allRows, record)
-	}
-	totalCount := len(allRows)
-
-	// Second pass: process in chunks with progress tracking
-	processed := 0
-	for start := 0; start < totalCount; start += chunkSize {
-		// Check if job was cancelled
-		currentJob, err := i.repos.Job.FindByID(ctx, j.ID())
-		if err != nil {
-			log.Warnf("item: import job %s failed to check cancellation status: %v", j.ID(), err)
-		}
-		if currentJob != nil && currentJob.IsCancelled() {
-			return res.Into(), fmt.Errorf("job cancelled")
-		}
-
-		end := min(start+chunkSize, totalCount)
-		rows := allRows[start:end]
-		chunkLen := len(rows)
-
-		// Check max record limit
-		if start+chunkLen > interfaces.MaxImportRecordCount {
-			return res.Into(), interfaces.ErrImportTooManyRecords
-		}
-
-		// Convert rows to maps
-		csvChunk := make([]map[string]any, 0, chunkLen)
-		for _, record := range rows {
-			row := csvRowToMap(headers, record, fieldMap)
-			csvChunk = append(csvChunk, row)
-		}
-
-		items, err := itemsParamsFrom(csvChunk, false, nil, param.SP)
-		if err != nil {
-			return res.Into(), err
-		}
-		err = i.saveChunk(ctx, prj, m, s, param, items, res, operator)
-		if err != nil {
-			return res.Into(), err
-		}
-
-		processed += chunkLen
-
-		// Publish progress
-		progress := job.NewProgress(processed, totalCount)
-		state := job.NewState(job.StatusInProgress, &progress, "")
-		if i.gateways.JobPubSub != nil {
-			if err := i.gateways.JobPubSub.Publish(ctx, j.ID(), state); err != nil {
-				log.Warnf("item: import job %s failed to publish progress: %v", j.ID(), err)
+		chunk = append(chunk, record)
+		if len(chunk) >= chunkSize {
+			if err := flushCSVChunk(); err != nil {
+				return res.Into(), err
 			}
 		}
-
-		// Update job progress
-		j.SetProgress(progress)
-		if err := i.repos.Job.Save(ctx, j); err != nil {
-			log.Errorf("item: import job %s failed to update progress: %v", j.ID(), err)
-		}
-
-		log.Printf("chunk with %d items saved.", chunkLen)
+	}
+	// Flush any remaining rows in the last partial chunk.
+	if err := flushCSVChunk(); err != nil {
+		return res.Into(), err
 	}
 
 	return res.Into(), nil

--- a/server/internal/usecase/interactor/item_import_test.go
+++ b/server/internal/usecase/interactor/item_import_test.go
@@ -1,13 +1,24 @@
 package interactor
 
 import (
+	"context"
+	"strings"
 	"testing"
 
+	"github.com/reearth/reearth-cms/server/internal/infrastructure/memory"
+	"github.com/reearth/reearth-cms/server/internal/usecase"
+	"github.com/reearth/reearth-cms/server/internal/usecase/gateway"
+	"github.com/reearth/reearth-cms/server/internal/usecase/interfaces"
 	"github.com/reearth/reearth-cms/server/pkg/id"
 	"github.com/reearth/reearth-cms/server/pkg/item"
+	"github.com/reearth/reearth-cms/server/pkg/job"
+	"github.com/reearth/reearth-cms/server/pkg/model"
+	"github.com/reearth/reearth-cms/server/pkg/project"
 	"github.com/reearth/reearth-cms/server/pkg/schema"
 	"github.com/reearth/reearth-cms/server/pkg/value"
 	"github.com/reearth/reearthx/account/accountdomain"
+	"github.com/reearth/reearthx/account/accountusecase"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -108,4 +119,73 @@ func TestApplyDefaultValues(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestItem_importWithProgress_streamsLargeInput verifies that importWithProgress
+// processes a JSON array without materialising all items into memory first
+// (the two-pass approach that was removed by the SCA-04 fix).
+//
+// The test creates a JSON array of 5 items and checks that all items are saved
+// to the repository after the call returns.
+func TestItem_importWithProgress_streamsLargeInput(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	wid := accountdomain.NewWorkspaceID()
+	prj := project.New().NewID().Workspace(wid).MustBuild()
+	sf := schema.NewField(schema.NewText(nil).TypeProperty()).NewID().Key(id.NewKey("name")).MustBuild()
+	s := schema.New().NewID().Workspace(wid).Project(prj.ID()).Fields(schema.FieldList{sf}).MustBuild()
+	m := model.New().NewID().Schema(s.ID()).Key(id.RandomKey()).Project(prj.ID()).MustBuild()
+
+	db := memory.New()
+	lo.Must0(db.Project.Save(ctx, prj))
+	lo.Must0(db.Schema.Save(ctx, s))
+	lo.Must0(db.Model.Save(ctx, m))
+	lo.Must0(db.Job.Save(ctx, job.New().NewID().
+		Project(prj.ID()).
+		User(accountdomain.NewUserID()).
+		Type(job.TypeImport).
+		MustBuild()))
+
+	// Build a JSON array of 5 objects.
+	jsonItems := `[
+		{"name": "item1"},
+		{"name": "item2"},
+		{"name": "item3"},
+		{"name": "item4"},
+		{"name": "item5"}
+	]`
+
+	j := job.New().NewID().
+		Project(prj.ID()).
+		User(accountdomain.NewUserID()).
+		Type(job.TypeImport).
+		MustBuild()
+	lo.Must0(db.Job.Save(ctx, j))
+
+	op := &usecase.Operator{
+		AcOperator: &accountusecase.Operator{
+			User:               accountdomain.NewUserID().Ref(),
+			ReadableWorkspaces: []accountdomain.WorkspaceID{wid},
+			WritableWorkspaces: []accountdomain.WorkspaceID{wid},
+		},
+		ReadableProjects: []id.ProjectID{prj.ID()},
+		WritableProjects: []id.ProjectID{prj.ID()},
+	}
+
+	sp := schema.NewPackage(s, nil, nil, nil)
+	itemUC := NewItem(db, &gateway.Container{})
+	itemUC.ignoreEvent = true
+
+	res, err := itemUC.importWithProgress(ctx, j, interfaces.ImportItemsParam{
+		ModelID:  m.ID(),
+		SP:       *sp,
+		Strategy: interfaces.ImportStrategyTypeInsert,
+		Format:   interfaces.ImportFormatTypeJSON,
+		Reader:   strings.NewReader(jsonItems),
+	}, op)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 5, res.Inserted)
+	assert.Equal(t, 5, res.Total)
 }


### PR DESCRIPTION
## Problem

`importWithProgress` (JSON/GeoJSON) and `importCSVWithProgress` (CSV) both used a two-pass approach:
1. **First pass**: decode/read all records into `allItems []map[string]any` / `allRows [][]string` to get a total count
2. **Second pass**: process in chunks from the in-memory slice

The in-memory expansion grows 3–10× over raw bytes. A 100 MB import could hold the buffered copy plus several hundred MB of live objects per goroutine. Under concurrent request handling, parallel async imports could OOM containers. The recent 100 MB cap (#1874) bounded input size but not the two-pass in-memory expansion.

## Fix

Replace the two-pass approach with a single streaming pass:
- Accumulate records into a reused chunk slice (capacity = `chunkSize`)
- Flush each full chunk via `saveChunk` immediately
- Continue reading; flush the last partial chunk at EOF

Progress is reported as processed count; `Total` is set to 0 during streaming (accurately: total is unknown until EOF). Peak memory during import is now O(chunkSize) instead of O(total records).

The 100 MB read limit from #1874 is retained as a complementary guard on raw upload size.