### PR TITLE
fix(server): drop project lookup from UpdateFiles archive-decompress event

### DIFF
--- a/server/internal/usecase/interactor/asset.go
+++ b/server/internal/usecase/interactor/asset.go
@@ -916,11 +916,6 @@ func (i *Asset) UpdateFiles(ctx context.Context, aid id.AssetID, s *asset.Archiv
 		return a, nil
 	}
 
-	prj, err := i.repos.Project.FindByID(ctx, a.Project())
-	if err != nil {
-		return nil, fmt.Errorf("failed to find a project: %w", err)
-	}
-
 	srcfile, err := i.repos.AssetFile.FindByID(ctx, aid)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find an asset file: %w", err)
@@ -982,11 +977,9 @@ func (i *Asset) UpdateFiles(ctx context.Context, aid id.AssetID, s *asset.Archiv
 	log.Debugfc(ctx, "asset.UpdateFiles: done: assetID=%s", aid)
 
 	if err := i.event(ctx, Event{
-		Project:   prj,
-		Workspace: prj.Workspace(),
-		Type:      event.AssetDecompress,
-		Object:    a,
-		Operator:  op.Operator(),
+		Type:     event.AssetDecompress,
+		Object:   a,
+		Operator: op.Operator(),
 	}); err != nil {
 		return nil, fmt.Errorf("failed to create an event: %w", err)
 	}


### PR DESCRIPTION
# Overview

Removes the Project.FindByID call in Asset.UpdateFiles and stops
populating Event.Project/Event.Workspace when firing the
AssetDecompress event, to avoid failing on assets whose project no
longer exists.
