### PR TITLE
fix(SSRF in asset from URL): block private IP dial and scheme validation in FromURL

### DIFF
--- a/server/pkg/file/file.go
+++ b/server/pkg/file/file.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"mime"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -17,9 +18,50 @@ import (
 	"github.com/reearth/reearthx/rerror"
 )
 
-// urlFetchClient enforces a hard timeout on user-supplied URL fetches
+// isPrivateIP returns true for IPs that must not be reached via user-supplied URLs:
+// loopback, link-local, RFC-1918 private ranges, and the AWS IMDS address.
+func isPrivateIP(ip net.IP) bool {
+	private := []net.IPNet{
+		{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(8, 32)},
+		{IP: net.ParseIP("172.16.0.0"), Mask: net.CIDRMask(12, 32)},
+		{IP: net.ParseIP("192.168.0.0"), Mask: net.CIDRMask(16, 32)},
+		{IP: net.ParseIP("169.254.0.0"), Mask: net.CIDRMask(16, 32)}, // link-local / AWS IMDS
+		{IP: net.ParseIP("127.0.0.0"), Mask: net.CIDRMask(8, 32)},   // loopback
+		{IP: net.ParseIP("::1"), Mask: net.CIDRMask(128, 128)},       // IPv6 loopback
+		{IP: net.ParseIP("fc00::"), Mask: net.CIDRMask(7, 128)},      // IPv6 ULA
+	}
+	for _, block := range private {
+		if block.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+var ssrfSafeDialer = &net.Dialer{Timeout: 30 * time.Second}
+
+// urlFetchClient enforces a hard timeout on user-supplied URL fetches and
+// blocks connections to private/reserved IP addresses (SSRF mitigation).
 var urlFetchClient = &http.Client{
 	Timeout: 5 * time.Minute,
+	Transport: &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, fmt.Errorf("ssrf: invalid address %q: %w", addr, err)
+			}
+			ips, err := net.DefaultResolver.LookupHost(ctx, host)
+			if err != nil {
+				return nil, fmt.Errorf("ssrf: DNS lookup failed for %q: %w", host, err)
+			}
+			for _, ipStr := range ips {
+				if ip := net.ParseIP(ipStr); ip != nil && isPrivateIP(ip) {
+					return nil, fmt.Errorf("ssrf: request to private/reserved IP %s is blocked", ipStr)
+				}
+			}
+			return ssrfSafeDialer.DialContext(ctx, network, net.JoinHostPort(ips[0], port))
+		},
+	},
 }
 
 type File struct {
@@ -66,6 +108,11 @@ func FromURL(ctx context.Context, rawURL string) (*File, error) {
 	URL, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, err
+	}
+
+	// Reject non-HTTP(S) schemes to prevent file://, ftp://, gopher://, etc.
+	if URL.Scheme != "http" && URL.Scheme != "https" {
+		return nil, fmt.Errorf("unsupported URL scheme %q: only http and https are allowed", URL.Scheme)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, URL.String(), nil)

--- a/server/pkg/file/file_test.go
+++ b/server/pkg/file/file_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path"
 	"testing"
@@ -17,8 +18,10 @@ import (
 func TestFromURL(t *testing.T) {
 	ctx := context.Background()
 
-	httpmock.Activate()
-	defer httpmock.Deactivate()
+	// Activate httpmock on the custom urlFetchClient (not the default transport)
+	// so that the existing mock responders intercept requests going through our client.
+	httpmock.ActivateNonDefault(urlFetchClient)
+	defer httpmock.DeactivateAndReset()
 
 	t.Run("with gzip encoding", func(t *testing.T) {
 		URL := "https://cms.com/xyz/test.txt.gz"
@@ -83,4 +86,35 @@ func TestFromURL(t *testing.T) {
 		assert.Equal(t, expected.Name, got.Name)
 		assert.Equal(t, z, lo.Must(io.ReadAll(got.Content)))
 	})
+
+	t.Run("rejects non-http scheme", func(t *testing.T) {
+		_, err := FromURL(ctx, "file:///etc/passwd")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported URL scheme")
+	})
+
+	t.Run("rejects ftp scheme", func(t *testing.T) {
+		_, err := FromURL(ctx, "ftp://example.com/file.txt")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported URL scheme")
+	})
+}
+
+// TestFromURL_SSRFLoopbackBlocked verifies that requests to loopback addresses
+// are rejected even when an HTTP server is actually listening there. This test
+// operates outside the httpmock scope so that the real DialContext is invoked.
+func TestFromURL_SSRFLoopbackBlocked(t *testing.T) {
+	ctx := context.Background()
+
+	// Start a real local server; its address will be 127.0.0.1:<port>.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// srv.URL is "http://127.0.0.1:<port>" — a loopback address.
+	// The SSRF dial error is wrapped by rerror.ErrInternalBy, so we check that
+	// an error is returned (the connection was blocked) rather than matching text.
+	_, err := FromURL(ctx, srv.URL)
+	assert.Error(t, err, "expected SSRF block for loopback address")
 }


### PR DESCRIPTION
## Problem
`FromURL` in `server/pkg/file/file.go` used a plain `http.Client` with no IP or scheme validation. An attacker could supply URLs like `http://169.254.169.254/` (AWS IMDS) or `file:///etc/passwd` to reach internal infrastructure.

## Fix
- Add `isPrivateIP` to identify RFC-1918, loopback, link-local, and IPv6-private addresses.
- Replace the bare `http.Client` with one whose `Transport.DialContext` resolves DNS and rejects any resolved IP that is private/reserved.
- Add scheme validation at the top of `FromURL` — only `http` and `https` are permitted.

## Tests
- `TestFromURL/rejects_non-http_scheme` — `file:///etc/passwd` → scheme error
- `TestFromURL/rejects_ftp_scheme` — `ftp://` → scheme error
- `TestFromURL_SSRFLoopbackBlocked` — real `httptest.Server` on 127.0.0.1 → dial blocked
- Existing mock tests updated to use `httpmock.ActivateNonDefault` to work with the custom transport.