### PR TITLE
feat(server): implement missing Cerbos permission checks

### DIFF
--- a/server/internal/usecase/interactor/asset.go
+++ b/server/internal/usecase/interactor/asset.go
@@ -924,6 +924,10 @@ func (i *Asset) UpdateFiles(ctx context.Context, aid id.AssetID, s *asset.Archiv
 				return nil, interfaces.ErrOperationDenied
 			}
 
+			if err := i.checkPermissions(ctx, rbac.ActionUpdate, id.ProjectIDList{a.Project()}); err != nil {
+				return nil, err
+			}
+
 			if shouldSkipUpdate(a.ArchiveExtractionStatus(), s) {
 				return a, nil
 			}

--- a/server/internal/usecase/interactor/integration.go
+++ b/server/internal/usecase/interactor/integration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/reearth/reearth-cms/server/internal/usecase/repo"
 	"github.com/reearth/reearth-cms/server/pkg/id"
 	"github.com/reearth/reearth-cms/server/pkg/integration"
+	"github.com/reearth/reearth-cms/server/pkg/rbac"
 	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/rerror"
 	"github.com/reearth/reearthx/util"
@@ -29,9 +30,16 @@ func NewIntegration(r *repo.Container, g *gateway.Container) interfaces.Integrat
 	}
 }
 
+func (i Integration) checkPermissions(ctx context.Context, action rbac.Action) error {
+	return doCheckPermission(ctx, i.gateways, rbac.ResourceIntegration, action)
+}
+
 func (i Integration) FindByMe(ctx context.Context, operator *usecase.Operator) (integration.List, error) {
 	if operator.AcOperator.User == nil {
 		return nil, interfaces.ErrInvalidOperator
+	}
+	if err := i.checkPermissions(ctx, rbac.ActionList); err != nil {
+		return nil, err
 	}
 	return Run1(ctx, operator, i.repos, Usecase().Transaction(),
 		func(ctx context.Context) (integration.List, error) {
@@ -47,6 +55,9 @@ func (i Integration) FindByIDs(ctx context.Context, ids id.IntegrationIDList, op
 	if operator.AcOperator.User == nil {
 		return nil, interfaces.ErrInvalidOperator
 	}
+	if err := i.checkPermissions(ctx, rbac.ActionRead); err != nil {
+		return nil, err
+	}
 	return Run1(ctx, operator, i.repos, Usecase().Transaction(),
 		func(ctx context.Context) (integration.List, error) {
 			in, err := i.repos.Integration.FindByIDs(ctx, ids)
@@ -60,6 +71,9 @@ func (i Integration) FindByIDs(ctx context.Context, ids id.IntegrationIDList, op
 func (i Integration) Create(ctx context.Context, param interfaces.CreateIntegrationParam, operator *usecase.Operator) (*integration.Integration, error) {
 	if operator.AcOperator.User == nil {
 		return nil, interfaces.ErrInvalidOperator
+	}
+	if err := i.checkPermissions(ctx, rbac.ActionCreate); err != nil {
+		return nil, err
 	}
 	return Run1(ctx, operator, i.repos, Usecase().Transaction(),
 		func(ctx context.Context) (*integration.Integration, error) {
@@ -87,6 +101,9 @@ func (i Integration) Create(ctx context.Context, param interfaces.CreateIntegrat
 func (i Integration) Update(ctx context.Context, iId id.IntegrationID, param interfaces.UpdateIntegrationParam, operator *usecase.Operator) (*integration.Integration, error) {
 	if operator.AcOperator.User == nil {
 		return nil, interfaces.ErrInvalidOperator
+	}
+	if err := i.checkPermissions(ctx, rbac.ActionUpdate); err != nil {
+		return nil, err
 	}
 	return Run1(ctx, operator, i.repos, Usecase().Transaction(),
 		func(ctx context.Context) (*integration.Integration, error) {
@@ -124,6 +141,9 @@ func (i Integration) Delete(ctx context.Context, integrationId id.IntegrationID,
 	if operator.AcOperator.User == nil {
 		return interfaces.ErrInvalidOperator
 	}
+	if err := i.checkPermissions(ctx, rbac.ActionDelete); err != nil {
+		return err
+	}
 	return Run0(ctx, operator, i.repos, Usecase().Transaction(),
 		func(ctx context.Context) error {
 			iid, err := accountdomain.IntegrationIDFrom(integrationId.String())
@@ -160,6 +180,9 @@ func (i Integration) Delete(ctx context.Context, integrationId id.IntegrationID,
 func (i Integration) DeleteMany(ctx context.Context, ids id.IntegrationIDList, operator *usecase.Operator) error {
 	if operator.AcOperator.User == nil {
 		return interfaces.ErrInvalidOperator
+	}
+	if err := i.checkPermissions(ctx, rbac.ActionDelete); err != nil {
+		return err
 	}
 	return Run0(ctx, operator, i.repos, Usecase().Transaction(),
 		func(ctx context.Context) error {
@@ -216,6 +239,9 @@ func (i Integration) RegenerateToken(ctx context.Context, iId id.IntegrationID, 
 	if operator.AcOperator.User == nil {
 		return nil, interfaces.ErrInvalidOperator
 	}
+	if err := i.checkPermissions(ctx, rbac.ActionUpdate); err != nil {
+		return nil, err
+	}
 	return Run1(ctx, operator, i.repos, Usecase().Transaction(),
 		func(ctx context.Context) (*integration.Integration, error) {
 			in, err := i.repos.Integration.FindByID(ctx, iId)
@@ -241,6 +267,9 @@ func (i Integration) RegenerateToken(ctx context.Context, iId id.IntegrationID, 
 func (i Integration) CreateWebhook(ctx context.Context, iId id.IntegrationID, param interfaces.CreateWebhookParam, operator *usecase.Operator) (*integration.Webhook, error) {
 	if operator.AcOperator.User == nil {
 		return nil, interfaces.ErrInvalidOperator
+	}
+	if err := i.checkPermissions(ctx, rbac.ActionUpdate); err != nil {
+		return nil, err
 	}
 	return Run1(ctx, operator, i.repos, Usecase().Transaction(),
 		func(ctx context.Context) (*integration.Webhook, error) {
@@ -280,6 +309,9 @@ func (i Integration) CreateWebhook(ctx context.Context, iId id.IntegrationID, pa
 func (i Integration) UpdateWebhook(ctx context.Context, iId id.IntegrationID, wId id.WebhookID, param interfaces.UpdateWebhookParam, operator *usecase.Operator) (*integration.Webhook, error) {
 	if operator.AcOperator.User == nil {
 		return nil, interfaces.ErrInvalidOperator
+	}
+	if err := i.checkPermissions(ctx, rbac.ActionUpdate); err != nil {
+		return nil, err
 	}
 	return Run1(ctx, operator, i.repos, Usecase().Transaction(),
 		func(ctx context.Context) (*integration.Webhook, error) {
@@ -333,6 +365,9 @@ func (i Integration) UpdateWebhook(ctx context.Context, iId id.IntegrationID, wI
 func (i Integration) DeleteWebhook(ctx context.Context, iId id.IntegrationID, wId id.WebhookID, operator *usecase.Operator) error {
 	if operator.AcOperator.User == nil {
 		return interfaces.ErrInvalidOperator
+	}
+	if err := i.checkPermissions(ctx, rbac.ActionUpdate); err != nil {
+		return err
 	}
 	return Run0(ctx, operator, i.repos, Usecase().Transaction(),
 		func(ctx context.Context) error {

--- a/server/internal/usecase/interactor/item_export.go
+++ b/server/internal/usecase/interactor/item_export.go
@@ -10,6 +10,7 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/exporters"
 	"github.com/reearth/reearth-cms/server/pkg/id"
 	"github.com/reearth/reearth-cms/server/pkg/item"
+	"github.com/reearth/reearth-cms/server/pkg/rbac"
 	"github.com/reearth/reearth-cms/server/pkg/version"
 	"github.com/reearth/reearthx/i18n"
 	"github.com/reearth/reearthx/log"
@@ -29,6 +30,10 @@ func defaultBatchConfig() *BatchConfig {
 }
 
 func (i Item) Export(ctx context.Context, params interfaces.ExportItemParams, w io.Writer, op *usecase.Operator) error {
+	if err := i.checkPermissions(ctx, rbac.ActionExport, id.ProjectIDList{params.SchemaPackage.Schema().Project()}); err != nil {
+		return err
+	}
+
 	// Create the exporter based on format
 	var exporter exporters.Exporter
 	switch params.Format {

--- a/server/internal/usecase/interactor/item_export.go
+++ b/server/internal/usecase/interactor/item_export.go
@@ -30,8 +30,10 @@ func defaultBatchConfig() *BatchConfig {
 }
 
 func (i Item) Export(ctx context.Context, params interfaces.ExportItemParams, w io.Writer, op *usecase.Operator) error {
-	if err := i.checkPermissions(ctx, rbac.ActionExport, id.ProjectIDList{params.SchemaPackage.Schema().Project()}); err != nil {
-		return err
+	if s := params.SchemaPackage.Schema(); s != nil {
+		if err := doCheckPermission(ctx, i.gateways, rbac.ResourceItem, rbac.ActionExport, s.Workspace()); err != nil {
+			return err
+		}
 	}
 
 	// Create the exporter based on format

--- a/server/internal/usecase/interactor/item_import.go
+++ b/server/internal/usecase/interactor/item_import.go
@@ -14,6 +14,7 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/job"
 	"github.com/reearth/reearth-cms/server/pkg/model"
 	"github.com/reearth/reearth-cms/server/pkg/project"
+	"github.com/reearth/reearth-cms/server/pkg/rbac"
 	"github.com/reearth/reearth-cms/server/pkg/schema"
 	"github.com/reearth/reearth-cms/server/pkg/task"
 	"github.com/reearth/reearth-cms/server/pkg/utils"
@@ -78,6 +79,9 @@ func (i Item) Import(ctx context.Context, param interfaces.ImportItemsParam, ope
 	s := param.SP.Schema()
 	if !operator.IsWritableWorkspace(s.Workspace()) {
 		return res.Into(), interfaces.ErrOperationDenied
+	}
+	if err := i.checkPermissions(ctx, rbac.ActionImport, id.ProjectIDList{s.Project()}); err != nil {
+		return res.Into(), err
 	}
 
 	lr := &io.LimitedReader{R: param.Reader, N: interfaces.MaxImportFileSize + 1}
@@ -205,6 +209,14 @@ func (i Item) TriggerImportJob(ctx context.Context, aId id.AssetID, mId id.Model
 		return interfaces.ErrInvalidOperator
 	}
 
+	m, err := i.repos.Model.FindByID(ctx, mId)
+	if err != nil {
+		return err
+	}
+	if err := i.checkPermissions(ctx, rbac.ActionImport, id.ProjectIDList{m.Project()}); err != nil {
+		return err
+	}
+
 	if i.gateways.TaskRunner == nil {
 		log.Info("item: import skipped because task runner is not configured")
 		return nil
@@ -241,6 +253,9 @@ func (i Item) ImportAsync(ctx context.Context, param interfaces.ImportItemsAsync
 	s := param.SP.Schema()
 	if !operator.IsWritableWorkspace(s.Workspace()) {
 		return id.JobID{}, interfaces.ErrOperationDenied
+	}
+	if err := i.checkPermissions(ctx, rbac.ActionImport, id.ProjectIDList{s.Project()}); err != nil {
+		return id.JobID{}, err
 	}
 
 	// Buffer the file content before starting the goroutine.

--- a/server/internal/usecase/interactor/item_import.go
+++ b/server/internal/usecase/interactor/item_import.go
@@ -80,7 +80,7 @@ func (i Item) Import(ctx context.Context, param interfaces.ImportItemsParam, ope
 	if !operator.IsWritableWorkspace(s.Workspace()) {
 		return res.Into(), interfaces.ErrOperationDenied
 	}
-	if err := i.checkPermissions(ctx, rbac.ActionImport, id.ProjectIDList{s.Project()}); err != nil {
+	if err := doCheckPermission(ctx, i.gateways, rbac.ResourceItem, rbac.ActionImport, s.Workspace()); err != nil {
 		return res.Into(), err
 	}
 
@@ -254,7 +254,7 @@ func (i Item) ImportAsync(ctx context.Context, param interfaces.ImportItemsAsync
 	if !operator.IsWritableWorkspace(s.Workspace()) {
 		return id.JobID{}, interfaces.ErrOperationDenied
 	}
-	if err := i.checkPermissions(ctx, rbac.ActionImport, id.ProjectIDList{s.Project()}); err != nil {
+	if err := doCheckPermission(ctx, i.gateways, rbac.ResourceItem, rbac.ActionImport, s.Workspace()); err != nil {
 		return id.JobID{}, err
 	}
 

--- a/server/internal/usecase/interactor/project.go
+++ b/server/internal/usecase/interactor/project.go
@@ -548,6 +548,10 @@ func (i *Project) CheckProjectLimits(ctx context.Context, workspaceID accountdom
 		return nil, interfaces.ErrOperationDenied
 	}
 
+	if err := doCheckPermission(ctx, i.gateways, rbac.ResourceProject, rbac.ActionRead, workspaceID); err != nil {
+		return nil, err
+	}
+
 	result := &interfaces.ProjectLimitsResult{
 		PublicProjectsAllowed:  true,
 		PrivateProjectsAllowed: true,

--- a/server/internal/usecase/interactor/workspacesettings.go
+++ b/server/internal/usecase/interactor/workspacesettings.go
@@ -8,6 +8,7 @@ import (
 	"github.com/reearth/reearth-cms/server/internal/usecase/gateway"
 	"github.com/reearth/reearth-cms/server/internal/usecase/interfaces"
 	"github.com/reearth/reearth-cms/server/internal/usecase/repo"
+	"github.com/reearth/reearth-cms/server/pkg/rbac"
 	"github.com/reearth/reearth-cms/server/pkg/workspacesettings"
 	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/rerror"
@@ -25,7 +26,19 @@ func NewWorkspaceSettings(r *repo.Container, g *gateway.Container) interfaces.Wo
 	}
 }
 
+func (ws *WorkspaceSettings) authz() gateway.Authorization {
+	if ws.gateways == nil {
+		return nil
+	}
+	return ws.gateways.Authorization
+}
+
 func (ws *WorkspaceSettings) Fetch(ctx context.Context, wid accountdomain.WorkspaceIDList, op *usecase.Operator) (result workspacesettings.List, err error) {
+	if len(wid) > 0 {
+		if err := doCheckPermission(ctx, ws.gateways, rbac.ResourceWorkspaceSettings, rbac.ActionRead, wid...); err != nil {
+			return nil, err
+		}
+	}
 	return ws.repos.WorkspaceSettings.FindByIDs(ctx, wid)
 }
 
@@ -35,7 +48,9 @@ func (ws *WorkspaceSettings) UpdateOrCreate(ctx context.Context, inp interfaces.
 		return nil, err
 	}
 
-	return Run1(ctx, op, ws.repos, Usecase().WithMaintainableWorkspaces(inp.ID).Transaction(),
+	return Run1(ctx, op, ws.repos, Usecase().WithMaintainableWorkspaces(inp.ID).
+		WithPermission(ws.authz(), rbac.ResourceWorkspaceSettings, rbac.ActionUpdate, inp.ID).
+		Transaction(),
 		func(ctx context.Context) (_ *workspacesettings.WorkspaceSettings, err error) {
 			if wss == nil {
 				wsb := workspacesettings.New().
@@ -60,7 +75,9 @@ func (ws *WorkspaceSettings) UpdateOrCreate(ctx context.Context, inp interfaces.
 }
 
 func (ws *WorkspaceSettings) Delete(ctx context.Context, inp interfaces.DeleteWorkspaceSettingsParam, op *usecase.Operator) error {
-	return Run0(ctx, op, ws.repos, Usecase().WithMaintainableWorkspaces(inp.ID).Transaction(),
+	return Run0(ctx, op, ws.repos, Usecase().WithMaintainableWorkspaces(inp.ID).
+		WithPermission(ws.authz(), rbac.ResourceWorkspaceSettings, rbac.ActionDelete, inp.ID).
+		Transaction(),
 		func(ctx context.Context) error {
 			return ws.repos.WorkspaceSettings.Remove(ctx, inp.ID)
 		})


### PR DESCRIPTION
## Summary
Adds Cerbos authorization checks to usecases that were missing them, completing the Cerbos permission-check rollout across the server:
- Asset: check update permission before archive extraction status update
- Integration: check list/read/create/update/delete permissions on all integration and webhook operations
- Item export/import: check export/import permissions before running export, import, async import, and triggered import jobs
- Project: check read permission before returning project limits
- WorkspaceSettings: check read/update/delete permissions on fetch, update-or-create, and delete

## Motivation
Continues the ongoing effort (see prior Cerbos permission-check PRs) to ensure every resource action goes through Cerbos authorization, closing gaps left in integration, item export/import, project, and workspace settings usecases.