### PR TITLE
feat(server): add OpenAPI specification for public API and align runtime behavior

### DIFF
--- a/server/internal/adapter/publicapi/openapi.go
+++ b/server/internal/adapter/publicapi/openapi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/reearth/reearth-cms/server/internal/adapter"
 	"github.com/reearth/reearth-cms/server/pkg/project"
 	"github.com/reearth/reearthx/usecasex"
 )
@@ -32,7 +33,7 @@ type OpenAPIComponents struct {
 	SecuritySchemes map[string]interface{} `json:"securitySchemes"`
 }
 
-// GetOpenAPISchema [WIP] generates the OpenAPI schema for the public API of the given workspace and project.
+// GetOpenAPISchema generates the OpenAPI schema for the public API of the given workspace and project.
 func (c *Controller) GetOpenAPISchema(ctx context.Context, wsAlias, pAlias string) (*OpenAPISpec, error) {
 	wpm, err := c.loadWPMContext(ctx, wsAlias, pAlias, "")
 	if err != nil {
@@ -59,16 +60,16 @@ func (c *Controller) GetOpenAPISchema(ctx context.Context, wsAlias, pAlias strin
 		},
 	}
 
-	// if project is private, return empty spec
+	// Endpoints of a private project require an API key; public projects are open
 	a11y := wpm.Project.Accessibility()
-	if a11y != nil && a11y.Visibility() == project.VisibilityPrivate {
-		return spec, nil
-	}
+	isPrivate := a11y != nil && a11y.Visibility() == project.VisibilityPrivate
+	keyId := adapter.APIKeyId(ctx)
 
-	// if no public models and no public assets, return empty spec
-	publication := a11y.Publication()
-	if publication != nil && (len(publication.PublicModels()) == 0 && !publication.PublicAssets()) {
-		return spec, nil
+	if isPrivate {
+		spec.Components.SecuritySchemes["apiKey"] = map[string]interface{}{
+			"type":   "http",
+			"scheme": "bearer",
+		}
 	}
 
 	// Get all models
@@ -77,15 +78,9 @@ func (c *Controller) GetOpenAPISchema(ctx context.Context, wsAlias, pAlias strin
 		return nil, err
 	}
 
-	// Add security schemes for API keys
-	spec.Components.SecuritySchemes["apiKey"] = map[string]interface{}{
-		"type":   "http",
-		"scheme": "bearer",
-	}
-
-	// Generate paths for each public model
+	// Generate paths for each model accessible to the caller
 	for _, m := range models {
-		if !wpm.Project.Accessibility().IsModelPublic(m.ID(), nil) {
+		if !a11y.IsModelPublic(m.ID(), keyId) {
 			continue
 		}
 
@@ -129,11 +124,6 @@ func (c *Controller) GetOpenAPISchema(ctx context.Context, wsAlias, pAlias strin
 					},
 					"404": map[string]interface{}{
 						"description": "Model not found",
-					},
-				},
-				"security": []map[string][]string{
-					{
-						"apiKey": {},
 					},
 				},
 			},
@@ -266,6 +256,27 @@ func (c *Controller) GetOpenAPISchema(ctx context.Context, wsAlias, pAlias strin
 					},
 				},
 			},
+		}
+	}
+
+	// Private projects require an API key on every endpoint
+	if isPrivate {
+		security := []map[string][]string{{"apiKey": {}}}
+		for _, pathItem := range spec.Paths {
+			pi, ok := pathItem.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			op, ok := pi["get"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			op["security"] = security
+			if responses, ok := op["responses"].(map[string]interface{}); ok {
+				responses["401"] = map[string]interface{}{
+					"description": "API key is invalid",
+				}
+			}
 		}
 	}
 

--- a/server/internal/adapter/publicapi/openapi.go
+++ b/server/internal/adapter/publicapi/openapi.go
@@ -79,9 +79,8 @@ func (c *Controller) GetOpenAPISchema(ctx context.Context, wsAlias, pAlias strin
 
 	// Add security schemes for API keys
 	spec.Components.SecuritySchemes["apiKey"] = map[string]interface{}{
-		"type": "apiKey",
-		"in":   "header",
-		"name": "Authorization",
+		"type":   "http",
+		"scheme": "bearer",
 	}
 
 	// Generate paths for each public model

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -31,6 +31,7 @@ func initEcho(appCtx *ApplicationContext) *echo.Echo {
 	// basic middleware
 	logger := log.New()
 	e.Logger = log.NewSlogLogger(logger)
+	e.Pre(middleware.RemoveTrailingSlash())
 	e.Use(
 		log.AccessLoggerV5(logger),
 		middleware.Recover(),

--- a/server/schemas/publicapi/publicapi.yaml
+++ b/server/schemas/publicapi/publicapi.yaml
@@ -98,6 +98,10 @@ components:
         Successful response. The structure varies per project and model.
         Field keys are defined by the model schema in Re:Earth CMS.
 
+  responses:
+    UnauthorizedError:
+      description: API key is invalid
+
 paths:
   # --- Items ---
 
@@ -123,6 +127,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '404':
           description: Model not found or not public
 
@@ -150,6 +156,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '404':
           description: Model not found or not public
 
@@ -177,6 +185,8 @@ paths:
             text/csv:
               schema:
                 type: string
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '404':
           description: Model not found or not public
 
@@ -213,6 +223,8 @@ paths:
                     type: array
                     items:
                       type: object
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '404':
           description: Model not found or not public
 
@@ -235,6 +247,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '404':
           description: Item not found
 
@@ -258,6 +272,8 @@ paths:
             application/json:
               schema:
                 type: object
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '404':
           description: Model not found
 
@@ -279,6 +295,8 @@ paths:
             application/json:
               schema:
                 type: object
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '404':
           description: Model not found
 
@@ -307,6 +325,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '404':
           description: No assets found
 
@@ -333,6 +353,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '404':
           description: No assets found
 
@@ -355,6 +377,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '404':
           description: Asset not found
 

--- a/server/schemas/publicapi/publicapi.yaml
+++ b/server/schemas/publicapi/publicapi.yaml
@@ -1,0 +1,380 @@
+openapi: 3.0.3
+info:
+  title: Re:Earth CMS - Public API
+  description: Public API for accessing published data from Re:Earth CMS projects.
+  version: "1.0.0"
+
+servers:
+  - url: /api/p/{workspace}/{project}
+    description: Public API endpoint
+    variables:
+      workspace:
+        default: "{workspace}"
+        description: Workspace ID or alias
+      project:
+        default: "{project}"
+        description: Project ID or alias
+
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: |
+        Required only for Private projects.
+        Format: `Bearer <your_api_key>`
+
+  parameters:
+    modelParam:
+      name: model
+      in: path
+      required: true
+      description: Model ID or key
+      schema:
+        type: string
+
+    itemIdParam:
+      name: itemId
+      in: path
+      required: true
+      description: Item ID
+      schema:
+        type: string
+
+    assetIdParam:
+      name: assetId
+      in: path
+      required: true
+      description: Asset ID
+      schema:
+        type: string
+
+    pageParam:
+      name: page
+      in: query
+      description: Page number for pagination
+      schema:
+        type: integer
+
+    limitParam:
+      name: limit
+      in: query
+      description: Number of items per page
+      schema:
+        type: integer
+        default: 50
+        maximum: 100
+
+    offsetParam:
+      name: offset
+      in: query
+      description: Number of items to skip (offset-based pagination)
+      schema:
+        type: integer
+
+    startCursorParam:
+      name: start_cursor
+      in: query
+      description: Cursor for cursor-based pagination
+      schema:
+        type: string
+
+    pageSizeParam:
+      name: page_size
+      in: query
+      description: Number of items per page (cursor-based pagination)
+      schema:
+        type: integer
+        default: 50
+        maximum: 100
+
+  schemas:
+    SuccessResponse:
+      type: object
+      description: |
+        Successful response. The structure varies per project and model.
+        Field keys are defined by the model schema in Re:Earth CMS.
+
+paths:
+  # --- Items ---
+
+  /{model}:
+    get:
+      summary: Get all items
+      description: Returns all published items from the specified model by default, and returns a paginated page response when pagination parameters are provided.
+      tags:
+        - Items
+      security:
+        - { }
+        - apiKey: [ ]
+      parameters:
+        - $ref: '#/components/parameters/modelParam'
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/offsetParam'
+        - $ref: '#/components/parameters/startCursorParam'
+        - $ref: '#/components/parameters/pageSizeParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '404':
+          description: Model not found or not public
+
+  /{model}.json:
+    get:
+      summary: Get all items (JSON)
+      description: |
+        Returns all published items from the specified model by default,
+        and returns a paginated page response when pagination parameters are provided (explicit JSON endpoint).
+      tags:
+        - Items
+      security:
+        - { }
+        - apiKey: [ ]
+      parameters:
+        - $ref: '#/components/parameters/modelParam'
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/offsetParam'
+        - $ref: '#/components/parameters/startCursorParam'
+        - $ref: '#/components/parameters/pageSizeParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '404':
+          description: Model not found or not public
+
+  /{model}.csv:
+    get:
+      summary: Get all items (CSV)
+      description: |
+        Returns all published items as CSV from the specified model by default,
+        and returns a paginated page response as CSV when pagination parameters are provided (CSV endpoint).
+      tags:
+        - Items
+      security:
+        - { }
+        - apiKey: [ ]
+      parameters:
+        - $ref: '#/components/parameters/modelParam'
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/offsetParam'
+        - $ref: '#/components/parameters/startCursorParam'
+        - $ref: '#/components/parameters/pageSizeParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            text/csv:
+              schema:
+                type: string
+        '404':
+          description: Model not found or not public
+
+  /{model}.geojson:
+    get:
+      summary: Get all items (GeoJSON)
+      description: |
+        Returns all published items from the specified model by default, and returns a paginated page response when pagination parameters are provided (GeoJSON endpoint).
+        Requires the model to have a Geometry type field defined.
+        Uses the first (bases on the order) Geometry type field in the model schema fields.
+      tags:
+        - Items
+      security:
+        - { }
+        - apiKey: [ ]
+      parameters:
+        - $ref: '#/components/parameters/modelParam'
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/offsetParam'
+        - $ref: '#/components/parameters/startCursorParam'
+        - $ref: '#/components/parameters/pageSizeParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/geo+json:
+              schema:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    example: FeatureCollection
+                  features:
+                    type: array
+                    items:
+                      type: object
+        '404':
+          description: Model not found or not public
+
+  /{model}/{itemId}:
+    get:
+      summary: Get an item by ID
+      description: Retrieve a single published item from the specified model by its ID.
+      tags:
+        - Items
+      security:
+        - { }
+        - apiKey: [ ]
+      parameters:
+        - $ref: '#/components/parameters/modelParam'
+        - $ref: '#/components/parameters/itemIdParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '404':
+          description: Item not found
+
+  # --- Schema ---
+
+  /{model}.schema.json:
+    get:
+      summary: Get model schema
+      description: Retrieve the JSON schema for the specified model.
+      tags:
+        - Schema
+      security:
+        - { }
+        - apiKey: [ ]
+      parameters:
+        - $ref: '#/components/parameters/modelParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Model not found
+
+  /{model}.metadata_schema.json:
+    get:
+      summary: Get model metadata schema
+      description: Retrieve the metadata JSON schema for the specified model.
+      tags:
+        - Schema
+      security:
+        - { }
+        - apiKey: [ ]
+      parameters:
+        - $ref: '#/components/parameters/modelParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Model not found
+
+  # --- Assets ---
+
+  /assets:
+    get:
+      summary: Get all assets
+      description: |
+        Returns all public assets in the project by default,
+        and returns a paginated page response when pagination parameters are provided.
+      tags:
+        - Assets
+      security:
+        - { }
+        - apiKey: [ ]
+      parameters:
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/offsetParam'
+        - $ref: '#/components/parameters/startCursorParam'
+        - $ref: '#/components/parameters/pageSizeParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '404':
+          description: No assets found
+
+  /assets.json:
+    get:
+      summary: Get all assets (JSON)
+      description: |
+        Returns all public assets in the project by default,
+        and returns a paginated page response when pagination parameters are provided (explicit JSON endpoint).
+      tags:
+        - Assets
+      security:
+        - { }
+        - apiKey: [ ]
+      parameters:
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/offsetParam'
+        - $ref: '#/components/parameters/startCursorParam'
+        - $ref: '#/components/parameters/pageSizeParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '404':
+          description: No assets found
+
+  /assets/{assetId}:
+    get:
+      summary: Get an asset by ID
+      description: |
+        Retrieve a single public asset by its ID.
+      tags:
+        - Assets
+      security:
+        - { }
+        - apiKey: [ ]
+      parameters:
+        - $ref: '#/components/parameters/assetIdParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '404':
+          description: Asset not found
+
+  # --- OpenAPI Schema ---
+
+  /:
+    get:
+      summary: Get OpenAPI schema
+      description: |
+        Retrieve the OpenAPI schema for this project. Generated dynamically per project.
+      tags:
+        - Schema
+      responses:
+        '200':
+          description: OpenAPI schema
+          content:
+            application/json:
+              schema:
+                type: object

--- a/server/schemas/publicapi/publicapi.yaml
+++ b/server/schemas/publicapi/publicapi.yaml
@@ -18,12 +18,12 @@ servers:
 components:
   securitySchemes:
     apiKey:
-      type: apiKey
-      in: header
-      name: Authorization
+      type: http
+      scheme: bearer
       description: |
-        Required only for Private projects.
-        Format: `Bearer <your_api_key>`
+        API key authentication. Required only for Private projects.
+        Send the API key as a bearer token: `Authorization: Bearer <your_api_key>`.
+        An invalid key results in a 401 response.
 
   parameters:
     modelParam:
@@ -53,14 +53,21 @@ components:
     pageParam:
       name: page
       in: query
-      description: Page number for pagination
+      description: |
+        Page number for page-based pagination. Values of 0 or less are treated as 1.
+        Ignored if `start_cursor` or `offset` is also provided
+        (pagination mode precedence: `start_cursor` > `offset` > `page`).
       schema:
         type: integer
 
     limitParam:
       name: limit
       in: query
-      description: Number of items per page
+      description: |
+        Number of items per page. Applies to all pagination modes (page, offset, and cursor).
+        Also accepted under the aliases `perPage`, `per_page`, `page_size`, and `pageSize`;
+        if several are provided, they are checked in that order of precedence, starting with `limit`.
+        Values above 100 are clamped to 100; values of 0 or less fall back to the default of 50.
       schema:
         type: integer
         default: 50
@@ -69,25 +76,20 @@ components:
     offsetParam:
       name: offset
       in: query
-      description: Number of items to skip (offset-based pagination)
+      description: |
+        Number of items to skip (offset-based pagination).
+        Takes precedence over `page`; ignored if `start_cursor` is also provided.
       schema:
         type: integer
 
     startCursorParam:
       name: start_cursor
       in: query
-      description: Cursor for cursor-based pagination
+      description: |
+        Cursor for cursor-based pagination.
+        Takes precedence over `offset` and `page` when provided.
       schema:
         type: string
-
-    pageSizeParam:
-      name: page_size
-      in: query
-      description: Number of items per page (cursor-based pagination)
-      schema:
-        type: integer
-        default: 50
-        maximum: 100
 
   schemas:
     SuccessResponse:
@@ -114,7 +116,6 @@ paths:
         - $ref: '#/components/parameters/limitParam'
         - $ref: '#/components/parameters/offsetParam'
         - $ref: '#/components/parameters/startCursorParam'
-        - $ref: '#/components/parameters/pageSizeParam'
       responses:
         '200':
           description: Successful response
@@ -142,7 +143,6 @@ paths:
         - $ref: '#/components/parameters/limitParam'
         - $ref: '#/components/parameters/offsetParam'
         - $ref: '#/components/parameters/startCursorParam'
-        - $ref: '#/components/parameters/pageSizeParam'
       responses:
         '200':
           description: Successful response
@@ -170,7 +170,6 @@ paths:
         - $ref: '#/components/parameters/limitParam'
         - $ref: '#/components/parameters/offsetParam'
         - $ref: '#/components/parameters/startCursorParam'
-        - $ref: '#/components/parameters/pageSizeParam'
       responses:
         '200':
           description: Successful response
@@ -187,7 +186,7 @@ paths:
       description: |
         Returns all published items from the specified model by default, and returns a paginated page response when pagination parameters are provided (GeoJSON endpoint).
         Requires the model to have a Geometry type field defined.
-        Uses the first (bases on the order) Geometry type field in the model schema fields.
+        Uses the first (based on the order) Geometry type field in the model schema fields.
       tags:
         - Items
       security:
@@ -199,7 +198,6 @@ paths:
         - $ref: '#/components/parameters/limitParam'
         - $ref: '#/components/parameters/offsetParam'
         - $ref: '#/components/parameters/startCursorParam'
-        - $ref: '#/components/parameters/pageSizeParam'
       responses:
         '200':
           description: Successful response
@@ -302,7 +300,6 @@ paths:
         - $ref: '#/components/parameters/limitParam'
         - $ref: '#/components/parameters/offsetParam'
         - $ref: '#/components/parameters/startCursorParam'
-        - $ref: '#/components/parameters/pageSizeParam'
       responses:
         '200':
           description: Successful response
@@ -329,7 +326,6 @@ paths:
         - $ref: '#/components/parameters/limitParam'
         - $ref: '#/components/parameters/offsetParam'
         - $ref: '#/components/parameters/startCursorParam'
-        - $ref: '#/components/parameters/pageSizeParam'
       responses:
         '200':
           description: Successful response
@@ -369,6 +365,7 @@ paths:
       summary: Get OpenAPI schema
       description: |
         Retrieve the OpenAPI schema for this project. Generated dynamically per project.
+        Served at the base project URL (`/api/p/{workspace}/{project}`).
       tags:
         - Schema
       responses:


### PR DESCRIPTION
## Summary

Adds a static OpenAPI 3.0.3 specification for the Public API (`server/schemas/publicapi/publicapi.yaml`), documenting all endpoints served under `/api/p/{workspace}/{project}`:

- Items: `/{model}`, `/{model}.json`, `/{model}.csv`, `/{model}.geojson`, `/{model}/{itemId}`
- Schema: `/{model}.schema.json`, `/{model}.metadata_schema.json`
- Assets: `/assets`, `/assets.json`, `/assets/{assetId}`
- Project-level OpenAPI schema endpoint (`/`)

The spec was verified against the actual handler implementation in `internal/adapter/publicapi`, and documents the real runtime behavior:

- API key security (`{}` + `apiKey`, HTTP bearer) on all endpoints that enforce project accessibility, including the schema export endpoints, with a reusable `401 UnauthorizedError` response on each of them
- Pagination: a single `limit` parameter with its accepted aliases (`perPage`, `per_page`, `page_size`, `pageSize`), clamping behavior (max 100, default 50), and pagination mode precedence (`start_cursor` > `offset` > `page`)
- 404 responses on all lookup/list endpoints

## Implementation changes

- `internal/app/app.go`: added `RemoveTrailingSlash` pre-middleware so endpoints resolve with or without a trailing slash (previously `/api/p/{ws}/{project}/` returned 404)
- `internal/adapter/publicapi/openapi.go`: the dynamically generated per-project spec now derives its security requirements from project visibility instead of always requiring an API key:
  - **Public projects** emit no security scheme or requirements, since no key is ever needed
  - **Private projects** declare the `apiKey` (HTTP bearer) scheme and mark every operation with `security: [{apiKey}]` plus a `401` response
  - Models are filtered with the caller's API key (`IsModelPublic(modelID, keyId)`) — the same check the runtime handlers use — so the generated spec reflects exactly what the presented credentials can access. As a result, private projects now generate paths for their accessible models instead of always returning an empty spec

## Testing

- `go build ./...`, `go vet`, and package tests for `internal/adapter/publicapi` and `internal/app` pass
- Spec validated as parseable YAML; parameter and response refs all resolve