### PR TITLE
fix(server): save extracted asset files outside the transaction to avoid WiredTiger transaction-size limit

### DIFF
--- a/server/internal/usecase/interactor/asset.go
+++ b/server/internal/usecase/interactor/asset.go
@@ -948,22 +948,29 @@ func (i *Asset) UpdateFiles(ctx context.Context, aid id.AssetID, s *asset.Archiv
 	})
 	log.Debugfc(ctx, "asset.UpdateFiles: listing asset files done: assetID=%s fileCount=%d", aid, len(assetFiles))
 
-	return Run1(
+	// SaveFlat below deliberately runs outside the transaction: for archives with
+	// hundreds of thousands of extracted files, inserting them all as part of one
+	// MongoDB transaction can exceed the storage engine's transaction-size limit
+	// (WiredTiger error -31800, "transaction is too large and will not fit in the
+	// storage engine cache"), aborting the whole write. SaveFlat already commits its
+	// bulk writes in independent batches; running it non-transactionally lets each
+	// batch commit on its own instead of accumulating in one uncommitted transaction.
+	a, prj, err := Run2(
 		ctx, op, i.repos,
 		Usecase().Transaction(),
-		func(ctx context.Context) (*asset.Asset, error) {
+		func(ctx context.Context) (*asset.Asset, *project.Project, error) {
 			a, skip, err := i.checkUpdateFilesPreconditions(ctx, aid, s, op)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			if skip {
 				log.Debugfc(ctx, "asset.UpdateFiles: skipped inside transaction, status already %s: assetID=%s", a.ArchiveExtractionStatus(), aid)
-				return a, nil
+				return a, nil, nil
 			}
 
 			prj, err := i.repos.Project.FindByID(ctx, a.Project())
 			if err != nil {
-				return nil, fmt.Errorf("failed to find a project: %w", err)
+				return nil, nil, fmt.Errorf("failed to find a project: %w", err)
 			}
 
 			a.UpdateArchiveExtractionStatus(s)
@@ -972,29 +979,59 @@ func (i *Asset) UpdateFiles(ctx context.Context, aid id.AssetID, s *asset.Archiv
 			}
 
 			if err := i.repos.Asset.Save(ctx, a); err != nil {
-				return nil, fmt.Errorf("failed to save an asset: %w", err)
+				return nil, nil, fmt.Errorf("failed to save an asset: %w", err)
 			}
 
-			log.Debugfc(ctx, "asset.UpdateFiles: saving asset files begin: assetID=%s fileCount=%d", aid, len(assetFiles))
-			if err := i.repos.AssetFile.SaveFlat(ctx, a.ID(), srcfile, assetFiles); err != nil {
-				return nil, fmt.Errorf("failed to save asset files: %w", err)
-			}
-			log.Debugfc(ctx, "asset.UpdateFiles: saving asset files done: assetID=%s", aid)
-
-			if err := i.event(ctx, Event{
-				Project:   prj,
-				Workspace: prj.Workspace(),
-				Type:      event.AssetDecompress,
-				Object:    a,
-				Operator:  op.Operator(),
-			}); err != nil {
-				return nil, fmt.Errorf("failed to create an event: %w", err)
-			}
-			log.Debugfc(ctx, "asset.UpdateFiles: done: assetID=%s", aid)
-
-			return a, nil
+			return a, prj, nil
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
+	if prj == nil {
+		// checkUpdateFilesPreconditions decided to skip; a is the asset as-is.
+		return a, nil
+	}
+
+	log.Debugfc(ctx, "asset.UpdateFiles: saving asset files begin: assetID=%s fileCount=%d", aid, len(assetFiles))
+	if err := i.repos.AssetFile.SaveFlat(ctx, a.ID(), srcfile, assetFiles); err != nil {
+		// The status-flipping transaction above already committed, so the asset would
+		// otherwise be left showing status s (e.g. "done") despite having no files.
+		// Best-effort mark it failed instead, so the UI doesn't show a misleading status.
+		i.markUpdateFilesFailed(ctx, aid)
+		return nil, fmt.Errorf("failed to save asset files: %w", err)
+	}
+	log.Debugfc(ctx, "asset.UpdateFiles: saving asset files done: assetID=%s", aid)
+
+	if err := i.event(ctx, Event{
+		Project:   prj,
+		Workspace: prj.Workspace(),
+		Type:      event.AssetDecompress,
+		Object:    a,
+		Operator:  op.Operator(),
+	}); err != nil {
+		i.markUpdateFilesFailed(ctx, aid)
+		return nil, fmt.Errorf("failed to create an event: %w", err)
+	}
+	log.Debugfc(ctx, "asset.UpdateFiles: done: assetID=%s", aid)
+
+	return a, nil
+}
+
+// markUpdateFilesFailed best-effort marks aid's archive extraction status as failed,
+// after UpdateFiles' status-flipping transaction already committed but a later,
+// non-transactional step (saving asset files, publishing the event) failed. Errors
+// here are only logged: the original error from the caller is what gets returned.
+func (i *Asset) markUpdateFilesFailed(ctx context.Context, aid id.AssetID) {
+	a, err := i.repos.Asset.FindByID(ctx, aid)
+	if err != nil {
+		log.Errorfc(ctx, "asset.UpdateFiles: failed to load asset %s to mark it failed: %v", aid, err)
+		return
+	}
+	a.UpdateArchiveExtractionStatus(lo.ToPtr(asset.ArchiveExtractionStatusFailed))
+	if err := i.repos.Asset.Save(ctx, a); err != nil {
+		log.Errorfc(ctx, "asset.UpdateFiles: failed to mark asset %s as failed: %v", aid, err)
+	}
 }
 
 func (i *Asset) checkUpdateFilesPreconditions(ctx context.Context, aid id.AssetID, s *asset.ArchiveExtractionStatus, op *usecase.Operator) (*asset.Asset, bool, error) {

--- a/server/internal/usecase/interactor/asset.go
+++ b/server/internal/usecase/interactor/asset.go
@@ -948,13 +948,6 @@ func (i *Asset) UpdateFiles(ctx context.Context, aid id.AssetID, s *asset.Archiv
 	})
 	log.Debugfc(ctx, "asset.UpdateFiles: listing asset files done: assetID=%s fileCount=%d", aid, len(assetFiles))
 
-	// SaveFlat below deliberately runs outside the transaction: for archives with
-	// hundreds of thousands of extracted files, inserting them all as part of one
-	// MongoDB transaction can exceed the storage engine's transaction-size limit
-	// (WiredTiger error -31800, "transaction is too large and will not fit in the
-	// storage engine cache"), aborting the whole write. SaveFlat already commits its
-	// bulk writes in independent batches; running it non-transactionally lets each
-	// batch commit on its own instead of accumulating in one uncommitted transaction.
 	a, prj, err := Run2(
 		ctx, op, i.repos,
 		Usecase().Transaction(),
@@ -989,15 +982,11 @@ func (i *Asset) UpdateFiles(ctx context.Context, aid id.AssetID, s *asset.Archiv
 		return nil, err
 	}
 	if prj == nil {
-		// checkUpdateFilesPreconditions decided to skip; a is the asset as-is.
 		return a, nil
 	}
 
 	log.Debugfc(ctx, "asset.UpdateFiles: saving asset files begin: assetID=%s fileCount=%d", aid, len(assetFiles))
 	if err := i.repos.AssetFile.SaveFlat(ctx, a.ID(), srcfile, assetFiles); err != nil {
-		// The status-flipping transaction above already committed, so the asset would
-		// otherwise be left showing status s (e.g. "done") despite having no files.
-		// Best-effort mark it failed instead, so the UI doesn't show a misleading status.
 		i.markUpdateFilesFailed(ctx, aid)
 		return nil, fmt.Errorf("failed to save asset files: %w", err)
 	}
@@ -1018,10 +1007,6 @@ func (i *Asset) UpdateFiles(ctx context.Context, aid id.AssetID, s *asset.Archiv
 	return a, nil
 }
 
-// markUpdateFilesFailed best-effort marks aid's archive extraction status as failed,
-// after UpdateFiles' status-flipping transaction already committed but a later,
-// non-transactional step (saving asset files, publishing the event) failed. Errors
-// here are only logged: the original error from the caller is what gets returned.
 func (i *Asset) markUpdateFilesFailed(ctx context.Context, aid id.AssetID) {
 	a, err := i.repos.Asset.FindByID(ctx, aid)
 	if err != nil {

--- a/server/internal/usecase/interactor/asset_test.go
+++ b/server/internal/usecase/interactor/asset_test.go
@@ -3,7 +3,6 @@ package interactor
 import (
 	"bytes"
 	"context"
-	"errors"
 	"io"
 	"path"
 	"runtime"
@@ -17,7 +16,6 @@ import (
 	"github.com/reearth/reearth-cms/server/internal/usecase"
 	"github.com/reearth/reearth-cms/server/internal/usecase/gateway"
 	"github.com/reearth/reearth-cms/server/internal/usecase/interfaces"
-	"github.com/reearth/reearth-cms/server/internal/usecase/repo"
 	"github.com/reearth/reearth-cms/server/pkg/asset"
 	"github.com/reearth/reearth-cms/server/pkg/file"
 	"github.com/reearth/reearth-cms/server/pkg/id"
@@ -1321,132 +1319,6 @@ func TestAsset_UpdateFiles(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestAsset_UpdateFiles_SavesFilesOnStatusTransition(t *testing.T) {
-	uid := accountdomain.NewUserID()
-	assetID, uuid1 := asset.NewID(), "5130c89f-8f67-4766-b127-49ee6796d464"
-	ws := workspace.New().NewID().MustBuild()
-	proj := project.New().NewID().Workspace(ws.ID()).MustBuild()
-
-	seedStatus := lo.ToPtr(asset.ArchiveExtractionStatusPending)
-	targetStatus := lo.ToPtr(asset.ArchiveExtractionStatusDone)
-	a := asset.New().
-		ID(assetID).
-		Project(proj.ID()).
-		CreatedByUser(uid).
-		Size(1000).
-		UUID(uuid1).
-		Thread(id.NewThreadID().Ref()).
-		ArchiveExtractionStatus(seedStatus).
-		MustBuild()
-	af := asset.NewFile().Name("xxx.zip").Path("xxx.zip").GuessContentType().Build()
-
-	acop := &accountusecase.Operator{
-		User:             &uid,
-		OwningWorkspaces: []accountdomain.WorkspaceID{ws.ID()},
-	}
-	op := &usecase.Operator{
-		AcOperator:     acop,
-		OwningProjects: []id.ProjectID{proj.ID()},
-	}
-
-	ctx := context.Background()
-	db := memory.New()
-	assert.NoError(t, db.Project.Save(ctx, proj))
-	assert.NoError(t, db.Asset.Save(ctx, a.Clone()))
-	assert.NoError(t, db.AssetFile.Save(ctx, assetID, af.Clone()))
-
-	assetUC := Asset{
-		repos: db,
-		gateways: &gateway.Container{
-			File: lo.Must(fs.NewFile(mockFs(), "", false)),
-		},
-		ignoreEvent: true,
-	}
-
-	got, err := assetUC.UpdateFiles(ctx, assetID, targetStatus, op)
-	assert.NoError(t, err)
-	assert.Equal(t, targetStatus.String(), got.ArchiveExtractionStatus().String())
-
-	// SaveFlat now runs after the status-flipping transaction commits (see
-	// UpdateFiles), rather than inside it; this asserts the files still end up saved.
-	saved, err := db.AssetFile.FindByID(ctx, assetID)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, saved.Files())
-}
-
-// erroringAssetFileRepo wraps a repo.AssetFile and fails the next N calls to
-// SaveFlat, to simulate a write error occurring after UpdateFiles' status-flipping
-// transaction has already committed.
-type erroringAssetFileRepo struct {
-	repo.AssetFile
-	failSaveFlatTimes int
-	saveFlatCalls     int
-	err               error
-}
-
-func (r *erroringAssetFileRepo) SaveFlat(ctx context.Context, id id.AssetID, parent *asset.File, files []*asset.File) error {
-	r.saveFlatCalls++
-	if r.saveFlatCalls <= r.failSaveFlatTimes {
-		return r.err
-	}
-	return r.AssetFile.SaveFlat(ctx, id, parent, files)
-}
-
-func TestAsset_UpdateFiles_MarksFailedOnSaveFlatError(t *testing.T) {
-	uid := accountdomain.NewUserID()
-	assetID, uuid1 := asset.NewID(), "5130c89f-8f67-4766-b127-49ee6796d464"
-	ws := workspace.New().NewID().MustBuild()
-	proj := project.New().NewID().Workspace(ws.ID()).MustBuild()
-
-	seedStatus := lo.ToPtr(asset.ArchiveExtractionStatusPending)
-	targetStatus := lo.ToPtr(asset.ArchiveExtractionStatusDone)
-	a := asset.New().
-		ID(assetID).
-		Project(proj.ID()).
-		CreatedByUser(uid).
-		Size(1000).
-		UUID(uuid1).
-		Thread(id.NewThreadID().Ref()).
-		ArchiveExtractionStatus(seedStatus).
-		MustBuild()
-	af := asset.NewFile().Name("xxx.zip").Path("xxx.zip").GuessContentType().Build()
-
-	acop := &accountusecase.Operator{
-		User:             &uid,
-		OwningWorkspaces: []accountdomain.WorkspaceID{ws.ID()},
-	}
-	op := &usecase.Operator{
-		AcOperator:     acop,
-		OwningProjects: []id.ProjectID{proj.ID()},
-	}
-
-	ctx := context.Background()
-	db := memory.New()
-	assert.NoError(t, db.Project.Save(ctx, proj))
-	assert.NoError(t, db.Asset.Save(ctx, a.Clone()))
-	assert.NoError(t, db.AssetFile.Save(ctx, assetID, af.Clone()))
-
-	wantErr := errors.New("write failed")
-	db.AssetFile = &erroringAssetFileRepo{AssetFile: db.AssetFile, failSaveFlatTimes: 1, err: wantErr}
-
-	assetUC := Asset{
-		repos: db,
-		gateways: &gateway.Container{
-			File: lo.Must(fs.NewFile(mockFs(), "", false)),
-		},
-		ignoreEvent: true,
-	}
-
-	_, err := assetUC.UpdateFiles(ctx, assetID, targetStatus, op)
-	assert.ErrorIs(t, err, wantErr)
-
-	// The status-flipping transaction already committed before SaveFlat failed, so
-	// without markUpdateFilesFailed the asset would incorrectly show targetStatus.
-	got, err := db.Asset.FindByID(ctx, assetID)
-	assert.NoError(t, err)
-	assert.Equal(t, asset.ArchiveExtractionStatusFailed.String(), got.ArchiveExtractionStatus().String())
 }
 
 func TestAsset_Delete(t *testing.T) {

--- a/server/internal/usecase/interactor/asset_test.go
+++ b/server/internal/usecase/interactor/asset_test.go
@@ -3,6 +3,7 @@ package interactor
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"path"
 	"runtime"
@@ -16,6 +17,7 @@ import (
 	"github.com/reearth/reearth-cms/server/internal/usecase"
 	"github.com/reearth/reearth-cms/server/internal/usecase/gateway"
 	"github.com/reearth/reearth-cms/server/internal/usecase/interfaces"
+	"github.com/reearth/reearth-cms/server/internal/usecase/repo"
 	"github.com/reearth/reearth-cms/server/pkg/asset"
 	"github.com/reearth/reearth-cms/server/pkg/file"
 	"github.com/reearth/reearth-cms/server/pkg/id"
@@ -1319,6 +1321,132 @@ func TestAsset_UpdateFiles(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAsset_UpdateFiles_SavesFilesOnStatusTransition(t *testing.T) {
+	uid := accountdomain.NewUserID()
+	assetID, uuid1 := asset.NewID(), "5130c89f-8f67-4766-b127-49ee6796d464"
+	ws := workspace.New().NewID().MustBuild()
+	proj := project.New().NewID().Workspace(ws.ID()).MustBuild()
+
+	seedStatus := lo.ToPtr(asset.ArchiveExtractionStatusPending)
+	targetStatus := lo.ToPtr(asset.ArchiveExtractionStatusDone)
+	a := asset.New().
+		ID(assetID).
+		Project(proj.ID()).
+		CreatedByUser(uid).
+		Size(1000).
+		UUID(uuid1).
+		Thread(id.NewThreadID().Ref()).
+		ArchiveExtractionStatus(seedStatus).
+		MustBuild()
+	af := asset.NewFile().Name("xxx.zip").Path("xxx.zip").GuessContentType().Build()
+
+	acop := &accountusecase.Operator{
+		User:             &uid,
+		OwningWorkspaces: []accountdomain.WorkspaceID{ws.ID()},
+	}
+	op := &usecase.Operator{
+		AcOperator:     acop,
+		OwningProjects: []id.ProjectID{proj.ID()},
+	}
+
+	ctx := context.Background()
+	db := memory.New()
+	assert.NoError(t, db.Project.Save(ctx, proj))
+	assert.NoError(t, db.Asset.Save(ctx, a.Clone()))
+	assert.NoError(t, db.AssetFile.Save(ctx, assetID, af.Clone()))
+
+	assetUC := Asset{
+		repos: db,
+		gateways: &gateway.Container{
+			File: lo.Must(fs.NewFile(mockFs(), "", false)),
+		},
+		ignoreEvent: true,
+	}
+
+	got, err := assetUC.UpdateFiles(ctx, assetID, targetStatus, op)
+	assert.NoError(t, err)
+	assert.Equal(t, targetStatus.String(), got.ArchiveExtractionStatus().String())
+
+	// SaveFlat now runs after the status-flipping transaction commits (see
+	// UpdateFiles), rather than inside it; this asserts the files still end up saved.
+	saved, err := db.AssetFile.FindByID(ctx, assetID)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, saved.Files())
+}
+
+// erroringAssetFileRepo wraps a repo.AssetFile and fails the next N calls to
+// SaveFlat, to simulate a write error occurring after UpdateFiles' status-flipping
+// transaction has already committed.
+type erroringAssetFileRepo struct {
+	repo.AssetFile
+	failSaveFlatTimes int
+	saveFlatCalls     int
+	err               error
+}
+
+func (r *erroringAssetFileRepo) SaveFlat(ctx context.Context, id id.AssetID, parent *asset.File, files []*asset.File) error {
+	r.saveFlatCalls++
+	if r.saveFlatCalls <= r.failSaveFlatTimes {
+		return r.err
+	}
+	return r.AssetFile.SaveFlat(ctx, id, parent, files)
+}
+
+func TestAsset_UpdateFiles_MarksFailedOnSaveFlatError(t *testing.T) {
+	uid := accountdomain.NewUserID()
+	assetID, uuid1 := asset.NewID(), "5130c89f-8f67-4766-b127-49ee6796d464"
+	ws := workspace.New().NewID().MustBuild()
+	proj := project.New().NewID().Workspace(ws.ID()).MustBuild()
+
+	seedStatus := lo.ToPtr(asset.ArchiveExtractionStatusPending)
+	targetStatus := lo.ToPtr(asset.ArchiveExtractionStatusDone)
+	a := asset.New().
+		ID(assetID).
+		Project(proj.ID()).
+		CreatedByUser(uid).
+		Size(1000).
+		UUID(uuid1).
+		Thread(id.NewThreadID().Ref()).
+		ArchiveExtractionStatus(seedStatus).
+		MustBuild()
+	af := asset.NewFile().Name("xxx.zip").Path("xxx.zip").GuessContentType().Build()
+
+	acop := &accountusecase.Operator{
+		User:             &uid,
+		OwningWorkspaces: []accountdomain.WorkspaceID{ws.ID()},
+	}
+	op := &usecase.Operator{
+		AcOperator:     acop,
+		OwningProjects: []id.ProjectID{proj.ID()},
+	}
+
+	ctx := context.Background()
+	db := memory.New()
+	assert.NoError(t, db.Project.Save(ctx, proj))
+	assert.NoError(t, db.Asset.Save(ctx, a.Clone()))
+	assert.NoError(t, db.AssetFile.Save(ctx, assetID, af.Clone()))
+
+	wantErr := errors.New("write failed")
+	db.AssetFile = &erroringAssetFileRepo{AssetFile: db.AssetFile, failSaveFlatTimes: 1, err: wantErr}
+
+	assetUC := Asset{
+		repos: db,
+		gateways: &gateway.Container{
+			File: lo.Must(fs.NewFile(mockFs(), "", false)),
+		},
+		ignoreEvent: true,
+	}
+
+	_, err := assetUC.UpdateFiles(ctx, assetID, targetStatus, op)
+	assert.ErrorIs(t, err, wantErr)
+
+	// The status-flipping transaction already committed before SaveFlat failed, so
+	// without markUpdateFilesFailed the asset would incorrectly show targetStatus.
+	got, err := db.Asset.FindByID(ctx, assetID)
+	assert.NoError(t, err)
+	assert.Equal(t, asset.ArchiveExtractionStatusFailed.String(), got.ArchiveExtractionStatus().String())
 }
 
 func TestAsset_Delete(t *testing.T) {


### PR DESCRIPTION
# Overview

For archives with hundreds of thousands of extracted files (tested with 577k), the decompress-finalize step kept failing silently and retrying forever, leaving the asset stuck at "in progress" in the UI. 

## Root cause
UpdateFiles wraps the whole write — including AssetFile.SaveFlat's bulk insert of every extracted file — in a single MongoDB transaction. Even though SaveFlat already sends its BulkWrite calls in batches, MongoDB's WiredTiger storage engine still has to hold all uncommitted writes from that one transaction in its cache until commit. For 577k files, the second batch pushed the transaction past WiredTiger's cache limit and the server aborted it — every retry hit the same wall.

## Fix
Split UpdateFiles so the transaction only covers the small, fast part (find asset, check preconditions, find project, flip status, save asset doc).
AssetFile.SaveFlat now runs after that transaction commits, non-transactionally, so each of its batches commits independently instead of accumulating in one giant uncommitted transaction.
Added markUpdateFilesFailed: since the status-flipping transaction now commits before files are saved, a failure in SaveFlat (or the follow-up event publish) would otherwise leave the asset showing a success status with no files. On failure, the asset is now best-effort marked failed instead.