### PR TITLE
fix(S3 upload buffering): stream body directly without in-memory buffering

### DIFF
--- a/server/internal/infrastructure/aws/file.go
+++ b/server/internal/infrastructure/aws/file.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -419,24 +418,37 @@ func (f *fileRepo) Read(ctx context.Context, filename string, headers map[string
 	return resp.Body, resheaders, nil
 }
 
+// s3UploadAPI is the minimal subset of *s3.Client used by Upload.
+// Keeping it narrow lets tests inject a fake without the full AWS SDK mock.
+type s3UploadAPI interface {
+	PutObject(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	HeadObject(context.Context, *s3.HeadObjectInput, ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
+}
+
 func (f *fileRepo) Upload(ctx context.Context, file *file.File, filename string) (int64, error) {
+	return f.uploadWithClient(ctx, f.s3Client, file, filename)
+}
+
+// uploadWithClient is the testable core of Upload; it accepts the s3UploadAPI
+// interface so tests can inject a fake S3 client.
+func (f *fileRepo) uploadWithClient(ctx context.Context, client s3UploadAPI, file *file.File, filename string) (int64, error) {
 	if filename == "" {
 		return 0, gateway.ErrInvalidFile
 	}
 
-	ba, err := io.ReadAll(file.Content)
-	if err != nil {
-		return 0, rerror.ErrInternalBy(err)
-	}
-	body := bytes.NewReader(ba)
-
+	// Stream the body directly to S3 instead of buffering the entire file in
+	// memory with io.ReadAll. When the file size is known, pass ContentLength
+	// so S3 can validate the upload without a second request.
 	input := &s3.PutObjectInput{
 		Bucket:          aws.String(f.bucketName),
 		CacheControl:    aws.String(f.cacheControl),
 		ContentEncoding: lo.EmptyableToPtr(file.ContentEncoding),
 		ContentType:     aws.String(file.ContentType),
 		Key:             aws.String(filename),
-		Body:            body,
+		Body:            file.Content,
+	}
+	if file.Size > 0 {
+		input.ContentLength = aws.Int64(file.Size)
 	}
 
 	if workspace := getWorkspaceFromContext(ctx); workspace != "" {
@@ -445,12 +457,12 @@ func (f *fileRepo) Upload(ctx context.Context, file *file.File, filename string)
 		}
 	}
 
-	_, err = f.s3Client.PutObject(ctx, input)
+	_, err := client.PutObject(ctx, input)
 	if err != nil {
 		return 0, gateway.ErrFailedToUploadFile
 	}
 
-	result, err := f.s3Client.HeadObject(ctx, &s3.HeadObjectInput{
+	result, err := client.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: aws.String(f.bucketName),
 		Key:    aws.String(filename),
 	})

--- a/server/internal/infrastructure/aws/file_upload_test.go
+++ b/server/internal/infrastructure/aws/file_upload_test.go
@@ -1,0 +1,85 @@
+package aws
+
+// file_upload_test.go verifies that the Upload method streams the file body
+// directly to S3 instead of buffering it with io.ReadAll.
+//
+// Because *s3.Client is a concrete struct (not an interface), we inject a fake
+// via a thin s3UploadAPI interface defined only for testing, and call the
+// internal uploadWithClient helper that accepts that interface. The helper is
+// defined in file_upload.go.
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/reearth/reearth-cms/server/internal/usecase/gateway"
+	"github.com/reearth/reearth-cms/server/pkg/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeS3 satisfies s3UploadAPI and records what was sent.
+type fakeS3 struct {
+	putInput *s3.PutObjectInput
+	putBody  string
+	headLen  int64
+}
+
+func (f *fakeS3) PutObject(_ context.Context, input *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	f.putInput = input
+	body, err := io.ReadAll(input.Body)
+	if err != nil {
+		return nil, err
+	}
+	f.putBody = string(body)
+	return &s3.PutObjectOutput{}, nil
+}
+
+func (f *fakeS3) HeadObject(_ context.Context, _ *s3.HeadObjectInput, _ ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	return &s3.HeadObjectOutput{ContentLength: awssdk.Int64(f.headLen)}, nil
+}
+
+func TestUpload_streamsBodyWithoutBuffering(t *testing.T) {
+	t.Parallel()
+
+	const content = "hello streaming world"
+	fake := &fakeS3{headLen: int64(len(content))}
+
+	repo := &fileRepo{
+		bucketName:   "test-bucket",
+		cacheControl: "no-cache",
+		s3Client:     nil, // not used — we call uploadWithClient directly
+	}
+
+	fi := &file.File{
+		Content:     io.NopCloser(strings.NewReader(content)),
+		Name:        "test.txt",
+		Size:        int64(len(content)),
+		ContentType: "text/plain",
+	}
+
+	size, err := repo.uploadWithClient(context.Background(), fake, fi, "uploads/test.txt")
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(content)), size)
+
+	// Verify that the body reached the fake S3 unchanged.
+	assert.Equal(t, content, fake.putBody)
+
+	// Verify ContentLength was set (streaming hint to S3).
+	require.NotNil(t, fake.putInput.ContentLength)
+	assert.Equal(t, int64(len(content)), awssdk.ToInt64(fake.putInput.ContentLength))
+}
+
+func TestUpload_returnsErrForEmptyFilename(t *testing.T) {
+	t.Parallel()
+
+	repo := &fileRepo{bucketName: "test-bucket"}
+	fi := &file.File{Content: io.NopCloser(strings.NewReader("data"))}
+
+	_, err := repo.Upload(context.Background(), fi, "")
+	assert.ErrorIs(t, err, gateway.ErrInvalidFile)
+}


### PR DESCRIPTION
## Problem
`fileRepo.Upload` in `server/internal/infrastructure/aws/file.go` called `io.ReadAll` to buffer the entire file into a `[]byte` before uploading to S3. For large files this caused OOM failures.

## Fix
- Remove `io.ReadAll` + `bytes.NewReader`; set `PutObjectInput.Body = file.Content` directly.
- When `file.Size > 0`, set `ContentLength` so S3 can validate the upload without a buffered copy.
- Extract the upload logic into `uploadWithClient(ctx, s3UploadAPI, ...)` so it can be tested by injecting a fake.

## Tests
`server/internal/infrastructure/aws/file_upload_test.go`:
- `TestUpload_streamsBodyWithoutBuffering` — verifies the body is delivered to S3 correctly and `ContentLength` is set.
- `TestUpload_returnsErrForEmptyFilename` — verifies `ErrInvalidFile` for empty filename.