### PR TITLE
fix: decouple Public API posting from authentication

### DIFF
--- a/server/e2e/publicapi_test.go
+++ b/server/e2e/publicapi_test.go
@@ -1156,7 +1156,7 @@ func TestPublicAPI_Model_Schema(t *testing.T) {
 }
 
 func TestPublicAPI_PostItem(t *testing.T) {
-	e := StartServer(t, &app.Config{}, true, baseSeederUser)
+	e, r, _ := StartServerWithRepos(t, &app.Config{}, true, baseSeederUser)
 
 	pId, _ := createProject(e, wId.String(), "posting-api-test", "posting-api-test", "posting-api-test")
 	mId, mRes := createModel(e, pId, "post-model", "post-model", "post-model")
@@ -1213,6 +1213,30 @@ func TestPublicAPI_PostItem(t *testing.T) {
 			Expect().
 			Status(http.StatusAccepted).
 			JSON().Object().ContainsKey("id").ContainsKey("$createdAt")
+	})
+
+	t.Run("invalid Public API key does not affect posting when a key is enabled", func(t *testing.T) {
+		ctx := context.Background()
+		projectID := lo.Must(id.ProjectIDFrom(pId))
+		modelID := lo.Must(id.ModelIDFrom(mId))
+		prj := lo.Must(r.Project.FindByID(ctx, projectID))
+		prj.Accessibility().SetAPIKeys(project.APIKeys{
+			project.NewAPIKeyBuilder().NewID().GenerateKey().Name("posting-key").
+				Publication(project.NewPublicationSettings(id.ModelIDList{modelID}, false)).Build(),
+		})
+		lo.Must0(r.Project.Save(ctx, prj))
+
+		e.POST("/api/p/{workspace}/{project}/{model}/items", wId.String(), pId, mKey).
+			WithHeader("Origin", "https://allowed.com").
+			WithHeader("Authorization", "Bearer secret_invalid").
+			Expect().
+			Status(http.StatusAccepted)
+
+		// Read endpoints remain protected by the Public API authentication middleware.
+		e.GET("/api/p/{workspace}/{project}/{model}", wId.String(), pId, mKey).
+			WithHeader("Authorization", "Bearer secret_invalid").
+			Expect().
+			Status(http.StatusUnauthorized)
 	})
 
 	// --- schema-based validation ---

--- a/server/internal/adapter/publicapi/api.go
+++ b/server/internal/adapter/publicapi/api.go
@@ -45,7 +45,7 @@ type RateLimitConfig struct {
 	ExpiresIn time.Duration
 }
 
-func Echo(e *echo.Group, rl RateLimitConfig) {
+func Echo(readGroup, postingGroup *echo.Group, rl RateLimitConfig) {
 
 	// --- Public API routing ---
 	// ws: workspace (id or alias)
@@ -62,11 +62,11 @@ func Echo(e *echo.Group, rl RateLimitConfig) {
 	// /:ws/:p/:m.zip
 	// /:ws/:p/:m/:i
 
-	e.GET("/:workspace/:project/:sub-route", SubRoute())
-	e.GET("/:workspace/:project/:model/:item", ItemOrAsset())
-	e.GET("/:workspace/:project", OpenAPISchema())
-	e.POST("/:workspace/:project/:model/items", PostItem(), RateLimitMiddleware(rl))
-	e.OPTIONS("/:workspace/:project/:model/items", PreflightItem())
+	readGroup.GET("/:workspace/:project/:sub-route", SubRoute())
+	readGroup.GET("/:workspace/:project/:model/:item", ItemOrAsset())
+	readGroup.GET("/:workspace/:project", OpenAPISchema())
+	postingGroup.POST("/:workspace/:project/:model/items", PostItem(), RateLimitMiddleware(rl))
+	postingGroup.OPTIONS("/:workspace/:project/:model/items", PreflightItem())
 }
 
 // parseSubRoute splits a sub-route segment into a model key and extension.

--- a/server/internal/app/public_api.go
+++ b/server/internal/app/public_api.go
@@ -30,8 +30,15 @@ func initPublicApi(appCtx *ApplicationContext, publicAPIGroup *echo.Group, useca
 		publicAPIGroup.OPTIONS("/*", func(ctx *echo.Context) error { return nil })
 	}
 
-	publicAPIGroup.Use(publicAPIAuthMiddleware(appCtx), usecaseMiddleware, AnonymousOperatorMiddleware())
-	publicapi.Echo(publicAPIGroup, publicApiRateLimit(appCtx))
+	readGroup := publicAPIGroup.Group("")
+	readGroup.Use(publicAPIAuthMiddleware(appCtx), usecaseMiddleware, AnonymousOperatorMiddleware())
+
+	// Posting is intentionally anonymous and must not be affected by Public API
+	// authentication, even when an Authorization header is present.
+	postingGroup := publicAPIGroup.Group("")
+	postingGroup.Use(usecaseMiddleware, AnonymousOperatorMiddleware())
+
+	publicapi.Echo(readGroup, postingGroup, publicApiRateLimit(appCtx))
 }
 
 func publicApiRateLimit(appCtx *ApplicationContext) publicapi.RateLimitConfig {

--- a/server/schemas/publicapi/publicapi.yaml
+++ b/server/schemas/publicapi/publicapi.yaml
@@ -331,9 +331,7 @@ paths:
         how many seconds to wait before retrying.
       tags:
         - Items
-      security:
-        - { }
-        - apiKey: [ ]
+      security: []
       parameters:
         - $ref: '#/components/parameters/modelParam'
       requestBody:
@@ -395,6 +393,7 @@ paths:
       description: Handles the CORS preflight request for browser-based posting clients.
       tags:
         - Items
+      security: []
       parameters:
         - $ref: '#/components/parameters/modelParam'
       responses:


### PR DESCRIPTION
# Overview

This PR decouples Public API posting from API key authentication. Posting should remain available regardless of whether the request has no token, a valid token, or an invalid token.

## What I've done

* Separated `POST` and `OPTIONS` routes from `publicAPIAuthMiddleware`.
* Kept the existing authentication behavior for GET routes.
* Updated the OpenAPI definition for posting to use `security: []`.
* Added an E2E test confirming that:

  * POST with `Bearer secret_invalid` is accepted.
  * GET with the same invalid token still returns `401`.

## What I haven't done

* I haven't changed the posting business logic or the authentication behavior of GET endpoints.
* Manual verification on the test environment is still pending.

## How I tested

* Ran the unit tests for `internal/app` and `publicapi`.
* Confirmed that all server packages compile successfully.
* Validated the OpenAPI YAML.
* Confirmed that the new E2E test compiles. Its local execution was skipped because MongoDB was not available in the local environment.

## Which point I want you to review particularly

Please review whether separating the posting routes from the authentication middleware is the right approach and whether any authentication-related behavior may still affect `POST` or `OPTIONS`.
