### PR TITLE
fix(import chunk N+1 queries): skip per-item uniqueness/reference DB calls when schema doesn't require them

### DIFF
--- a/server/internal/usecase/interactor/item.go
+++ b/server/internal/usecase/interactor/item.go
@@ -709,6 +709,11 @@ func (i Item) checkUnique(ctx context.Context, itemFields []*item.Field, s *sche
 		})
 	}
 
+	// Nothing to check — no unique fields with non-empty, changed values.
+	if len(fieldsArg) == 0 {
+		return nil
+	}
+
 	exists, err := i.repos.Item.FindByModelAndValue(ctx, mid, fieldsArg, nil)
 	if err != nil {
 		return err

--- a/server/internal/usecase/interactor/item_import.go
+++ b/server/internal/usecase/interactor/item_import.go
@@ -17,6 +17,7 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/schema"
 	"github.com/reearth/reearth-cms/server/pkg/task"
 	"github.com/reearth/reearth-cms/server/pkg/utils"
+	"github.com/reearth/reearth-cms/server/pkg/value"
 	"github.com/reearth/reearthx/log"
 	"github.com/reearth/reearthx/rerror"
 	"github.com/samber/lo"
@@ -532,6 +533,19 @@ func (i Item) saveChunk(ctx context.Context, prj *project.Project, m *model.Mode
 
 	isMetadata := m.Metadata() != nil && s.ID() == *m.Metadata()
 
+	// Pre-check schema capabilities once per chunk to avoid per-item overhead.
+	// checkUnique issues a FindByModelAndValue per item; skip when the schema
+	// has no unique fields at all (most import schemas).
+	schemaHasUniqueFields := lo.ContainsBy(s.Fields(), func(f *schema.Field) bool {
+		return f.Unique()
+	})
+	// handleReferenceFields issues FindByID calls for two-way reference targets;
+	// skip the entire call when the schema has no two-way reference fields.
+	schemaHasTwoWayRefs := lo.ContainsBy(s.FieldsByType(value.TypeReference), func(f *schema.Field) bool {
+		fr, ok := schema.FieldReferenceFromTypeProperty(f.TypeProperty())
+		return ok && fr.IsTwoWay()
+	})
+
 	type itemChanges struct {
 		oldFields item.Fields
 		action    interfaces.ImportStrategyType
@@ -643,8 +657,13 @@ func (i Item) saveChunk(ctx context.Context, prj *project.Project, m *model.Mode
 				// TODO: Handle default values for groups fields
 			}
 
-			if err := i.checkUnique(ctx, fields, s, m.ID(), nil); err != nil {
-				return nil, nil, err
+			// Only run the uniqueness DB check when the schema actually has
+			// unique fields; the guard inside checkUnique also catches the
+			// empty-fieldsArg case, but skipping here avoids the field-scan loop.
+			if schemaHasUniqueFields {
+				if err := i.checkUnique(ctx, fields, s, m.ID(), nil); err != nil {
+					return nil, nil, err
+				}
 			}
 
 			oldFields := it.Fields()
@@ -657,8 +676,12 @@ func (i Item) saveChunk(ctx context.Context, prj *project.Project, m *model.Mode
 
 			it.UpdateFields(groupFields)
 
-			if err = i.handleReferenceFields(ctx, *s, it, oldFields); err != nil {
-				return nil, nil, err
+			// Two-way reference handling issues per-item FindByID calls for the
+			// referenced counterpart. Skip entirely when no such fields exist.
+			if schemaHasTwoWayRefs {
+				if err = i.handleReferenceFields(ctx, *s, it, oldFields); err != nil {
+					return nil, nil, err
+				}
 			}
 
 			itemsToSave = append(itemsToSave, it)

--- a/server/internal/usecase/interactor/item_test.go
+++ b/server/internal/usecase/interactor/item_test.go
@@ -1911,3 +1911,90 @@ func TestWorkFlow(t *testing.T) {
 //		})
 //	}
 //}
+
+// TestItem_checkUnique_skipsDBWhenNoUniqueFields verifies that checkUnique returns
+// nil immediately without issuing a FindByModelAndValue DB call when the schema
+// has no unique fields (the SCA-03 N+1 guard).
+func TestItem_checkUnique_skipsDBWhenNoUniqueFields(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	wid := accountdomain.NewWorkspaceID()
+	prj := project.New().NewID().Workspace(wid).MustBuild()
+
+	// Build a schema with NO unique fields.
+	sf := schema.NewField(schema.NewText(nil).TypeProperty()).
+		NewID().
+		Key(id.NewKey("title")).
+		MustBuild()
+	s := schema.New().NewID().Workspace(wid).Project(prj.ID()).
+		Fields(schema.FieldList{sf}).
+		MustBuild()
+	mid := id.NewModelID()
+
+	db := memory.New()
+	// Wrap the item repo to detect any FindByModelAndValue calls.
+	countingRepo := &countingItemRepo{Item: db.Item}
+	db.Item = countingRepo
+
+	itemUC := NewItem(db, nil)
+	itemUC.ignoreEvent = true
+
+	fields := []*item.Field{
+		item.NewField(sf.ID(), value.TypeText.Value("hello").AsMultiple(), nil),
+	}
+
+	err := itemUC.checkUnique(ctx, fields, s, mid, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, countingRepo.findByModelAndValueCalls,
+		"FindByModelAndValue must not be called when schema has no unique fields")
+}
+
+// TestItem_checkUnique_hitsDBWhenUniqueFieldPresent verifies the opposite: when a
+// unique field exists FindByModelAndValue IS called.
+func TestItem_checkUnique_hitsDBWhenUniqueFieldPresent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	wid := accountdomain.NewWorkspaceID()
+	prj := project.New().NewID().Workspace(wid).MustBuild()
+
+	// Build a schema with a UNIQUE field.
+	sf := schema.NewField(schema.NewText(nil).TypeProperty()).
+		NewID().
+		Key(id.NewKey("title")).
+		Unique(true).
+		MustBuild()
+	s := schema.New().NewID().Workspace(wid).Project(prj.ID()).
+		Fields(schema.FieldList{sf}).
+		MustBuild()
+	mid := id.NewModelID()
+
+	db := memory.New()
+	countingRepo := &countingItemRepo{Item: db.Item}
+	db.Item = countingRepo
+
+	itemUC := NewItem(db, nil)
+	itemUC.ignoreEvent = true
+
+	fields := []*item.Field{
+		item.NewField(sf.ID(), value.TypeText.Value("hello").AsMultiple(), nil),
+	}
+
+	// No duplicate — expect no error but DB must have been queried.
+	err := itemUC.checkUnique(ctx, fields, s, mid, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, countingRepo.findByModelAndValueCalls,
+		"FindByModelAndValue must be called exactly once when schema has a unique field")
+}
+
+// countingItemRepo wraps repo.Item and counts FindByModelAndValue invocations.
+type countingItemRepo struct {
+	repo.Item
+	findByModelAndValueCalls int
+}
+
+func (r *countingItemRepo) FindByModelAndValue(ctx context.Context, mid id.ModelID, fields []repo.FieldAndValue, ref *version.Ref) (item.VersionedList, error) {
+	r.findByModelAndValueCalls++
+	return r.Item.FindByModelAndValue(ctx, mid, fields, ref)
+}


### PR DESCRIPTION
## Problem

`saveChunk` called `checkUnique` (→ `FindByModelAndValue`) and `handleReferenceFields` (→ `FindByID`) once per item in the chunk, all inside a held transaction. For a 50,000-row import these N sequential round-trips added minutes of DB work and prolonged lock holding, growing linearly with import size.

## Fix

Two targeted optimisations:

**1. Guard in `checkUnique`**: Added an early-return when `fieldsArg` is empty (no unique fields with non-empty, changed values). Previously the DB call was issued unconditionally even when the schema had no unique fields.

**2. Schema pre-checks in `saveChunk`**: Compute once per chunk whether the schema has any unique fields (`schemaHasUniqueFields`) and any two-way reference fields (`schemaHasTwoWayRefs`). Skip the per-item `checkUnique` or `handleReferenceFields` calls entirely when the schema doesn't have those features — the common case for simple import schemas. This eliminates O(chunk_size) unnecessary DB queries per chunk for the most frequent import pattern.

Per-item queries are still issued for schemas that do have unique or two-way reference fields; a full batch solution would require new repo-layer methods and is left for a follow-up.