### PR TITLE
fix(ci): disable major updates for mongo-driver package

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>reearth/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "go.mongodb.org/mongo-driver"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Add a Renovate `packageRules` entry to disable major version updates for `go.mongodb.org/mongo-driver`

## Motivation
Major version bumps of the MongoDB Go driver can introduce breaking API changes and require careful manual review/testing, so we don't want Renovate auto-proposing them. Minor/patch updates are still allowed.

Note: we can revisit/re-enable this once reearthx picks up the corresponding mongo-driver major update.