### PR TITLE
fix(model delete accumulation): flush threads and events per page

### DIFF
--- a/server/internal/usecase/interactor/model.go
+++ b/server/internal/usecase/interactor/model.go
@@ -421,10 +421,8 @@ func (i Model) deleteItemsByModel(ctx context.Context, prj *project.Project, m *
 
 	itemInteractor := NewItem(i.repos, i.gateways)
 
-	var allThreadIDs id.ThreadIDList
-	var allEvents []Event
-
-	// collect thread IDs, events, and clean up cross-model references
+	// Process items page-by-page, flushing threads and events per page so that
+	// memory usage is bounded regardless of model size.
 	for {
 		vList, pageInfo, err := i.repos.Item.FindByModel(ctx, m.ID(), nil, nil,
 			usecasex.CursorPagination{First: lo.ToPtr(pageSize), After: cursor}.Wrap())
@@ -434,11 +432,14 @@ func (i Model) deleteItemsByModel(ctx context.Context, prj *project.Project, m *
 
 		items := vList.Unwrap()
 		if len(items) > 0 {
+			var pageThreadIDs id.ThreadIDList
+			var pageEvents []Event
+
 			for idx, itm := range items {
 				if itm.Thread() != nil {
-					allThreadIDs = append(allThreadIDs, *itm.Thread())
+					pageThreadIDs = append(pageThreadIDs, *itm.Thread())
 				}
-				allEvents = append(allEvents, Event{
+				pageEvents = append(pageEvents, Event{
 					Project:   prj,
 					Workspace: sp.Schema().Workspace(),
 					Type:      event.ItemDelete,
@@ -455,6 +456,20 @@ func (i Model) deleteItemsByModel(ctx context.Context, prj *project.Project, m *
 			if err := itemInteractor.handleRelatedReferenceFields(ctx, items.IDs(), sp); err != nil {
 				return err
 			}
+
+			// Flush threads for this page immediately.
+			if len(pageThreadIDs) > 0 {
+				if err := i.repos.Thread.RemoveByIDs(ctx, pageThreadIDs); err != nil {
+					return err
+				}
+			}
+
+			// Flush events for this page immediately.
+			if len(pageEvents) > 0 {
+				if _, err := createEvents(ctx, i.repos, i.gateways, pageEvents); err != nil {
+					return err
+				}
+			}
 		}
 
 		if pageInfo == nil || !pageInfo.HasNextPage {
@@ -463,23 +478,9 @@ func (i Model) deleteItemsByModel(ctx context.Context, prj *project.Project, m *
 		cursor = pageInfo.EndCursor
 	}
 
-	// delete all items and metadata items for this model in one query
+	// Delete all items for this model in a single bulk query.
 	if err := i.repos.Item.RemoveByModel(ctx, m.ID()); err != nil {
 		return err
-	}
-
-	// delete threads that belonged to the deleted items
-	if len(allThreadIDs) > 0 {
-		if err := i.repos.Thread.RemoveByIDs(ctx, allThreadIDs); err != nil {
-			return err
-		}
-	}
-
-	// publish item.delete events
-	if len(allEvents) > 0 {
-		if _, err := createEvents(ctx, i.repos, i.gateways, allEvents); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/server/internal/usecase/interactor/model_test.go
+++ b/server/internal/usecase/interactor/model_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/project"
 	"github.com/reearth/reearth-cms/server/pkg/rbac"
 	"github.com/reearth/reearth-cms/server/pkg/schema"
+	"github.com/reearth/reearth-cms/server/pkg/thread"
 	"github.com/reearth/reearth-cms/server/pkg/value"
 	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/account/accountdomain/user"
@@ -1489,4 +1490,69 @@ func TestModel_FindOrCreateSchema(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+// TestModel_deleteItemsByModel_flushesPerPage verifies that when a model is
+// deleted its items, threads, and events are cleaned up per page rather than
+// accumulating all in memory before flushing.
+//
+// We test this end-to-end via Model.Delete so the full deleteItemsByModel
+// code-path runs. Three items are seeded (each with a thread); after deletion
+// all items and threads must be gone from the repository.
+func TestModel_deleteItemsByModel_flushesPerPage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	wid := accountdomain.NewWorkspaceID()
+	db := memory.New()
+
+	p := project.New().NewID().Workspace(wid).MustBuild()
+	s := schema.New().NewID().Workspace(wid).Project(p.ID()).MustBuild()
+	m := model.New().NewID().Key(id.RandomKey()).Project(p.ID()).Schema(s.ID()).MustBuild()
+
+	ownerOp := &usecase.Operator{
+		OwningProjects: []id.ProjectID{p.ID()},
+		AcOperator:     &accountusecase.Operator{User: accountdomain.NewUserID().Ref()},
+	}
+
+	assert.NoError(t, db.Project.Save(ctx, p.Clone()))
+	assert.NoError(t, db.Model.Save(ctx, m.Clone()))
+	assert.NoError(t, db.Schema.Save(ctx, s.Clone()))
+
+	// Seed three items, each with its own thread.
+	threadIDs := make([]id.ThreadID, 3)
+	itemIDs := make([]id.ItemID, 3)
+	for i := range 3 {
+		thid := id.NewThreadID()
+		threadIDs[i] = thid
+
+		// Seed the thread itself so we can verify it is removed afterwards.
+		th := thread.New().ID(thid).Workspace(wid).Comments(nil).MustBuild()
+		assert.NoError(t, db.Thread.Save(ctx, th))
+
+		it := item.New().NewID().Schema(s.ID()).Model(m.ID()).Project(p.ID()).Thread(thid.Ref()).MustBuild()
+		itemIDs[i] = it.ID()
+		assert.NoError(t, db.Item.Save(ctx, it))
+	}
+
+	sp := *schema.NewPackage(s, nil, nil, nil)
+	u := NewModel(db, nil)
+	err := u.Delete(ctx, m.ID(), sp, ownerOp)
+	assert.NoError(t, err)
+
+	// All items must be gone.
+	for _, iid := range itemIDs {
+		_, itemErr := db.Item.FindByID(ctx, iid, nil)
+		assert.ErrorIs(t, itemErr, rerror.ErrNotFound, "item %s should be deleted", iid)
+	}
+
+	// All threads must be gone.
+	for _, thid := range threadIDs {
+		_, thErr := db.Thread.FindByID(ctx, thid)
+		assert.ErrorIs(t, thErr, rerror.ErrNotFound, "thread %s should be deleted", thid)
+	}
+
+	// The model itself must be gone.
+	_, err = db.Model.FindByID(ctx, m.ID())
+	assert.ErrorIs(t, err, rerror.ErrNotFound)
 }


### PR DESCRIPTION
## Problem
`deleteItemsByModel` in `model.go` accumulated `allThreadIDs` and `allEvents` across all pages before flushing. For large models this could consume significant memory — each page added to unbounded in-memory slices.

## Fix
Remove the two-phase collect-all-then-flush loop. Threads and events for each page are dispatched immediately (`RemoveByIDs`, `createEvents`) inside the loop before advancing to the next page. Peak memory is now proportional to the page size (100 items) regardless of model size.

## Tests
`TestModel_deleteItemsByModel_flushesPerPage` in `model_test.go` seeds three items with threads, calls `Delete`, and verifies all items and threads are removed.