### PR TITLE
fix(server): keep asset file commit atomic with status update

### DIFF
--- a/server/internal/infrastructure/memory/asset_file.go
+++ b/server/internal/infrastructure/memory/asset_file.go
@@ -75,11 +75,18 @@ func (r *AssetFile) Save(ctx context.Context, id id.AssetID, file *asset.File) e
 	return nil
 }
 
-func (r *AssetFile) SaveFlat(ctx context.Context, id id.AssetID, parent *asset.File, files []*asset.File) error {
+func (r *AssetFile) SaveFlatFiles(ctx context.Context, id id.AssetID, files []*asset.File) error {
+	if r.err != nil {
+		return r.err
+	}
+	r.files.Store(id, slices.Clone(files))
+	return nil
+}
+
+func (r *AssetFile) CommitFlatFiles(ctx context.Context, id id.AssetID, parent *asset.File) error {
 	if r.err != nil {
 		return r.err
 	}
 	r.data.Store(id, parent.Clone())
-	r.files.Store(id, slices.Clone(files))
 	return nil
 }

--- a/server/internal/infrastructure/mongo/asset_file.go
+++ b/server/internal/infrastructure/mongo/asset_file.go
@@ -143,23 +143,11 @@ func (r *AssetFile) Save(ctx context.Context, id id.AssetID, file *asset.File) e
 	return nil
 }
 
-func (r *AssetFile) SaveFlat(ctx context.Context, id id.AssetID, parent *asset.File, files []*asset.File) error {
-	doc := mongodoc.NewFile(parent)
-	_, err := r.client.Client().UpdateOne(ctx, bson.M{
-		"id": id.String(),
-	}, bson.M{
-		"$set": bson.M{
-			"id":        id.String(),
-			"flatfiles": true,
-			"file":      doc,
-		},
-	})
-	if errors.Is(err, mongo.ErrNoDocuments) {
-		return rerror.ErrNotFound
-	}
-	if err != nil {
-		return rerror.ErrInternalBy(err)
-	}
+// SaveFlatFiles replaces the staged file list for the asset. It does not
+// touch the parent asset document's flatfiles pointer, so it is safe to run
+// outside a transaction regardless of how large the file list is; readers
+// keep seeing the previous file tree until CommitFlatFiles flips the pointer.
+func (r *AssetFile) SaveFlatFiles(ctx context.Context, id id.AssetID, files []*asset.File) error {
 	if err := r.assetFilesClient.RemoveAll(ctx, bson.M{"assetid": id.String()}); err != nil {
 		return rerror.ErrInternalBy(err)
 	}
@@ -179,6 +167,29 @@ func (r *AssetFile) SaveFlat(ctx context.Context, id id.AssetID, parent *asset.F
 			return rerror.ErrInternalBy(err)
 		}
 		log.Debugfc(ctx, "mongo asset_file: bulk write batch done: assetID=%s batch=%d/%d", id, i+1, len(batches))
+	}
+	return nil
+}
+
+// CommitFlatFiles points the parent asset document at the file list most
+// recently written by SaveFlatFiles. This is a single small document write,
+// so it is safe to run inside a transaction alongside other asset writes.
+func (r *AssetFile) CommitFlatFiles(ctx context.Context, id id.AssetID, parent *asset.File) error {
+	doc := mongodoc.NewFile(parent)
+	_, err := r.client.Client().UpdateOne(ctx, bson.M{
+		"id": id.String(),
+	}, bson.M{
+		"$set": bson.M{
+			"id":        id.String(),
+			"flatfiles": true,
+			"file":      doc,
+		},
+	})
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return rerror.ErrNotFound
+	}
+	if err != nil {
+		return rerror.ErrInternalBy(err)
 	}
 	return nil
 }

--- a/server/internal/infrastructure/mongo/asset_file_test.go
+++ b/server/internal/infrastructure/mongo/asset_file_test.go
@@ -94,7 +94,7 @@ func TestAssetFileRepo_FindByID(t *testing.T) {
 	}
 }
 
-func TestAssetFileRepo_SaveFlat(t *testing.T) {
+func TestAssetFileRepo_SaveFlatFiles_CommitFlatFiles(t *testing.T) {
 	initDB := mongotest.Connect(t)
 
 	t.Run("saves and round-trips files across multiple pages and bulk-write batches", func(t *testing.T) {
@@ -119,7 +119,8 @@ func TestAssetFileRepo_SaveFlat(t *testing.T) {
 			files[i] = asset.NewFile().Name(name).Path(name).Size(1).Build()
 		}
 
-		assert.NoError(t, r.SaveFlat(ctx, aid, parent, files))
+		assert.NoError(t, r.SaveFlatFiles(ctx, aid, files))
+		assert.NoError(t, r.CommitFlatFiles(ctx, aid, parent))
 
 		got, err := r.FindByID(ctx, aid)
 		assert.NoError(t, err)
@@ -155,7 +156,8 @@ func TestAssetFileRepo_SaveFlat(t *testing.T) {
 			files[i] = asset.NewFile().Name(name).Path(name).Size(1).Build()
 		}
 
-		assert.NoError(t, r.SaveFlat(ctx, aid, parent, files))
+		assert.NoError(t, r.SaveFlatFiles(ctx, aid, files))
+		assert.NoError(t, r.CommitFlatFiles(ctx, aid, parent))
 
 		got, err := r.FindByID(ctx, aid)
 		assert.NoError(t, err)
@@ -185,14 +187,45 @@ func TestAssetFileRepo_SaveFlat(t *testing.T) {
 		assert.NoError(t, r.Save(ctx, aid, parent))
 
 		first := []*asset.File{asset.NewFile().Name("old.txt").Path("old.txt").Size(1).Build()}
-		assert.NoError(t, r.SaveFlat(ctx, aid, parent, first))
+		assert.NoError(t, r.SaveFlatFiles(ctx, aid, first))
+		assert.NoError(t, r.CommitFlatFiles(ctx, aid, parent))
 
 		second := []*asset.File{asset.NewFile().Name("new.txt").Path("new.txt").Size(1).Build()}
-		assert.NoError(t, r.SaveFlat(ctx, aid, parent, second))
+		assert.NoError(t, r.SaveFlatFiles(ctx, aid, second))
+		assert.NoError(t, r.CommitFlatFiles(ctx, aid, parent))
 
 		got, err := r.FindByID(ctx, aid)
 		assert.NoError(t, err)
 		assert.Len(t, got.Files(), 1)
 		assert.Equal(t, "/new.txt", got.Files()[0].Path())
+	})
+
+	t.Run("files are not visible until CommitFlatFiles flips the pointer", func(t *testing.T) {
+		t.Parallel()
+
+		db := initDB(t)
+		ctx := context.Background()
+		client := mongox.NewClientWithDatabase(db)
+		r := NewAssetFile(client)
+
+		aid := id.NewAssetID()
+		_, err := db.Collection("asset").InsertOne(ctx, bson.M{"id": aid.String()})
+		assert.NoError(t, err)
+
+		parent := asset.NewFile().Name("root").Path("/").Build()
+		assert.NoError(t, r.Save(ctx, aid, parent))
+
+		files := []*asset.File{asset.NewFile().Name("new.txt").Path("new.txt").Size(1).Build()}
+		assert.NoError(t, r.SaveFlatFiles(ctx, aid, files))
+
+		got, err := r.FindByID(ctx, aid)
+		assert.NoError(t, err)
+		assert.Empty(t, got.Files())
+
+		assert.NoError(t, r.CommitFlatFiles(ctx, aid, parent))
+
+		got, err = r.FindByID(ctx, aid)
+		assert.NoError(t, err)
+		assert.Len(t, got.Files(), 1)
 	})
 }

--- a/server/internal/usecase/interactor/asset.go
+++ b/server/internal/usecase/interactor/asset.go
@@ -916,6 +916,11 @@ func (i *Asset) UpdateFiles(ctx context.Context, aid id.AssetID, s *asset.Archiv
 		return a, nil
 	}
 
+	prj, err := i.repos.Project.FindByID(ctx, a.Project())
+	if err != nil && !errors.Is(err, rerror.ErrNotFound) {
+		return nil, fmt.Errorf("failed to find a project: %w", err)
+	}
+
 	srcfile, err := i.repos.AssetFile.FindByID(ctx, aid)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find an asset file: %w", err)
@@ -948,10 +953,26 @@ func (i *Asset) UpdateFiles(ctx context.Context, aid id.AssetID, s *asset.Archiv
 	})
 	log.Debugfc(ctx, "asset.UpdateFiles: listing asset files done: assetID=%s fileCount=%d", aid, len(assetFiles))
 
+	// Stage the (possibly large) file list outside the transaction: a
+	// MongoDB transaction has to hold every write in its WiredTiger cache
+	// until commit, so bulk-inserting a large archive's files inside one
+	// can exceed the engine's transaction-size limit. SaveFlatFiles doesn't
+	// touch the asset's flatfiles pointer, so readers keep seeing the
+	// previous file tree until CommitFlatFiles flips it below.
+	log.Debugfc(ctx, "asset.UpdateFiles: saving asset files begin: assetID=%s fileCount=%d", aid, len(assetFiles))
+	if err := i.repos.AssetFile.SaveFlatFiles(ctx, aid, assetFiles); err != nil {
+		return nil, fmt.Errorf("failed to save asset files: %w", err)
+	}
+	log.Debugfc(ctx, "asset.UpdateFiles: saving asset files done: assetID=%s", aid)
+
 	res, err := Run1(
 		ctx, op, i.repos,
 		Usecase().Transaction(),
 		func(ctx context.Context) (*asset.Asset, error) {
+			if err := i.repos.AssetFile.CommitFlatFiles(ctx, aid, srcfile); err != nil {
+				return nil, fmt.Errorf("failed to commit asset files: %w", err)
+			}
+
 			a.UpdateArchiveExtractionStatus(s)
 			if previewType != nil {
 				a.UpdatePreviewType(previewType)
@@ -969,24 +990,16 @@ func (i *Asset) UpdateFiles(ctx context.Context, aid id.AssetID, s *asset.Archiv
 		return nil, err
 	}
 
-	log.Debugfc(ctx, "asset.UpdateFiles: saving asset files begin: assetID=%s fileCount=%d", aid, len(assetFiles))
-	if err := i.repos.AssetFile.SaveFlat(ctx, res.ID(), srcfile, assetFiles); err != nil {
-		i.markUpdateFilesFailed(ctx, aid)
-		return nil, fmt.Errorf("failed to save asset files: %w", err)
+	ev := Event{
+		Type:     event.AssetDecompress,
+		Object:   res,
+		Operator: op.Operator(),
 	}
-	log.Debugfc(ctx, "asset.UpdateFiles: saving asset files done: assetID=%s", aid)
-
-	prj, err := i.repos.Project.FindByID(ctx, res.Project())
-	if err != nil {
-		return nil, fmt.Errorf("failed to find a project: %w", err)
+	if prj != nil {
+		ev.Project = prj
+		ev.Workspace = prj.Workspace()
 	}
-	if err := i.event(ctx, Event{
-		Project:   prj,
-		Workspace: prj.Workspace(),
-		Type:      event.AssetDecompress,
-		Object:    res,
-		Operator:  op.Operator(),
-	}); err != nil {
+	if err := i.event(ctx, ev); err != nil {
 		return nil, fmt.Errorf("failed to create an event: %w", err)
 	}
 	log.Debugfc(ctx, "asset.UpdateFiles: done: assetID=%s", aid)
@@ -1086,17 +1099,20 @@ func (i *Asset) Delete(ctx context.Context, aId id.AssetID, operator *usecase.Op
 		}
 
 		p, err := i.repos.Project.FindByID(ctx, a.Project())
-		if err != nil {
+		if err != nil && !errors.Is(err, rerror.ErrNotFound) {
 			return aId, err
 		}
 
-		if err := i.event(ctx, Event{
-			Project:   p,
-			Workspace: p.Workspace(),
-			Type:      event.AssetDelete,
-			Object:    a,
-			Operator:  operator.Operator(),
-		}); err != nil {
+		ev := Event{
+			Type:     event.AssetDelete,
+			Object:   a,
+			Operator: operator.Operator(),
+		}
+		if p != nil {
+			ev.Project = p
+			ev.Workspace = p.Workspace()
+		}
+		if err := i.event(ctx, ev); err != nil {
 			return aId, err
 		}
 

--- a/server/internal/usecase/interactor/asset_test.go
+++ b/server/internal/usecase/interactor/asset_test.go
@@ -1144,13 +1144,28 @@ func TestAsset_UpdateFiles(t *testing.T) {
 		ArchiveExtractionStatus(sp).
 		MustBuild()
 	a2f := asset.NewFile().Build()
+
+	assetID3 := asset.NewID()
+	orphanProj := project.New().NewID().Workspace(ws.ID()).MustBuild()
+	a3 := asset.New().
+		ID(assetID3).
+		Project(orphanProj.ID()).
+		CreatedByUser(uid).
+		Size(1000).
+		UUID(uuid1).
+		Thread(id.NewThreadID().Ref()).
+		ArchiveExtractionStatus(sp).
+		MustBuild()
+	a3f := asset.NewFile().Name("xxx").Path("/xxx.zip").GuessContentType().Build()
+	sd := lo.ToPtr(asset.ArchiveExtractionStatusDone)
+
 	acop := &accountusecase.Operator{
 		User:             &uid,
 		OwningWorkspaces: []accountdomain.WorkspaceID{ws.ID()},
 	}
 	op := &usecase.Operator{
 		AcOperator:     acop,
-		OwningProjects: []id.ProjectID{proj.ID()},
+		OwningProjects: []id.ProjectID{proj.ID(), orphanProj.ID()},
 	}
 
 	tests := []struct {
@@ -1269,6 +1284,39 @@ func TestAsset_UpdateFiles(t *testing.T) {
 			}).Build(),
 			wantErr: nil,
 		},
+		{
+			name:       "update with orphaned project",
+			operator:   op,
+			seedAssets: asset.List{a3.Clone()},
+			seedFiles: map[asset.ID]*asset.File{
+				a3.ID(): a3f,
+			},
+			// orphanProj is intentionally not seeded, simulating a project
+			// that was deleted while the asset still references it.
+			prepareFileFunc: func() afero.Fs {
+				return mockFs()
+			},
+			assetID: assetID3,
+			status:  sd,
+			want: asset.New().
+				ID(assetID3).
+				Project(orphanProj.ID()).
+				CreatedByUser(uid).
+				Size(1000).
+				UUID(uuid1).
+				Thread(a3.Thread()).
+				ArchiveExtractionStatus(sd).
+				MustBuild(),
+			wantFile: asset.NewFile().Name("xxx").Path(path.Join("xxx.zip")).GuessContentType().Children([]*asset.File{
+				asset.NewFile().Name("xxx").Path(path.Join("xxx")).Dir().Children([]*asset.File{
+					asset.NewFile().Name("yyy").Path(path.Join("xxx", "yyy")).Dir().Children([]*asset.File{
+						asset.NewFile().Name("hello.txt").Path(path.Join("xxx", "yyy", "hello.txt")).GuessContentType().Build(),
+					}).Build(),
+					asset.NewFile().Name("zzz.txt").Path(path.Join("xxx", "zzz.txt")).GuessContentType().Build(),
+				}).Build(),
+			}).Build(),
+			wantErr: nil,
+		},
 	}
 
 	for _, tc := range tests {
@@ -1335,13 +1383,18 @@ func TestAsset_Delete(t *testing.T) {
 	a2 := asset.New().ID(aid2).Project(proj2.ID()).NewUUID().
 		CreatedByUser(uid).Size(1000).Thread(id.NewThreadID().Ref()).MustBuild()
 
+	orphanProj := project.New().NewID().Workspace(ws.ID()).MustBuild()
+	aid3 := id.NewAssetID()
+	a3 := asset.New().ID(aid3).Project(orphanProj.ID()).NewUUID().
+		CreatedByUser(uid).Size(1000).Thread(id.NewThreadID().Ref()).MustBuild()
+
 	acop := &accountusecase.Operator{
 		User:             &uid,
 		OwningWorkspaces: []accountdomain.WorkspaceID{ws.ID()},
 	}
 	op := &usecase.Operator{
 		AcOperator:     acop,
-		OwningProjects: []id.ProjectID{proj1.ID()},
+		OwningProjects: []id.ProjectID{proj1.ID(), orphanProj.ID()},
 	}
 	type args struct {
 		id       id.AssetID
@@ -1414,6 +1467,18 @@ func TestAsset_Delete(t *testing.T) {
 			},
 			want:    nil,
 			wantErr: rerror.ErrNotFound,
+		},
+		{
+			name:       "delete with orphaned project",
+			seedsAsset: asset.List{a3},
+			// orphanProj is intentionally not seeded, simulating a project
+			// that was deleted while the asset still references it.
+			args: args{
+				id:       aid3,
+				operator: op,
+			},
+			want:    nil,
+			wantErr: nil,
 		},
 	}
 

--- a/server/internal/usecase/interactor/common.go
+++ b/server/internal/usecase/interactor/common.go
@@ -106,6 +106,11 @@ func webhooks(ctx context.Context, r *repo.Container, g *gateway.Container, el [
 
 	// all events are assumed to have the same workspace
 	wId := el[0].Workspace
+	if wId.IsNil() {
+		log.Infof("asset: webhook was not sent because event has no workspace")
+		return nil
+	}
+
 	ws, err := r.Workspace.FindByID(ctx, wId)
 	if err != nil {
 		return err

--- a/server/internal/usecase/interactor/common_test.go
+++ b/server/internal/usecase/interactor/common_test.go
@@ -102,6 +102,12 @@ func TestCommon_webhook(t *testing.T) {
 	}
 
 	ctx := context.Background()
+
+	// empty workspace ID: skipped without error, no lookup attempted
+	mRunner.EXPECT().Run(ctx, gomock.Any()).Times(0)
+	err = webhook(ctx, db, gw, Event{}, ev)
+	assert.NoError(t, err)
+
 	// no workspace
 	err = webhook(ctx, db, gw, Event{Workspace: ws.ID()}, ev)
 	assert.Error(t, err)

--- a/server/internal/usecase/repo/asset.go
+++ b/server/internal/usecase/repo/asset.go
@@ -30,5 +30,13 @@ type AssetFile interface {
 	FindByID(context.Context, id.AssetID) (*asset.File, error)
 	FindByIDs(context.Context, id.AssetIDList) (map[id.AssetID]*asset.File, error)
 	Save(context.Context, id.AssetID, *asset.File) error
-	SaveFlat(context.Context, id.AssetID, *asset.File, []*asset.File) error
+	// SaveFlatFiles writes the flattened file list to storage without
+	// flipping the parent asset's flatfiles pointer, so a large write can
+	// run outside a transaction while CommitFlatFiles stays small enough
+	// to run inside one.
+	SaveFlatFiles(context.Context, id.AssetID, []*asset.File) error
+	// CommitFlatFiles flips the parent asset document to point at the files
+	// most recently written by SaveFlatFiles. Cheap and safe to run inside
+	// a transaction alongside other asset writes.
+	CommitFlatFiles(context.Context, id.AssetID, *asset.File) error
 }


### PR DESCRIPTION
## Summary
- Splits `AssetFile.SaveFlat` into `SaveFlatFiles` (writes the flattened file list to the `asset_files` collection, unbounded size, runs outside the transaction) and `CommitFlatFiles` (flips the parent asset's `flatfiles` pointer — a single small document write — runs inside the same transaction as the status/PreviewType update).
- Restores atomicity between the asset's `ArchiveExtractionStatus` and its file tree without reintroducing the WiredTiger "transaction too large / oldest pinned transaction rolled back for eviction" crash: a MongoDB transaction has to hold every write in its cache until commit, so bulk-inserting a large archive's files inside one can exceed the engine's size limit regardless of batching. Staging the files first (outside tx) and committing only the pointer flip (inside tx) keeps both properties.
- Also restores the orphaned-project tolerance in `UpdateFiles`/`Delete` and the `webhooks()` nil-workspace guard, which were dropped from `main` when SaveFlat was reverted back inside the transaction (#1984) — that revert was based on an older commit and lost these fixes.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run` on changed packages — 0 issues
- [x] `go test ./...` — all 43 packages pass
- [x] New/updated tests:
  - `TestAssetFileRepo_SaveFlatFiles_CommitFlatFiles` (mongo integration, requires `REEARTH_CMS_DB`) — includes a new case asserting files aren't visible until `CommitFlatFiles` flips the pointer
  - `TestAsset_UpdateFiles/update_with_orphaned_project`
  - `TestAsset_Delete/delete_with_orphaned_project`
  - `TestCommon_webhook` — empty-workspace skip case