### PR TITLE
fix(server): wire ref query param through Integration API item endpoints

### DIFF
--- a/server/e2e/integration_item_test.go
+++ b/server/e2e/integration_item_test.go
@@ -2131,6 +2131,113 @@ func TestIntegrationGetItemAPI(t *testing.T) {
 		})
 }
 
+// GET /items/{itemId}?ref=public vs ref=latest
+func TestIntegrationGetItemAPIRef(t *testing.T) {
+	e := StartServer(t, &app.Config{}, true, baseSeeder)
+
+	// itmId1 has never been published: ref=public must not find it, ref=latest/default must.
+	iAPIItemGet(e, wId0, pid, mId1, itmId1).
+		WithHeader("authorization", "Bearer "+secret).
+		WithQuery("ref", "public").
+		Expect().
+		Status(http.StatusNotFound)
+
+	iAPIItemGet(e, wId0, pid, mId1, itmId1).
+		WithHeader("authorization", "Bearer "+secret).
+		WithQuery("ref", "latest").
+		Expect().
+		Status(http.StatusOK).
+		JSON().
+		Object().
+		Value("fields").
+		IsEqual([]any{
+			map[string]string{
+				"id":    fId2.String(),
+				"key":   "asset",
+				"type":  "asset",
+				"value": aid1.String(),
+			},
+		})
+
+	// Publish the current version, then diverge the draft from it.
+	iAPIItemPublish(e, wId0, pid, mId1, itmId1).
+		WithHeader("authorization", "Bearer "+secret).
+		Expect().
+		Status(http.StatusOK).
+		JSON().
+		Object().
+		Value("refs").
+		Array().
+		ContainsAny("public")
+
+	iAPIItemUpdate(e, wId0, pid, mId1, itmId1).
+		WithHeader("authorization", "Bearer "+secret).
+		WithJSON(map[string]any{
+			"fields": []any{
+				map[string]string{
+					"id":    fId1.String(),
+					"value": "draft-only value",
+				},
+			},
+		}).
+		Expect().
+		Status(http.StatusOK)
+
+	// ref=public must still return the published version, unaffected by the later draft edit.
+	rPublic := iAPIItemGet(e, wId0, pid, mId1, itmId1).
+		WithHeader("authorization", "Bearer "+secret).
+		WithQuery("ref", "public").
+		Expect().
+		Status(http.StatusOK).
+		JSON().
+		Object()
+	rPublic.Value("refs").IsEqual([]string{"public"})
+	rPublic.Value("fields").IsEqual([]any{
+		map[string]string{
+			"id":    fId2.String(),
+			"key":   "asset",
+			"type":  "asset",
+			"value": aid1.String(),
+		},
+	})
+
+	// ref=latest (and the default, no ref) must return the draft, including the new field.
+	for _, q := range []map[string]any{{"ref": "latest"}, {}} {
+		req := iAPIItemGet(e, wId0, pid, mId1, itmId1).
+			WithHeader("authorization", "Bearer "+secret)
+		for k, v := range q {
+			req = req.WithQuery(k, v)
+		}
+		rLatest := req.
+			Expect().
+			Status(http.StatusOK).
+			JSON().
+			Object()
+		rLatest.Value("refs").IsEqual([]string{"latest"})
+		rLatest.Value("fields").IsEqual([]any{
+			map[string]string{
+				"id":    fId2.String(),
+				"key":   "asset",
+				"type":  "asset",
+				"value": aid1.String(),
+			},
+			map[string]string{
+				"id":    fId1.String(),
+				"type":  "text",
+				"value": "draft-only value",
+				"key":   sfKey1.String(),
+			},
+		})
+	}
+
+	// A caller without read permission still gets rejected regardless of ref.
+	iAPIItemGet(e, wId0, pid, mId1, itmId1).
+		WithHeader("authorization", "Bearer secret_abc").
+		WithQuery("ref", "public").
+		Expect().
+		Status(http.StatusUnauthorized)
+}
+
 // DELETE /items/{itemId}
 func TestIntegrationDeleteItemAPI(t *testing.T) {
 	e := StartServer(t, &app.Config{}, true, baseSeeder)

--- a/server/internal/adapter/gql/resolver_item.go
+++ b/server/internal/adapter/gql/resolver_item.go
@@ -228,7 +228,7 @@ func (r *mutationResolver) DeleteItem(ctx context.Context, input gqlmodel.Delete
 		return nil, err
 	}
 
-	i, err := usecases(ctx).Item.FindByID(ctx, iid, getOperator(ctx))
+	i, err := usecases(ctx).Item.FindByID(ctx, iid, nil, getOperator(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func (r *mutationResolver) DeleteItems(ctx context.Context, input gqlmodel.Delet
 		return nil, err
 	}
 
-	i, err := usecases(ctx).Item.FindByID(ctx, itemIDs[0], getOperator(ctx))
+	i, err := usecases(ctx).Item.FindByID(ctx, itemIDs[0], nil, getOperator(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/adapter/gql/resolver_model.go
+++ b/server/internal/adapter/gql/resolver_model.go
@@ -23,6 +23,7 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/file"
 	"github.com/reearth/reearth-cms/server/pkg/id"
 	"github.com/reearth/reearth-cms/server/pkg/model"
+	"github.com/reearth/reearth-cms/server/pkg/version"
 	"github.com/reearth/reearthx/log"
 	"github.com/samber/lo"
 )
@@ -160,7 +161,7 @@ func (r *mutationResolver) ExportModel(ctx context.Context, input gqlmodel.Expor
 		ModelID:       mId,
 		SchemaPackage: *sp,
 		Options: exporters.ExportOptions{
-			PublicOnly: true,
+			Ref: version.Public.Ref(),
 		},
 	}, w, op)
 	if err != nil {

--- a/server/internal/adapter/integration/convert.go
+++ b/server/internal/adapter/integration/convert.go
@@ -9,6 +9,7 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/project"
 	"github.com/reearth/reearth-cms/server/pkg/schema"
 	"github.com/reearth/reearth-cms/server/pkg/value"
+	"github.com/reearth/reearth-cms/server/pkg/version"
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
 	"github.com/reearth/reearthx/usecasex"
 	"github.com/reearth/reearthx/util"
@@ -17,6 +18,13 @@ import (
 
 const maxPerPage = 100
 const defaultPerPage int64 = 50
+
+func fromRef[T ~string](ref *T) *version.Ref {
+	if ref == nil {
+		return nil
+	}
+	return version.Ref(*ref).Ref()
+}
 
 func fromPagination(page, perPage *integrationapi.PageParam) *usecasex.Pagination {
 	p := int64(1)

--- a/server/internal/adapter/integration/convert_test.go
+++ b/server/internal/adapter/integration/convert_test.go
@@ -6,11 +6,18 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/group"
 	"github.com/reearth/reearth-cms/server/pkg/integrationapi"
 	"github.com/reearth/reearth-cms/server/pkg/project"
+	"github.com/reearth/reearth-cms/server/pkg/version"
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
 	"github.com/reearth/reearthx/usecasex"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestFromRef(t *testing.T) {
+	assert.Nil(t, fromRef[integrationapi.ItemFilterParamsRef](nil))
+	assert.Equal(t, version.Public.Ref(), fromRef(lo.ToPtr(integrationapi.ItemFilterParamsRef("public"))))
+	assert.Equal(t, version.Latest.Ref(), fromRef(lo.ToPtr(integrationapi.ItemFilterParamsRef("latest"))))
+}
 
 func TestFromPagination(t *testing.T) {
 	assert.Equal(t, &usecasex.Pagination{

--- a/server/internal/adapter/integration/item.go
+++ b/server/internal/adapter/integration/item.go
@@ -18,6 +18,7 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/id"
 	"github.com/reearth/reearth-cms/server/pkg/integrationapi"
 	"github.com/reearth/reearth-cms/server/pkg/item"
+	"github.com/reearth/reearth-cms/server/pkg/version"
 	"github.com/reearth/reearthx/rerror"
 	"github.com/reearth/reearthx/util"
 	"github.com/samber/lo"
@@ -42,7 +43,7 @@ func (s *Server) ItemFilter(ctx context.Context, request ItemFilterRequestObject
 
 	p := fromPagination(request.Params.Page, request.Params.PerPage)
 
-	q := item.NewQuery(sp.Schema().Project(), wp.Model.ID(), sp.Schema().ID().Ref(), lo.FromPtr(request.Params.Keyword), nil)
+	q := item.NewQuery(sp.Schema().Project(), wp.Model.ID(), sp.Schema().ID().Ref(), lo.FromPtr(request.Params.Keyword), fromRef(request.Params.Ref))
 
 	if request.Params.Sort != nil {
 		s := fromSort(*sp, integrationapi.SortParam(*request.Params.Sort), (*integrationapi.SortDirParam)(request.Params.Dir))
@@ -105,7 +106,7 @@ func (s *Server) ItemFilterPost(ctx context.Context, request ItemFilterPostReque
 
 	p := fromPagination(request.Params.Page, request.Params.PerPage)
 
-	q := item.NewQuery(sp.Schema().Project(), wp.Model.ID(), sp.Schema().ID().Ref(), lo.FromPtr(request.Params.Keyword), nil)
+	q := item.NewQuery(sp.Schema().Project(), wp.Model.ID(), sp.Schema().ID().Ref(), lo.FromPtr(request.Params.Keyword), fromRef(request.Params.Ref))
 
 	if request.Params.Sort != nil {
 		s := fromSort(*sp, integrationapi.SortParam(*request.Params.Sort), (*integrationapi.SortDirParam)(request.Params.Dir))
@@ -181,6 +182,7 @@ func (s *Server) ItemsAsGeoJSON(ctx context.Context, request ItemsAsGeoJSONReque
 		Format:  exporters.FormatGeoJSON,
 		Options: exporters.ExportOptions{
 			IncludeAssets: true,
+			PublicOnly:    lo.FromPtr(request.Params.Ref) == integrationapi.ItemsAsGeoJSONParamsRef(version.Public),
 		},
 		SchemaPackage: *sp,
 	}

--- a/server/internal/adapter/integration/item.go
+++ b/server/internal/adapter/integration/item.go
@@ -182,7 +182,7 @@ func (s *Server) ItemsAsGeoJSON(ctx context.Context, request ItemsAsGeoJSONReque
 		Format:  exporters.FormatGeoJSON,
 		Options: exporters.ExportOptions{
 			IncludeAssets: true,
-			PublicOnly:    lo.FromPtr(request.Params.Ref) == integrationapi.ItemsAsGeoJSONParamsRef(version.Public),
+			Ref:           fromRef(request.Params.Ref),
 		},
 		SchemaPackage: *sp,
 	}
@@ -219,7 +219,7 @@ func (s *Server) ItemsAsCSV(ctx context.Context, request ItemsAsCSVRequestObject
 	}
 
 	pagination := fromPagination(request.Params.Page, request.Params.PerPage)
-	vl, _, err := uc.Item.FindBySchema(ctx, sp.Schema().ID(), nil, pagination, op)
+	vl, _, err := uc.Item.FindBySchema(ctx, sp.Schema().ID(), fromRef(request.Params.Ref), nil, pagination, op)
 	if err != nil {
 		if errors.Is(err, rerror.ErrNotFound) {
 			return ItemsAsCSV404Response{}, err
@@ -396,7 +396,12 @@ func (s *Server) ItemGet(ctx context.Context, request ItemGetRequestObject) (Ite
 		return ItemGet400Response{}, err
 	}
 
-	i, err := uc.Item.FindByID(ctx, request.ItemId, op)
+	var i item.Versioned
+	if lo.FromPtr(fromRef(request.Params.Ref)) == version.Public {
+		i, err = uc.Item.FindPublicByID(ctx, request.ItemId, op)
+	} else {
+		i, err = uc.Item.FindByID(ctx, request.ItemId, op)
+	}
 	if err != nil {
 		if errors.Is(err, rerror.ErrNotFound) {
 			return ItemGet404Response{}, err

--- a/server/internal/adapter/integration/item.go
+++ b/server/internal/adapter/integration/item.go
@@ -18,7 +18,6 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/id"
 	"github.com/reearth/reearth-cms/server/pkg/integrationapi"
 	"github.com/reearth/reearth-cms/server/pkg/item"
-	"github.com/reearth/reearth-cms/server/pkg/version"
 	"github.com/reearth/reearthx/rerror"
 	"github.com/reearth/reearthx/util"
 	"github.com/samber/lo"
@@ -268,7 +267,7 @@ func (s *Server) ItemUpdate(ctx context.Context, request ItemUpdateRequestObject
 		return ItemUpdate400Response{}, err
 	}
 
-	i, err := uc.Item.FindByID(ctx, request.ItemId, op)
+	i, err := uc.Item.FindByID(ctx, request.ItemId, nil, op)
 	if err != nil {
 		return ItemUpdate400Response{}, err
 	}
@@ -299,7 +298,7 @@ func (s *Server) ItemUpdate(ctx context.Context, request ItemUpdateRequestObject
 				return ItemUpdate400Response{}, err
 			}
 		} else {
-			metaItem, err = uc.Item.FindByID(ctx, *i.Value().MetadataItem(), op)
+			metaItem, err = uc.Item.FindByID(ctx, *i.Value().MetadataItem(), nil, op)
 			if err != nil {
 				return ItemUpdate400Response{}, err
 			}
@@ -355,7 +354,7 @@ func (s *Server) ItemDelete(ctx context.Context, request ItemDeleteRequestObject
 		return ItemDelete400Response{}, err
 	}
 
-	i, err := uc.Item.FindByID(ctx, request.ItemId, op)
+	i, err := uc.Item.FindByID(ctx, request.ItemId, nil, op)
 	if err != nil {
 		if errors.Is(err, rerror.ErrNotFound) {
 			return ItemDelete400Response{}, err
@@ -396,12 +395,7 @@ func (s *Server) ItemGet(ctx context.Context, request ItemGetRequestObject) (Ite
 		return ItemGet400Response{}, err
 	}
 
-	var i item.Versioned
-	if lo.FromPtr(fromRef(request.Params.Ref)) == version.Public {
-		i, err = uc.Item.FindPublicByID(ctx, request.ItemId, op)
-	} else {
-		i, err = uc.Item.FindByID(ctx, request.ItemId, op)
-	}
+	i, err := uc.Item.FindByID(ctx, request.ItemId, fromRef(request.Params.Ref), op)
 	if err != nil {
 		if errors.Is(err, rerror.ErrNotFound) {
 			return ItemGet404Response{}, err
@@ -455,7 +449,7 @@ func (s *Server) ItemPublish(ctx context.Context, request ItemPublishRequestObje
 		return ItemPublish400Response{}, err
 	}
 
-	i, err := uc.Item.FindByID(ctx, request.ItemId, op)
+	i, err := uc.Item.FindByID(ctx, request.ItemId, nil, op)
 	if err != nil {
 		if errors.Is(err, rerror.ErrNotFound) {
 			return ItemPublish404Response{}, err

--- a/server/internal/adapter/integration/item_comment.go
+++ b/server/internal/adapter/integration/item_comment.go
@@ -24,7 +24,7 @@ func (s *Server) ItemCommentList(ctx context.Context, request ItemCommentListReq
 		return ItemCommentList400Response{}, err
 	}
 
-	i, err := uc.Item.FindByID(ctx, request.ItemId, op)
+	i, err := uc.Item.FindByID(ctx, request.ItemId, nil, op)
 	if err != nil {
 		if errors.Is(err, rerror.ErrNotFound) {
 			return ItemCommentList404Response{}, err
@@ -60,7 +60,7 @@ func (s *Server) ItemCommentCreate(ctx context.Context, request ItemCommentCreat
 		return ItemCommentCreate400Response{}, err
 	}
 
-	i, err := uc.Item.FindByID(ctx, request.ItemId, op)
+	i, err := uc.Item.FindByID(ctx, request.ItemId, nil, op)
 	if err != nil {
 		if errors.Is(err, rerror.ErrNotFound) {
 			return ItemCommentCreate404Response{}, err
@@ -99,7 +99,7 @@ func (s *Server) ItemCommentUpdate(ctx context.Context, request ItemCommentUpdat
 		return ItemCommentUpdate400Response{}, err
 	}
 
-	i, err := uc.Item.FindByID(ctx, request.ItemId, op)
+	i, err := uc.Item.FindByID(ctx, request.ItemId, nil, op)
 	if err != nil {
 		if errors.Is(err, rerror.ErrNotFound) {
 			return ItemCommentUpdate404Response{}, err
@@ -131,7 +131,7 @@ func (s *Server) ItemCommentDelete(ctx context.Context, request ItemCommentDelet
 		return ItemCommentDelete400Response{}, err
 	}
 
-	i, err := uc.Item.FindByID(ctx, request.ItemId, op)
+	i, err := uc.Item.FindByID(ctx, request.ItemId, nil, op)
 	if err != nil {
 		if errors.Is(err, rerror.ErrNotFound) {
 			return ItemCommentDelete404Response{}, err

--- a/server/internal/adapter/internalapi/server.go
+++ b/server/internal/adapter/internalapi/server.go
@@ -501,7 +501,7 @@ func (s server) GetModelGeoJSONExportURL(ctx context.Context, req *pb.ExportRequ
 		ModelID:       mId,
 		SchemaPackage: *sp,
 		Options: exporters.ExportOptions{
-			PublicOnly: true,
+			Ref: version.Public.Ref(),
 		},
 	}, w, op)
 	if err != nil {
@@ -562,7 +562,7 @@ func (s server) GetModelExportURL(ctx context.Context, req *pb.ModelExportReques
 		ModelID:       mId,
 		SchemaPackage: *sp,
 		Options: exporters.ExportOptions{
-			PublicOnly: true,
+			Ref: version.Public.Ref(),
 		},
 	}, w, op)
 	if err != nil {

--- a/server/internal/adapter/publicapi/item.go
+++ b/server/internal/adapter/publicapi/item.go
@@ -15,6 +15,7 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/item"
 	"github.com/reearth/reearth-cms/server/pkg/schema"
 	"github.com/reearth/reearth-cms/server/pkg/value"
+	"github.com/reearth/reearth-cms/server/pkg/version"
 	"github.com/reearth/reearthx/rerror"
 	"github.com/reearth/reearthx/usecasex"
 )
@@ -95,7 +96,7 @@ func (c *Controller) GetPublicItems(ctx context.Context, wsAlias, pAlias, mKey, 
 		SchemaPackage: *sp,
 		Format:        format,
 		Options: exporters.ExportOptions{
-			PublicOnly:       true,
+			Ref:              version.Public.Ref(),
 			IncludeAssets:    wpm.PublicAssets,
 			IncludeGeometry:  true,
 			GeometryField:    nil,

--- a/server/internal/usecase/interactor/item.go
+++ b/server/internal/usecase/interactor/item.go
@@ -60,8 +60,8 @@ func (i Item) checkPermissions(ctx context.Context, action rbac.Action, projectI
 	return doCheckPermission(ctx, i.gateways, rbac.ResourceItem, action, lo.Uniq(projects.Workspaces())...)
 }
 
-func (i Item) FindByID(ctx context.Context, itemID id.ItemID, _ *usecase.Operator) (item.Versioned, error) {
-	itm, err := i.repos.Item.FindByID(ctx, itemID, nil)
+func (i Item) FindByID(ctx context.Context, itemID id.ItemID, ref *version.Ref, _ *usecase.Operator) (item.Versioned, error) {
+	itm, err := i.repos.Item.FindByID(ctx, itemID, ref)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/usecase/interactor/item.go
+++ b/server/internal/usecase/interactor/item.go
@@ -146,8 +146,8 @@ func (i Item) FindPublicByModel(ctx context.Context, modelID id.ModelID, p *usec
 	return items.Unwrap(), pi, nil
 }
 
-func (i Item) FindBySchema(ctx context.Context, schemaID id.SchemaID, sort *usecasex.Sort, p *usecasex.Pagination, _ *usecase.Operator) (item.VersionedList, *usecasex.PageInfo, error) {
-	items, pi, err := i.repos.Item.FindBySchema(ctx, schemaID, nil, sort, p)
+func (i Item) FindBySchema(ctx context.Context, schemaID id.SchemaID, ref *version.Ref, sort *usecasex.Sort, p *usecasex.Pagination, _ *usecase.Operator) (item.VersionedList, *usecasex.PageInfo, error) {
+	items, pi, err := i.repos.Item.FindBySchema(ctx, schemaID, ref, sort, p)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/internal/usecase/interactor/item_export.go
+++ b/server/internal/usecase/interactor/item_export.go
@@ -11,7 +11,6 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/id"
 	"github.com/reearth/reearth-cms/server/pkg/item"
 	"github.com/reearth/reearth-cms/server/pkg/rbac"
-	"github.com/reearth/reearth-cms/server/pkg/version"
 	"github.com/reearth/reearthx/i18n"
 	"github.com/reearth/reearthx/log"
 	"github.com/reearth/reearthx/rerror"
@@ -79,10 +78,7 @@ func (i Item) Export(ctx context.Context, params interfaces.ExportItemParams, w 
 		pagination = params.Options.Pagination
 	}
 
-	ver := version.Public.Ref()
-	if !params.Options.PublicOnly {
-		ver = nil
-	}
+	ver := params.Options.Ref
 
 	pageInfo := &usecasex.PageInfo{}
 

--- a/server/internal/usecase/interactor/item_test.go
+++ b/server/internal/usecase/interactor/item_test.go
@@ -105,7 +105,7 @@ func TestItem_FindByID(t *testing.T) {
 			itemUC := NewItem(db, nil)
 			itemUC.ignoreEvent = true
 
-			got, err := itemUC.FindByID(ctx, tc.args.id, tc.args.operator)
+			got, err := itemUC.FindByID(ctx, tc.args.id, nil, tc.args.operator)
 			if tc.wantErr != nil {
 				assert.Equal(t, tc.wantErr, err)
 				return
@@ -741,7 +741,7 @@ func TestItem_Update(t *testing.T) {
 		ReadableProjects: []id.ProjectID{s.Project()},
 		WritableProjects: []id.ProjectID{s.Project()},
 	}
-	vi, _ := itemUC.FindByID(ctx, i.ID(), op)
+	vi, _ := itemUC.FindByID(ctx, i.ID(), nil, op)
 
 	// ok
 	item, err := itemUC.Update(ctx, interfaces.UpdateItemParam{
@@ -777,7 +777,7 @@ func TestItem_Update(t *testing.T) {
 	}, &usecase.Operator{AcOperator: &accountusecase.Operator{}})
 	assert.Equal(t, interfaces.ErrInvalidOperator, err)
 	assert.Nil(t, item)
-	vi, _ = itemUC.FindByID(ctx, i.ID(), op)
+	vi, _ = itemUC.FindByID(ctx, i.ID(), nil, op)
 
 	// ok with key
 	item, err = itemUC.Update(ctx, interfaces.UpdateItemParam{
@@ -799,7 +799,7 @@ func TestItem_Update(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, item.Value(), it.Value())
 	assert.Equal(t, value.TypeText.Value("yyy").AsMultiple(), it.Value().Field(sf.ID()).Value())
-	vi, _ = itemUC.FindByID(ctx, i.ID(), op)
+	vi, _ = itemUC.FindByID(ctx, i.ID(), nil, op)
 
 	// validate fails
 	item, err = itemUC.Update(ctx, interfaces.UpdateItemParam{
@@ -815,7 +815,7 @@ func TestItem_Update(t *testing.T) {
 	}, op)
 	assert.ErrorContains(t, err, "it sholud be shorter than 10")
 	assert.Nil(t, item)
-	vi, _ = itemUC.FindByID(ctx, i.ID(), op)
+	vi, _ = itemUC.FindByID(ctx, i.ID(), nil, op)
 
 	// update same item is not a duplicate
 	item, err = itemUC.Update(ctx, interfaces.UpdateItemParam{
@@ -832,7 +832,7 @@ func TestItem_Update(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, i.ID(), item.Value().ID())
 	assert.Equal(t, s.ID(), item.Value().Schema())
-	vi3, _ := itemUC.FindByID(ctx, i3.ID(), op)
+	vi3, _ := itemUC.FindByID(ctx, i3.ID(), nil, op)
 
 	// update no permission
 	_, err = itemUC.Update(ctx, interfaces.UpdateItemParam{
@@ -847,7 +847,7 @@ func TestItem_Update(t *testing.T) {
 		Version: new(vi3.Version()),
 	}, op)
 	assert.Equal(t, interfaces.ErrOperationDenied, err)
-	vi2, _ := itemUC.FindByID(ctx, i2.ID(), op)
+	vi2, _ := itemUC.FindByID(ctx, i2.ID(), nil, op)
 
 	// duplicate
 	item, err = itemUC.Update(ctx, interfaces.UpdateItemParam{
@@ -877,7 +877,7 @@ func TestItem_Update(t *testing.T) {
 	s.RemoveField(sf.ID())
 	s.AddField(sf)
 	lo.Must0(db.Schema.Save(ctx, s))
-	vi, _ = itemUC.FindByID(ctx, i.ID(), op)
+	vi, _ = itemUC.FindByID(ctx, i.ID(), nil, op)
 
 	item, err = itemUC.Update(ctx, interfaces.UpdateItemParam{
 		ItemID: i.ID(),
@@ -892,7 +892,7 @@ func TestItem_Update(t *testing.T) {
 	}, op)
 	assert.ErrorIs(t, err, schema.ErrValueRequired)
 	assert.Nil(t, item)
-	vi, _ = itemUC.FindByID(ctx, i.ID(), op)
+	vi, _ = itemUC.FindByID(ctx, i.ID(), nil, op)
 
 	// mock item error
 	wantErr := errors.New("test")
@@ -971,7 +971,7 @@ func TestItem_Delete(t *testing.T) {
 	})
 	assert.Equal(t, rerror.ErrNotFound, err)
 
-	_, err = itemUC.FindByID(ctx, i1.ID(), op)
+	_, err = itemUC.FindByID(ctx, i1.ID(), nil, op)
 	assert.Error(t, err)
 
 	// mock item error
@@ -1332,7 +1332,7 @@ func TestItem_BatchDelete(t *testing.T) {
 
 			// Verify items are deleted
 			for _, itemID := range tt.wantIDs {
-				i, err := itemUC.FindByID(ctx, itemID, tt.op)
+				i, err := itemUC.FindByID(ctx, itemID, nil, tt.op)
 				assert.Nil(t, i)
 				assert.ErrorIs(t, err, rerror.ErrNotFound)
 			}
@@ -1416,9 +1416,9 @@ func TestItem_BatchDelete_TwoWayReference(t *testing.T) {
 	itemUC.ignoreEvent = true
 
 	// Verify initial state: both items reference each other
-	vi1Before, err := itemUC.FindByID(ctx, iid1, op)
+	vi1Before, err := itemUC.FindByID(ctx, iid1, nil, op)
 	assert.NoError(t, err)
-	vi2Before, err := itemUC.FindByID(ctx, iid2, op)
+	vi2Before, err := itemUC.FindByID(ctx, iid2, nil, op)
 	assert.NoError(t, err)
 
 	// Check that Item 1 references Item 2
@@ -1446,11 +1446,11 @@ func TestItem_BatchDelete_TwoWayReference(t *testing.T) {
 	assert.Equal(t, 1, len(result))
 
 	// Verify Item 1 is deleted
-	_, err = itemUC.FindByID(ctx, iid1, op)
+	_, err = itemUC.FindByID(ctx, iid1, nil, op)
 	assert.Error(t, err)
 
 	// Verify Item 2 still exists but its reference to Item 1 is cleared
-	vi2After, err := itemUC.FindByID(ctx, iid2, op)
+	vi2After, err := itemUC.FindByID(ctx, iid2, nil, op)
 	assert.NoError(t, err)
 
 	field2After := vi2After.Value().Field(refField2ID)

--- a/server/internal/usecase/interactor/item_test.go
+++ b/server/internal/usecase/interactor/item_test.go
@@ -279,7 +279,7 @@ func TestItem_FindBySchema(t *testing.T) {
 			itemUC := NewItem(db, nil)
 			itemUC.ignoreEvent = true
 
-			got, _, err := itemUC.FindBySchema(ctx, tc.args.schema, nil, tc.args.pagination, tc.args.operator)
+			got, _, err := itemUC.FindBySchema(ctx, tc.args.schema, nil, nil, tc.args.pagination, tc.args.operator)
 			if tc.wantErr != nil {
 				assert.Equal(t, tc.wantErr, err)
 				return

--- a/server/internal/usecase/interactor/request_test.go
+++ b/server/internal/usecase/interactor/request_test.go
@@ -408,7 +408,7 @@ func TestRequest_Approve(t *testing.T) {
 	assert.NoError(t, err)
 
 	itemUC := NewItem(db, nil)
-	itm, err := itemUC.FindByID(ctx, i.ID(), op)
+	itm, err := itemUC.FindByID(ctx, i.ID(), nil, op)
 	assert.NoError(t, err)
 	expected := version.MustBeValue(itm.Version(), nil, version.NewRefs(version.Public, version.Latest), now, i)
 	assert.Equal(t, expected, itm)

--- a/server/internal/usecase/interfaces/item.go
+++ b/server/internal/usecase/interfaces/item.go
@@ -145,7 +145,7 @@ type Item interface {
 	FindPublicByID(context.Context, id.ItemID, *usecase.Operator) (item.Versioned, error)
 	FindByIDs(context.Context, id.ItemIDList, *usecase.Operator) (item.VersionedList, error)
 	FindByAssets(context.Context, id.AssetIDList, *usecase.Operator) (map[id.AssetID]item.VersionedList, error)
-	FindBySchema(context.Context, id.SchemaID, *usecasex.Sort, *usecasex.Pagination, *usecase.Operator) (item.VersionedList, *usecasex.PageInfo, error)
+	FindBySchema(context.Context, id.SchemaID, *version.Ref, *usecasex.Sort, *usecasex.Pagination, *usecase.Operator) (item.VersionedList, *usecasex.PageInfo, error)
 	FindPublicByModel(context.Context, id.ModelID, *usecasex.Pagination, *usecase.Operator) (item.List, *usecasex.PageInfo, error)
 	FindVersionByID(context.Context, id.ItemID, version.VersionOrRef, *usecase.Operator) (item.Versioned, error)
 	FindAllVersionsByID(context.Context, id.ItemID, *usecase.Operator) (item.VersionedList, error)

--- a/server/internal/usecase/interfaces/item.go
+++ b/server/internal/usecase/interfaces/item.go
@@ -141,7 +141,7 @@ type ExportItemParams struct {
 }
 
 type Item interface {
-	FindByID(context.Context, id.ItemID, *usecase.Operator) (item.Versioned, error)
+	FindByID(context.Context, id.ItemID, *version.Ref, *usecase.Operator) (item.Versioned, error)
 	FindPublicByID(context.Context, id.ItemID, *usecase.Operator) (item.Versioned, error)
 	FindByIDs(context.Context, id.ItemIDList, *usecase.Operator) (item.VersionedList, error)
 	FindByAssets(context.Context, id.AssetIDList, *usecase.Operator) (map[id.AssetID]item.VersionedList, error)

--- a/server/pkg/exporters/interface.go
+++ b/server/pkg/exporters/interface.go
@@ -7,6 +7,7 @@ import (
 	"github.com/reearth/reearth-cms/server/pkg/id"
 	"github.com/reearth/reearth-cms/server/pkg/item"
 	"github.com/reearth/reearth-cms/server/pkg/schema"
+	"github.com/reearth/reearth-cms/server/pkg/version"
 	"github.com/reearth/reearthx/usecasex"
 )
 
@@ -33,7 +34,7 @@ type ExportRequest struct {
 
 // ExportOptions contains format-specific options
 type ExportOptions struct {
-	PublicOnly       bool
+	Ref              *version.Ref
 	IncludeAssets    bool
 	IncludeGeometry  bool
 	GeometryField    *schema.FieldID


### PR DESCRIPTION
# Overview

ref (latest/public) was parsed but never passed through in ItemFilter/ItemFilterPost/ItemGet (always nil) or ItemsAsGeoJSON/ItemsAsCSV (never applied), so ref=public still returned drafts. Wires ref into item.NewQuery, Item.FindByID/FindBySchema, and exporters.ExportOptions.Ref (replacing the lossy PublicOnly bool) across all five endpoints.

Also fixes a regression: routing ItemGet through FindPublicByID for ref=public bypassed the RBAC read-permission check. FindByID now takes the ref directly and always checks permissions.